### PR TITLE
chore: point dependabot at develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # Backend (root package.json)
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -18,6 +19,7 @@ updates:
   # Frontend app
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -30,6 +32,7 @@ updates:
   # Styles (Sass) build
   - package-ecosystem: "npm"
     directory: "/styles"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -42,12 +45,14 @@ updates:
   # Container base images (Dockerfile)
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
 
   # GitHub Actions used by the workflows
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Adds `target-branch: "develop"` to all five Dependabot update blocks (npm root, frontend, styles, docker, github-actions) so future dependency PRs open against `develop` instead of `master`.

Dependabot reads its config from the **default branch** (master), so this change must land on master to take effect — it cannot be applied via develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)