### PR TITLE
build(deps): migrate openid-client 5.7.1 → 6.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "nodemailer": "9.0.1",
         "oauth": "^0.10.0",
         "oidc-provider": "^9.8.5",
-        "openid-client": "^5.7.1",
+        "openid-client": "^6.8.4",
         "original-url": "^1.2.3",
         "parse-domain": "^8.3.1",
         "parseurl": "^1.3.3",
@@ -272,19 +272,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/openid-client": {
-      "version": "6.8.4",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
-      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^6.2.2",
-        "oauth4webapi": "^3.8.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@kubernetes/client-node/node_modules/undici-types": {
@@ -3903,18 +3890,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -4517,15 +4492,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
-      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -4557,36 +4523,16 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/original-url": {
@@ -6845,12 +6791,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/yarn": {
       "version": "1.22.22",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nodemailer": "9.0.1",
     "oauth": "^0.10.0",
     "oidc-provider": "^9.8.5",
-    "openid-client": "^5.7.1",
+    "openid-client": "^6.8.4",
     "original-url": "^1.2.3",
     "parse-domain": "^8.3.1",
     "parseurl": "^1.3.3",

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -1,4 +1,4 @@
-import { generators } from "openid-client";
+import * as client from "openid-client";
 import Account from "../../models/account.js";
 import accessDenied from "../../utils/session/access-denied.js";
 import getLoginResult from "../../utils/user/get-login-result.js";
@@ -45,25 +45,25 @@ export default async (ctx, provider, providerConfig) => {
 
     // Phase 1 — start the authorization-code flow.
     if (!identity && !Object.keys(callbackParams).length) {
-        const client = await getOidcClient(providerConfig);
-        const codeVerifier = generators.codeVerifier();
-        const codeChallenge = generators.codeChallenge(codeVerifier);
-        const nonce = generators.nonce();
+        const config = await getOidcClient(providerConfig);
+        const codeVerifier = client.randomPKCECodeVerifier();
+        const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+        const nonce = client.randomNonce();
         // Keep the `uid|random` state shape so repost.ejs can recover the uid.
-        const state = `${ctx.params.uid}|${generators.state()}`;
+        const state = `${ctx.params.uid}|${client.randomState()}`;
         await provider.interactionResult(ctx.req, ctx.res, {
             oidcFlow: { provider: key, state, codeVerifier, nonce },
         });
         ctx.status = 302;
         auditLog(ctx, { interactionDetails, state }, `Redirecting user to ${displayName}`);
-        return ctx.redirect(client.authorizationUrl({
+        return ctx.redirect(client.buildAuthorizationUrl(config, {
             redirect_uri: redirectUri,
             scope: providerConfig.scopes.join(' '),
             state,
             nonce,
             code_challenge: codeChallenge,
             code_challenge_method: 'S256',
-        }));
+        }).href);
     }
 
     // Phase 2 — handle the callback: validate state, exchange the code (PKCE),
@@ -75,23 +75,31 @@ export default async (ctx, provider, providerConfig) => {
             return accessDenied(ctx, provider, 'State does not match');
         }
 
-        const client = await getOidcClient(providerConfig);
+        const config = await getOidcClient(providerConfig);
+        // v6 reads the callback parameters from a full URL; reconstruct it from
+        // the registered redirect URI plus the posted-back query parameters.
+        const callbackUrl = new URL(redirectUri);
+        for (const [param, value] of Object.entries(callbackParams)) {
+            if (value !== undefined && value !== null) {
+                callbackUrl.searchParams.set(param, String(value));
+            }
+        }
         let tokenSet;
         try {
-            tokenSet = await client.callback(redirectUri, callbackParams, {
-                state: flow.state,
-                code_verifier: flow.codeVerifier,
-                nonce: flow.nonce,
+            tokenSet = await client.authorizationCodeGrant(config, callbackUrl, {
+                expectedState: flow.state,
+                pkceCodeVerifier: flow.codeVerifier,
+                expectedNonce: flow.nonce,
             });
         } catch (error) {
             auditLog(ctx, { error: error.message, interactionDetails }, `Error getting tokens from ${displayName}`);
             return accessDenied(ctx, provider, 'User aborted login');
         }
 
-        const claims = tokenSet.claims();
+        const claims = tokenSet.claims() ?? {};
         let userinfo = {};
         try {
-            userinfo = await client.userinfo(tokenSet);
+            userinfo = await client.fetchUserInfo(config, tokenSet.access_token, claims.sub);
         } catch (error) {
             // userinfo is best-effort — the id_token already carries sub/email.
             auditLog(ctx, { error: error.message, interactionDetails }, `Error getting userinfo from ${displayName}`);

--- a/src/utils/oidc-providers.js
+++ b/src/utils/oidc-providers.js
@@ -1,4 +1,4 @@
-import { Issuer } from "openid-client";
+import * as client from "openid-client";
 
 // Generic OIDC upstream providers. GitHub is intentionally NOT here — its API
 // is not standards-compliant OIDC and keeps its own handler (github-login.js).
@@ -76,20 +76,24 @@ export const getOidcProvider = (key) => getOidcProviders().find(p => p.key === k
 // Redirect URI registered with the upstream provider's OAuth application.
 export const oidcRedirectUri = (key) => `${process.env.ISSUER_URL}interaction/callback/${key}`;
 
-// Discovery is network I/O, so the configured Client is memoized per provider.
-const clientCache = new Map();
+// Discovery is network I/O, so the configured openid-client Configuration is
+// memoized per provider.
+const configCache = new Map();
 
+// Resolve a provider into an openid-client v6 `Configuration`. We pin
+// client_secret_basic to preserve the upstream auth method used under v5
+// (`new issuer.Client(...)` defaulted to basic; v6 `discovery()` would
+// otherwise default to client_secret_post).
 export const getOidcClient = async (providerConfig) => {
-    if (clientCache.has(providerConfig.key)) {
-        return clientCache.get(providerConfig.key);
+    if (configCache.has(providerConfig.key)) {
+        return configCache.get(providerConfig.key);
     }
-    const issuer = await Issuer.discover(providerConfig.issuer);
-    const client = new issuer.Client({
-        client_id: providerConfig.clientId,
-        client_secret: providerConfig.clientSecret,
-        redirect_uris: [oidcRedirectUri(providerConfig.key)],
-        response_types: ['code'],
-    });
-    clientCache.set(providerConfig.key, client);
-    return client;
+    const config = await client.discovery(
+        new URL(providerConfig.issuer),
+        providerConfig.clientId,
+        providerConfig.clientSecret,
+        client.ClientSecretBasic(providerConfig.clientSecret),
+    );
+    configCache.set(providerConfig.key, config);
+    return config;
 };


### PR DESCRIPTION
Supersedes #119 (dependabot bumped the version but openid-client v6 is a full API rewrite that needs code migration).

## What changed
openid-client v6 replaces the `Issuer`/`Client` classes with a functional API.

**`src/utils/oidc-providers.js`**
- `Issuer.discover()` + `new issuer.Client()` → `client.discovery()`
- Pinned `ClientSecretBasic` to preserve the v5 default upstream auth method (`client_secret_basic`); v6's `discovery()` would otherwise default to `client_secret_post`.

**`src/services/login/oidc-login.js`**
- `generators.*` → `client.randomPKCECodeVerifier()` / `calculatePKCECodeChallenge()` (now **async**) / `randomNonce()` / `randomState()`
- `client.authorizationUrl()` → `client.buildAuthorizationUrl()` (returns a `URL`)
- `client.callback(redirectUri, params, checks)` → `client.authorizationCodeGrant(config, callbackUrl, checks)` — v6 reads params from a full callback `URL`, reconstructed from the redirect URI + posted-back params
- `client.userinfo(tokenSet)` → `client.fetchUserInfo(config, accessToken, sub)` — requires the expected `sub` from id_token claims

## Verification
- `npm install` resolves cleanly; v6 functions all present
- `node --check` passes on both files
- `oidc-providers.js` imports without error under v6
- ⚠️ No automated test suite — the upstream-login flow (Google/GitLab/EntraID redirect → callback → link) was **not** exercised against a live provider. Worth a manual smoke test before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)