### PR TITLE
build(deps): bump marked 5.1.2 → 18.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa-static": "^5.0.0",
         "lodash": "^4.18.1",
-        "marked": "^5.1.2",
+        "marked": "^18.0.5",
         "micromatch": "^4.0.7",
         "nodemailer": "9.0.1",
         "oauth": "^0.10.0",
@@ -4162,15 +4162,15 @@
       "license": "ISC"
     },
     "node_modules/marked": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
-      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa-static": "^5.0.0",
     "lodash": "^4.18.1",
-    "marked": "^5.1.2",
+    "marked": "^18.0.5",
     "micromatch": "^4.0.7",
     "nodemailer": "9.0.1",
     "oauth": "^0.10.0",

--- a/src/utils/get-text.js
+++ b/src/utils/get-text.js
@@ -31,7 +31,9 @@ export function getText(name) {
 }
 
 const renderer = {
-    link(href, title, text) {
-        return `<a target="_blank" href="${href}">${text}</a>`;
+    // marked v5+ passes a token object; the link text is rendered from its
+    // child tokens via the bound parser.
+    link({ href, tokens }) {
+        return `<a target="_blank" href="${href}">${this.parser.parseInline(tokens)}</a>`;
     }
 };

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -6,14 +6,16 @@ const SAFE_HREF = /^(https?:|mailto:|\/)/i;
 
 const renderer = {
     // Open links in a new tab and reject script-y URL schemes.
-    link(href, title, text) {
+    // marked v5+ passes a token object and the link text is rendered from its
+    // child tokens via the bound parser.
+    link({ href, tokens }) {
         const safe = href && SAFE_HREF.test(href.trim()) ? href : '#';
-        return `<a target="_blank" rel="noreferrer noopener" href="${htmlSafe(safe)}">${text}</a>`;
+        return `<a target="_blank" rel="noreferrer noopener" href="${htmlSafe(safe)}">${this.parser.parseInline(tokens)}</a>`;
     },
     // Neutralise any raw HTML embedded in the markdown source (block + inline),
     // so rendering the result with v-html can't inject markup/scripts.
-    html(html) {
-        return htmlSafe(html);
+    html({ text }) {
+        return htmlSafe(text);
     },
 };
 


### PR DESCRIPTION
Supersedes #106 (dependabot bumped the version; marked v5+ changed the custom renderer API).

## Breaking change fixed
marked changed custom renderer methods from positional arguments to a single **token object**. Migrated both renderers:
- `src/utils/markdown.js`: `link(href, title, text)` → `link({ href, tokens })` (link text now via `this.parser.parseInline(tokens)`); `html(html)` → `html({ text })`.
- `src/utils/get-text.js`: `link(href, title, text)` → `link({ href, tokens })`.

## Verified
Exercised the real `renderMarkdown` export under v18:
- Headings/bold/links render correctly.
- **Security preserved**: unsafe link schemes (`javascript:`) are still rewritten to `#`, and raw embedded HTML (e.g. `<img onerror=…>`, `<script>`) is still escaped via `oidc-provider`'s `html_safe`.

The legacy `mangle` / `headerIds` constructor options are now no-ops in v18 but are still accepted (no error); left in place to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)