### PR TITLE
build(deps): bump koa-pino-logger 4.0.0 → 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jsondiffpatch": "0.7.6",
         "koa": "^3.2.1",
         "koa-body": "^8.0.0",
-        "koa-pino-logger": "^4.0.0",
+        "koa-pino-logger": "^5.0.0",
         "koa-static": "^5.0.0",
         "lodash": "^4.18.1",
         "marked": "^18.0.5",
@@ -2001,32 +2001,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.2"
-      }
-    },
-    "node_modules/duplexify/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2288,24 +2262,6 @@
       },
       "engines": {
         "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
       }
     },
     "node_modules/fastq": {
@@ -3722,12 +3678,12 @@
       "license": "MIT"
     },
     "node_modules/koa-pino-logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/koa-pino-logger/-/koa-pino-logger-4.0.0.tgz",
-      "integrity": "sha512-YI/LB9ajyLPpjvf6e+7Ewmn+OQkCJpu/Y9eI1n7fnipu5Y1NchuNlke0mqh3/2z+5oDYr7pijjOWruEDIfua2A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/koa-pino-logger/-/koa-pino-logger-5.0.0.tgz",
+      "integrity": "sha512-iGx5P6CwsSsQ4a8B9rx6EMkmUKvM5toJjPPX4gXfx+l+Ikd+Ih6Akps4EQo/du+bVjHNGVKNMBETEVHYxDMM0g==",
       "license": "MIT",
       "dependencies": {
-        "pino-http": "^6.5.0"
+        "pino-http": "^11.0.0"
       }
     },
     "node_modules/koa-send": {
@@ -4892,98 +4848,15 @@
       }
     },
     "node_modules/pino-http": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-6.6.0.tgz",
-      "integrity": "sha512-PlItaK2MLpoIMLEcClhfb1VQk/o6fKppINl5s6sPE/4rvufkdO3kCSs/92EwrBsB1yssRCQqDV+w1xpYuPVnjg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
+      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-url-parser": "^1.1.3",
         "get-caller-file": "^2.0.5",
-        "pino": "^7.5.0",
-        "pino-std-serializers": "^5.0.0"
-      }
-    },
-    "node_modules/pino-http/node_modules/on-exit-leak-free": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
-      "license": "MIT"
-    },
-    "node_modules/pino-http/node_modules/pino": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.0.0",
-        "on-exit-leak-free": "^0.2.0",
-        "pino-abstract-transport": "v0.5.0",
-        "pino-std-serializers": "^4.0.0",
-        "process-warning": "^1.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.1.0",
-        "safe-stable-stringify": "^2.1.0",
-        "sonic-boom": "^2.2.1",
-        "thread-stream": "^0.15.1"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/pino-http/node_modules/pino-abstract-transport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexify": "^4.1.2",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/pino-http/node_modules/pino-std-serializers": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.6.0.tgz",
-      "integrity": "sha512-VdUXCw8gO+xhir7sFuoYSjTnzB+TMDGxhAC/ph3YS3sdHnXNdsK0wMtADNUltfeGkn2KDxEM21fnjF3RwXyC8A==",
-      "license": "MIT"
-    },
-    "node_modules/pino-http/node_modules/pino/node_modules/pino-std-serializers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
-      "license": "MIT"
-    },
-    "node_modules/pino-http/node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
-      "license": "MIT"
-    },
-    "node_modules/pino-http/node_modules/real-require": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
-      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/pino-http/node_modules/sonic-boom": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
-      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/pino-http/node_modules/thread-stream": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.1.0"
+        "pino": "^10.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
       }
     },
     "node_modules/pino-std-serializers": {
@@ -5056,12 +4929,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
@@ -5927,12 +5794,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/stream-shift": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT"
-    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -5942,15 +5803,6 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -6611,12 +6463,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jsondiffpatch": "0.7.6",
     "koa": "^3.2.1",
     "koa-body": "^8.0.0",
-    "koa-pino-logger": "^4.0.0",
+    "koa-pino-logger": "^5.0.0",
     "koa-static": "^5.0.0",
     "lodash": "^4.18.1",
     "marked": "^18.0.5",


### PR DESCRIPTION
Supersedes #116.

## No code changes required
`koa-pino-logger` is **not imported anywhere** in the codebase — logging is configured directly via `pino` in `src/providers/setup-logger.js`. So this major bump has no runtime impact.

## Recommendation
The dependency appears to be entirely unused (direct dep, zero references in `src/`). A follow-up could simply remove it instead of carrying it. Left in place here to keep this PR a straight dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)