### PR TITLE
test: add test suite (unit + integration + e2e) and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    # Non-blocking for now: the browser login goes through the dashboard's
-    # implicit-flow self-client, and oidc-provider v9 requires https redirect
-    # URIs for implicit. Running this stack over plain http therefore can't
-    # complete the dashboard login. Finishing the e2e needs a TLS terminator in
-    # front of passmower (or reworking the test to a loopback code-flow client).
-    # The harness, Dex, kind+CRDs and passmower boot are all exercised regardless.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Non-blocking for now: the browser login goes through the dashboard's
+    # implicit-flow self-client, and oidc-provider v9 requires https redirect
+    # URIs for implicit. Running this stack over plain http therefore can't
+    # complete the dashboard login. Finishing the e2e needs a TLS terminator in
+    # front of passmower (or reworking the test to a loopback code-flow client).
+    # The harness, Dex, kind+CRDs and passmower boot are all exercised regardless.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,107 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [develop, master]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Unit tests
+        run: npm run test:unit
+      - name: Frontend build (compile check)
+        run: |
+          npm --prefix frontend ci
+          npm --prefix frontend run build
+
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 5s
+          --health-timeout 3s --health-retries 5
+    env:
+      REDIS_URI: redis://127.0.0.1:6379
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Integration tests (real Redis + fake kube + mock IdP)
+        run: npm run test:integration
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Start Redis + Dex
+        run: docker compose -f docker-compose.test.yml up -d
+
+      - name: Create kind cluster + apply CRDs
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: passmower-e2e
+      - run: |
+          kubectl apply -f charts/passmower/templates/crds.yaml
+          kubectl create namespace passmower-test --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Build frontend + styles
+        run: |
+          npm --prefix frontend ci && npm --prefix frontend run build
+          npm --prefix styles ci && npm --prefix styles run sass-prod
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for Dex
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:5556/dex/.well-known/openid-configuration && break
+            sleep 1
+          done
+
+      - name: Start passmower
+        run: |
+          set -a; . test/e2e/passmower.env; set +a
+          export KUBECONFIG="$HOME/.kube/config"
+          export OIDC_COOKIE_KEYS='["e2e-cookie-secret-0123456789abcdef0123456789"]'
+          export OIDC_JWKS="$(node -e "const {generateKeyPairSync}=require('crypto');const {privateKey}=generateKeyPairSync('rsa',{modulusLength:2048});const j=privateKey.export({format:'jwk'});j.use='sig';j.alg='RS256';j.kid='e2e';console.log(JSON.stringify([j]))")"
+          node src/app.js > passmower-e2e.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:3000/.well-known/openid-configuration && break
+            sleep 1
+          done
+
+      - name: Run Playwright e2e
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: passmower logs on failure
+        if: failure()
+        run: cat passmower-e2e.log || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
           cache: npm
       - run: npm ci
 
+      - name: Pin passmower hostname to localhost
+        run: echo "127.0.0.1 passmower.localtest.me" | sudo tee -a /etc/hosts
+
       - name: Start Redis + Dex
         run: docker compose -f docker-compose.test.yml up -d
 
@@ -88,11 +91,17 @@ jobs:
           export OIDC_JWKS="$(node -e "const {generateKeyPairSync}=require('crypto');const {privateKey}=generateKeyPairSync('rsa',{modulusLength:2048});const j=privateKey.export({format:'jwk'});j.use='sig';j.alg='RS256';j.kid='e2e';console.log(JSON.stringify([j]))")"
           node src/app.js > passmower-e2e.log 2>&1 &
           for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:3000/.well-known/openid-configuration && break
+            curl -sf http://passmower.localtest.me:3000/.well-known/openid-configuration && break
             sleep 1
           done
+          # Fail fast (with logs) if passmower never came up.
+          curl -sf http://passmower.localtest.me:3000/.well-known/openid-configuration > /dev/null || {
+            echo "::error::passmower did not start"; cat passmower-e2e.log; exit 1;
+          }
 
       - name: Run Playwright e2e
+        env:
+          PASSMOWER_URL: http://passmower.localtest.me:3000
         run: npx playwright test
 
       - name: Upload Playwright report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,13 @@ jobs:
             sleep 1
           done
 
-      - name: Start passmower
+      - name: Install Caddy (TLS terminator)
+        run: |
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.8.4/caddy_2.8.4_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin caddy
+          caddy version
+
+      - name: Start passmower (http) behind Caddy (https)
         run: |
           set -a; . test/e2e/passmower.env; set +a
           export KUBECONFIG="$HOME/.kube/config"
@@ -98,17 +104,24 @@ jobs:
           export OIDC_JWKS="$(node -e "const {generateKeyPairSync}=require('crypto');const {privateKey}=generateKeyPairSync('rsa',{modulusLength:2048});const j=privateKey.export({format:'jwk'});j.use='sig';j.alg='RS256';j.kid='e2e';console.log(JSON.stringify([j]))")"
           node src/app.js > passmower-e2e.log 2>&1 &
           for i in $(seq 1 30); do
-            curl -sf http://passmower.localtest.me:3000/.well-known/openid-configuration && break
+            curl -sf http://127.0.0.1:3000/.well-known/openid-configuration && break
             sleep 1
           done
-          # Fail fast (with logs) if passmower never came up.
-          curl -sf http://passmower.localtest.me:3000/.well-known/openid-configuration > /dev/null || {
+          curl -sf http://127.0.0.1:3000/.well-known/openid-configuration > /dev/null || {
             echo "::error::passmower did not start"; cat passmower-e2e.log; exit 1;
+          }
+          caddy start --config test/e2e/Caddyfile
+          for i in $(seq 1 20); do
+            curl -ksf https://passmower.localtest.me:8443/.well-known/openid-configuration && break
+            sleep 1
+          done
+          curl -ksf https://passmower.localtest.me:8443/.well-known/openid-configuration > /dev/null || {
+            echo "::error::TLS endpoint not reachable"; cat passmower-e2e.log; exit 1;
           }
 
       - name: Run Playwright e2e
         env:
-          PASSMOWER_URL: http://passmower.localtest.me:3000
+          PASSMOWER_URL: https://passmower.localtest.me:8443
         run: npx playwright test
 
       - name: Upload Playwright report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,10 @@ jobs:
       - run: npm ci
       - name: Unit tests
         run: npm run test:unit
-      - name: Frontend build (compile check)
+      - name: Frontend lint + build
         run: |
           npm --prefix frontend ci
+          npm --prefix frontend run lint:check
           npm --prefix frontend run build
 
   integration:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 node_modules
 /dist
 
+# Test artifacts
+/playwright-report
+/test-results
+/coverage
+passmower-e2e.log
+test/e2e/k3s-output
+
 # local env files
 .env.local
 .env.*.local

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,19 @@
+# Supporting services for the e2e login test: Redis (oidc-provider storage) and
+# Dex (the upstream OIDC IdP). The Kubernetes API and passmower itself are
+# started by test/e2e/run-local.sh (locally) / the CI workflow, so they can use
+# the host-built frontend and a KUBECONFIG pointing at the test cluster.
+services:
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "6379:6379"
+
+  dex:
+    image: ghcr.io/dexidp/dex:v2.41.1
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    volumes:
+      # ":Z" relabels for SELinux hosts (e.g. podman/Fedora); a no-op on others.
+      - ./test/e2e/dex/config.yaml:/etc/dex/config.yaml:ro,Z
+    ports:
+      - "5556:5556"

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,4 +26,13 @@ export default [
   js.configs.recommended,
   ...pluginVue.configs['flat/essential'],
   skipFormatting,
+  {
+    name: 'app/rules',
+    rules: {
+      // This app's components are top-level views (Profile, Apps, Admin) and
+      // single-glyph icon components (Key, Plus, …) where single-word names are
+      // intentional and clearer than forced two-word names.
+      'vue/multi-word-component-names': 'off',
+    },
+  },
 ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,11 +2,13 @@
   "name": "passmower-frontend",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",
+    "lint:check": "eslint .",
     "format": "prettier --write src/"
   },
   "dependencies": {

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -9,7 +9,7 @@
         <div class="profile-section-header">
             <h2>Users</h2>
         </div>
-        <div class="item" v-for="account in accounts">
+        <div class="item" v-for="account in accounts" :key="account.accountId">
             <div class="item-details">
                 <h3>{{ account.accountId }}</h3>
                 <p>Name: {{ account.name }}</p>

--- a/frontend/src/components/Admin/InviteUser.vue
+++ b/frontend/src/components/Admin/InviteUser.vue
@@ -52,7 +52,7 @@ export default {
           let message
           try {
             message = await response.json()
-          } catch (e) {}
+          } catch { /* no/!JSON body — leave message undefined */ }
           if (message?.errors) {
             message.errors.forEach(e => {
               const $toast = useToast();

--- a/frontend/src/components/User/Apps.vue
+++ b/frontend/src/components/User/Apps.vue
@@ -3,7 +3,7 @@
         <div class="profile-section-header">
             <h2>Available apps</h2>
         </div>
-        <div class="item" v-for="app in apps">
+        <div class="item" v-for="app in apps" :key="app.name">
          <div class="item-details">
           <h3>{{ app.name }}</h3>
           <a :href="app.url" rel="noreferrer noopener" target="_blank">{{ app.url }}</a>

--- a/frontend/src/components/User/Modals/EndSession.vue
+++ b/frontend/src/components/User/Modals/EndSession.vue
@@ -49,8 +49,6 @@ export default {
             position: 'top-right'
           });
         })
-      } else {
-
       }
 
       fetch('/api/session/end', {

--- a/frontend/src/components/User/Passkeys.vue
+++ b/frontend/src/components/User/Passkeys.vue
@@ -27,7 +27,6 @@
 import { mapState, mapActions } from "pinia";
 import { useAccountStore } from "@/stores/account";
 import { openModal } from "jenesius-vue-modal";
-import { useToast } from "vue-toast-notification";
 import Plus from "@/components/Icons/Plus.vue";
 import Key from "@/components/Icons/Key.vue";
 import Pencil from "@/components/Icons/Pencil.vue";

--- a/frontend/src/components/User/Profile.vue
+++ b/frontend/src/components/User/Profile.vue
@@ -9,15 +9,15 @@
         <p><strong>Primary email: </strong> {{ account.email }}</p>
         <p><strong>Emails: </strong></p>
         <ul>
-            <li v-for="email in account.emails">{{ email }}</li>
+            <li v-for="email in account.emails" :key="email">{{ email }}</li>
         </ul>
         <p><strong>Phones: </strong></p>
         <ul>
-          <li v-for="phone in account.phones">{{ phone }}</li>
+          <li v-for="phone in account.phones" :key="phone">{{ phone }}</li>
         </ul>
         <p><strong>Groups: </strong></p>
         <ul>
-            <li v-for="group in account.groups">{{ group.displayName }}</li>
+            <li v-for="group in account.groups" :key="group.displayName">{{ group.displayName }}</li>
         </ul>
         <br/>
         <p v-if="account.tos_accepted_at"><a target="_blank" href="/terms-of-service">Terms of Service</a> accepted at {{account.tos_accepted_at}}</p>
@@ -42,7 +42,7 @@ export default {
     },
     methods: {
         ...mapActions(useAccountStore, ['setAccount']),
-        async editProfile(e) {
+        async editProfile() {
             const modal = await openModal(EditProfile);
             modal.onclose = () => {
                 this.setAccount(this.originalAccount)

--- a/frontend/src/components/User/Sessions.vue
+++ b/frontend/src/components/User/Sessions.vue
@@ -3,7 +3,7 @@
     <div class="profile-section-header">
       <h2>Sessions</h2>
     </div>
-    <div class="item" v-for="session in sessions">
+    <div class="item" v-for="session in sessions" :key="session.id">
       <div class="item-details">
         <h3>{{ session.browser }} on {{ session.os }} <span v-if="session.current">(current session)</span></h3>
         <p>Initial IP: {{ session.ip }}</p>
@@ -27,7 +27,8 @@ export default {
   name: "Profile",
   components: {
     XMark,
-    EndSession
+    // EndSession is opened imperatively via openModal(), not used in the
+    // template, so it doesn't need to be registered as a component.
   },
   computed: {
     ...mapStores(useAccountStore),

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,72 @@
         "validator": "^13.15.35"
       },
       "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.9",
         "nodemon": "^3.1.14",
-        "npm-run-all": "^4.1.5"
+        "npm-run-all": "^4.1.5",
+        "oauth2-mock-server": "^9.0.0",
+        "supertest": "^7.2.2",
+        "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@codemowers/oidc-key-manager": {
@@ -84,6 +148,40 @@
       "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
       "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
@@ -285,6 +383,25 @@
       "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -512,6 +629,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -695,6 +822,270 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@simplewebauthn/server": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.2.tgz",
@@ -761,6 +1152,13 @@
         "npm": ">= 8.6.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -785,6 +1183,17 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
@@ -802,6 +1211,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/cli-progress": {
@@ -849,6 +1269,20 @@
         "@types/keygrip": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -1000,6 +1434,150 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -1194,6 +1772,39 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/astral-regex": {
@@ -1393,6 +2004,26 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1501,6 +2132,16 @@
       },
       "bin": {
         "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1665,6 +2306,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1705,6 +2356,30 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookies": {
       "version": "0.9.1",
@@ -1943,6 +2618,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -2126,6 +2811,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2202,6 +2894,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eta": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
@@ -2229,6 +2931,16 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -2250,6 +2962,13 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -2728,6 +3447,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-assert": {
       "version": "1.5.0",
@@ -3236,6 +3962,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3468,6 +4207,58 @@
         "ws": "*"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jake": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
@@ -3493,6 +4284,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3803,6 +4601,267 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -3845,6 +4904,44 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -3900,6 +4997,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3911,6 +5018,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -4306,6 +5426,24 @@
       "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
       "license": "MIT"
     },
+    "node_modules/oauth2-mock-server": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/oauth2-mock-server/-/oauth2-mock-server-9.0.0.tgz",
+      "integrity": "sha512-fLOtud91LgWzKkx/vQY9DF6C0YPFdQFfPrpUKK4Czl44+BLA8i9bEBQElsFuOItmYKg15cEem1vUiWGBMSXo/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "is-plain-obj": "^4.1.0",
+        "jose": "^6.2.3"
+      },
+      "bin": {
+        "oauth2-mock-server": "dist/oauth2-mock-server.mjs"
+      },
+      "engines": {
+        "node": "^22.12 || ^24 || ^26"
+      }
+    },
     "node_modules/oauth4webapi": {
       "version": "3.8.6",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
@@ -4365,6 +5503,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/oidc-provider": {
@@ -4722,6 +5874,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4819,6 +5978,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/process-warning": {
@@ -5255,6 +6462,40 @@
       "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5553,6 +6794,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -5639,6 +6887,16 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -5702,6 +6960,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -5716,6 +6981,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5881,6 +7153,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -6022,14 +7330,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6056,15 +7381,25 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6458,6 +7793,200 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -6574,6 +8103,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "validator": "^13.15.35"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@vitest/coverage-v8": "^4.1.9",
         "nodemon": "^3.1.14",
         "npm-run-all": "^4.1.5",
@@ -821,6 +822,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
@@ -5969,6 +5986,53 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "validator": "^13.15.35"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@vitest/coverage-v8": "^4.1.9",
     "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
   "scripts": {
     "dev": "nodemon --inspect=0.0.0.0 --trace-warnings src/app.js -e ejs,js,css,html,jpg,png,scss --watch src",
     "dev-frontend": "npm run dev --prefix frontend",
-    "dev-styles": "npm run --prefix styles sass-dev"
+    "dev-styles": "npm run --prefix styles sass-dev",
+    "test": "vitest run --project unit",
+    "test:unit": "vitest run --project unit",
+    "test:integration": "vitest run --project integration",
+    "test:watch": "vitest --project unit",
+    "test:coverage": "vitest run --project unit --coverage",
+    "test:e2e": "playwright test"
   },
   "type": "module",
   "dependencies": {
@@ -45,8 +51,12 @@
     "validator": "^13.15.35"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.9",
     "nodemon": "^3.1.14",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "oauth2-mock-server": "^9.0.0",
+    "supertest": "^7.2.2",
+    "vitest": "^4.1.9"
   },
   "author": "Erki Aas"
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test'
+
+// End-to-end browser tests. These assume the supporting stack is already up
+// (Redis + Dex + a Kubernetes API with the CRDs applied + passmower itself).
+// `test/e2e/run-local.sh` brings that stack up for local runs; CI does the
+// equivalent in .github/workflows/test.yml.
+export default defineConfig({
+    testDir: './test/e2e',
+    testMatch: '**/*.spec.js',
+    timeout: 60_000,
+    expect: { timeout: 10_000 },
+    fullyParallel: false,
+    retries: process.env.CI ? 1 : 0,
+    reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+    use: {
+        baseURL: process.env.PASSMOWER_URL ?? 'http://127.0.0.1:3000',
+        ignoreHTTPSErrors: true,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+    },
+})

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -12,8 +12,18 @@ export class KubernetesAdapter {
     constructor() {
         const kc = new k8s.KubeConfig();
         this.kc = kc
-        kc.loadFromCluster()
-        this.namespace = kc.getContextObject(kc.getCurrentContext()).namespace;
+        // In-cluster by default; fall back to the local kubeconfig (KUBECONFIG or
+        // ~/.kube/config) when not running inside a pod. This lets the operator run
+        // against an out-of-cluster API server for local development and tests
+        // (e.g. envtest), without changing in-cluster behaviour.
+        if (process.env.KUBERNETES_SERVICE_HOST) {
+            kc.loadFromCluster()
+        } else {
+            kc.loadFromDefault()
+        }
+        this.namespace = kc.getContextObject(kc.getCurrentContext())?.namespace
+            ?? process.env.POD_NAMESPACE
+            ?? 'default';
         this.deployment = process.env.DEPLOYMENT_NAME
         this.instance = this.namespace + '-' + this.deployment
         const userAgentMiddleware = setHeaderMiddleware('User-Agent', this.instance)

--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -3,11 +3,6 @@ import Redis from 'ioredis'; // eslint-disable-line import/no-unresolved
 import isEmpty from 'lodash/isEmpty.js';
 import dns from 'node:dns/promises';
 
-// Parse Redis URI to extract host for DNS refresh
-const redisUrl = new URL(process.env.REDIS_URI);
-const redisHost = redisUrl.hostname;
-const isHeadlessService = redisHost.endsWith('.svc.cluster.local') || redisHost.endsWith('.svc');
-
 // Track connection state
 let connectionErrorCount = 0;
 let isReady = false;
@@ -16,6 +11,13 @@ let readyPromise = new Promise(resolve => { readyResolve = resolve; });
 
 const MAX_ERROR_COUNT = 5;
 const DNS_REFRESH_INTERVAL = 30000; // 30 seconds
+
+// The single shared client and the timers that keep it healthy. These are
+// created lazily by connect() rather than at import time so that importing a
+// module that transitively pulls in this adapter does NOT open a Redis
+// connection or pin the event loop (important for tests and tooling).
+let client;
+let timers = [];
 
 function createRedisClient(isInitial = false) {
     const newClient = new Redis(process.env.REDIS_URI, {
@@ -71,49 +73,78 @@ function createRedisClient(isInitial = false) {
     return newClient;
 }
 
-let client = createRedisClient(true);
+// Open the connection and start the health timers. Idempotent: safe to call
+// more than once. Called lazily on first use (getClient/waitForReady) and
+// explicitly at app boot via waitForReady().
+export function connect() {
+    if (client) {
+        return client;
+    }
 
-// For headless services: periodically check if DNS has changed and reconnect if needed
-if (isHeadlessService) {
-    let lastKnownIps = [];
+    const redisHost = new URL(process.env.REDIS_URI).hostname;
+    const isHeadlessService = redisHost.endsWith('.svc.cluster.local') || redisHost.endsWith('.svc');
 
-    const checkDnsAndReconnect = async () => {
-        try {
-            const currentIps = await dns.resolve(redisHost);
-            currentIps.sort();
+    client = createRedisClient(true);
 
-            if (lastKnownIps.length > 0 && JSON.stringify(lastKnownIps) !== JSON.stringify(currentIps)) {
-                globalThis.logger?.warn({ oldIps: lastKnownIps, newIps: currentIps }, 'Redis: DNS changed, reconnecting...')
-                client.disconnect();
-                client = createRedisClient(false);
+    // For headless services: periodically check if DNS has changed and reconnect if needed
+    if (isHeadlessService) {
+        let lastKnownIps = [];
+
+        const checkDnsAndReconnect = async () => {
+            try {
+                const currentIps = await dns.resolve(redisHost);
+                currentIps.sort();
+
+                if (lastKnownIps.length > 0 && JSON.stringify(lastKnownIps) !== JSON.stringify(currentIps)) {
+                    globalThis.logger?.warn({ oldIps: lastKnownIps, newIps: currentIps }, 'Redis: DNS changed, reconnecting...')
+                    client.disconnect();
+                    client = createRedisClient(false);
+                }
+                lastKnownIps = currentIps;
+            } catch (err) {
+                globalThis.logger?.error({ err }, 'Redis: DNS lookup failed')
             }
-            lastKnownIps = currentIps;
-        } catch (err) {
-            globalThis.logger?.error({ err }, 'Redis: DNS lookup failed')
-        }
-    };
+        };
 
-    // Initial DNS lookup
-    checkDnsAndReconnect();
-    // Periodic DNS check
-    setInterval(checkDnsAndReconnect, DNS_REFRESH_INTERVAL);
+        // Initial DNS lookup
+        checkDnsAndReconnect();
+        // Periodic DNS check
+        timers.push(setInterval(checkDnsAndReconnect, DNS_REFRESH_INTERVAL).unref());
+    }
+
+    // Force reconnect if too many errors accumulate
+    timers.push(setInterval(() => {
+        if (connectionErrorCount >= MAX_ERROR_COUNT) {
+            globalThis.logger?.warn(`Redis: ${connectionErrorCount} errors accumulated, forcing reconnect...`)
+            connectionErrorCount = 0;
+            client.disconnect();
+            client = createRedisClient(false);
+        }
+    }, 10000).unref());
+
+    return client;
 }
 
-// Force reconnect if too many errors accumulate
-setInterval(() => {
-    if (connectionErrorCount >= MAX_ERROR_COUNT) {
-        globalThis.logger?.warn(`Redis: ${connectionErrorCount} errors accumulated, forcing reconnect...`)
-        connectionErrorCount = 0;
-        client.disconnect();
-        client = createRedisClient(false);
+// Tear down the connection and timers (for test teardown / graceful shutdown).
+export async function disconnect() {
+    timers.forEach(clearInterval);
+    timers = [];
+    if (client) {
+        await client.quit().catch(() => client.disconnect());
+        client = undefined;
     }
-}, 10000);
+    isReady = false;
+    readyPromise = new Promise(resolve => { readyResolve = resolve; });
+}
 
-// Export a getter to always use the current client instance
-const getClient = () => client;
+// Export a getter to always use the current client instance. Connects on first use.
+const getClient = () => client ?? connect();
 
-// Wait for initial connection to be ready
-export const waitForReady = () => readyPromise;
+// Wait for initial connection to be ready (connecting if necessary).
+export const waitForReady = () => {
+    connect();
+    return readyPromise;
+};
 
 const grantable = new Set([
     'AccessToken',

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { dirname } from 'desm';
 import render from '@koa/ejs';
 import oidcRoutes from './routes/oidcRoutes.js';
@@ -19,11 +20,10 @@ const __dirname = dirname(import.meta.url);
 
 const { PORT = 3000 } = process.env;
 
-let server;
-
-try {
-    setupLogger()
-    getUsernameSource() // validate USERNAME_SOURCE (and warn on deprecated flags) at boot
+// Construct the fully-wired oidc-provider (views, routes, static assets) without
+// binding a port or starting the metrics server / Kubernetes operators. This is
+// the seam used by HTTP-level tests, which drive it via supertest(provider.callback()).
+export async function buildProvider() {
     const provider = await setupProvider()
     render(provider.app, {
         cache: false,
@@ -37,18 +37,40 @@ try {
     provider.use(forwardAuthRoutes(provider).routes());
     provider.use(serve('frontend/dist'));
     provider.use(serve('styles/dist'));
-    server = provider.listen(PORT, () => {
-        globalThis.logger.info(`application is listening on port ${PORT}, check its /.well-known/openid-configuration`);
-    });
-    metricsServer()
+    return provider
+}
+
+// Start the operators that watch the cluster for OIDC client/user resources.
+export async function startOperators(provider) {
     const kubeClientOperator = new KubeOIDCClientOperator(provider)
     await kubeClientOperator.watchClients()
     const kubeMiddlewareClientOperator = new KubeOIDCMiddlewareClientOperator(provider)
     await kubeMiddlewareClientOperator.watchClients()
     const kubeUserOperator = new KubeOidcUserOperator(provider)
     await kubeUserOperator.watchUsers()
-} catch (err) {
-    if (server?.listening) server.close();
-    console.error(err);
-    process.exitCode = 1;
+}
+
+// Boot the full application. Skipped when imported as a module (e.g. by tests),
+// which import buildProvider()/startOperators() directly.
+export async function main() {
+    let server;
+    try {
+        setupLogger()
+        getUsernameSource() // validate USERNAME_SOURCE (and warn on deprecated flags) at boot
+        const provider = await buildProvider()
+        server = provider.listen(PORT, () => {
+        globalThis.logger.info(`application is listening on port ${PORT}, check its /.well-known/openid-configuration`);
+    });
+    metricsServer()
+    await startOperators(provider)
+    } catch (err) {
+        if (server?.listening) server.close();
+        console.error(err);
+        process.exitCode = 1;
+    }
+}
+
+// Only boot when run directly (node src/app.js), not when imported by tests.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    await main();
 }

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -8,10 +8,10 @@ import {KubernetesAdapter} from "../adapters/kubernetes.js";
 import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 
 export class KubeOIDCClientOperator {
-    constructor(provider) {
+    constructor(provider, adapter = new KubernetesAdapter()) {
         this.redisAdapter = new RedisAdapter('Client')
         this.provider = provider
-        this.adapter = new KubernetesAdapter()
+        this.adapter = adapter
         this.instance = this.adapter.instance
     }
 

--- a/src/operators/kube-oidc-middleware-client-operator.js
+++ b/src/operators/kube-oidc-middleware-client-operator.js
@@ -9,10 +9,10 @@ import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 import {Claimed} from "../conditions/claimed.js";
 
 export class KubeOIDCMiddlewareClientOperator {
-    constructor(provider) {
+    constructor(provider, adapter = new KubernetesAdapter()) {
         this.redisAdapter = new RedisAdapter('Client')
         this.provider = provider
-        this.adapter = new KubernetesAdapter()
+        this.adapter = adapter
         this.instance = this.adapter.instance
     }
 

--- a/src/operators/kube-oidc-user-operator.js
+++ b/src/operators/kube-oidc-user-operator.js
@@ -8,12 +8,12 @@ import {KubeOIDCUserService} from "../services/kube-oidc-user-service.js";
 import {ClaimedBy} from "../conditions/claimed-by.js";
 
 export class KubeOIDCUserOperator {
-    constructor(provider) {
+    constructor(provider, adapter = new KubernetesAdapter()) {
         // this.redisAdapter = new RedisAdapter('Client')
         this.provider = provider
-        this.adapter = new KubernetesAdapter()
+        this.adapter = adapter
         this.instance = this.adapter.instance
-        this.userService = new KubeOIDCUserService();
+        this.userService = new KubeOIDCUserService(this.adapter);
     }
 
     async watchUsers() {

--- a/src/providers/setup-logger.js
+++ b/src/providers/setup-logger.js
@@ -5,7 +5,12 @@ export const setupLogger = () => {
         level: process.env.NODE_ENV === 'production' ? 'info' : 'trace',
         redact: [
             'ctx.request.header.cookie',
-            'ctx.response.header["set-cookie"].*',
+            // NOTE: do NOT redact 'ctx.response.header["set-cookie"]'. Koa's
+            // ctx.response.header is a getter returning a fresh object each
+            // access, which breaks pino/fast-redact's mutate-then-restore for
+            // array-wildcard paths: it mutates the *live* Set-Cookie array in
+            // place but restores into a throwaway copy, leaving "[Redacted]" on
+            // the actual response and corrupting every cookie (breaks login).
             'interaction.session.cookie',
             '*.jti',
             'interaction.result.token',

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -14,8 +14,8 @@ function mergeReplacingArrays(objValue, srcValue) {
 }
 
 export class KubeOIDCUserService {
-    constructor() {
-        this.adapter = new KubernetesAdapter()
+    constructor(adapter = new KubernetesAdapter()) {
+        this.adapter = adapter
     }
 
     async listUsers() {

--- a/src/services/session-service.js
+++ b/src/services/session-service.js
@@ -72,11 +72,18 @@ export class SessionService {
 
     async endOIDCSession(sessionToDelete, ctx, next) {
         sessionToDelete = await this.sessionRedis.find(sessionToDelete)
+        // Only touch the browser's cookies when ending the *current* session;
+        // otherwise use a no-op so ending another session (or cleaning up after
+        // an authorization error, where ctx has no cookies at all) doesn't clear
+        // the live cookie or throw.
+        const cookies = (sessionToDelete?.jti === ctx.currentSession?.jti && ctx.cookies)
+            ? ctx.cookies
+            : { set: () => {} }
+        // oidc-provider v9's end_session action reads ctx.cookies (v8 read
+        // ctx.oidc.cookies), so set both for the "dirty hack" call below.
+        ctx.cookies = cookies
         ctx.oidc = {
-            // don't clear cookies when it's not current session
-            cookies: sessionToDelete?.jti === ctx.currentSession?.jti && ctx.cookies ? ctx.cookies : {
-                set: () => {}
-            },
+            cookies,
             urlFor: () => {
                 // don't redirect when ending other sessions in frontpage
                 return process.env.ISSUER_URL

--- a/src/utils/get-email-content.js
+++ b/src/utils/get-email-content.js
@@ -1,7 +1,11 @@
 import {dirname} from "desm";
-import {renderFile} from "ejs";
+// ejs 6 is CommonJS and only exposes renderFile on its default export
+// (no named ESM export), so import the default and destructure.
+import ejs from "ejs";
 import path from "path";
 import fs from "fs";
+
+const {renderFile} = ejs;
 
 export const getEmailContent = async (template, variables) => {
     return {

--- a/src/utils/oidc-providers.js
+++ b/src/utils/oidc-providers.js
@@ -88,11 +88,19 @@ export const getOidcClient = async (providerConfig) => {
     if (configCache.has(providerConfig.key)) {
         return configCache.get(providerConfig.key);
     }
+    // Opt-in escape hatch for local/CI testing against an http upstream IdP
+    // (e.g. a Dex container). Never enable this in production. Passing
+    // allowInsecureRequests in the discovery options also relaxes the resulting
+    // Configuration's token/userinfo requests.
+    const options = process.env.OIDC_ALLOW_INSECURE_UPSTREAM === 'true'
+        ? { execute: [client.allowInsecureRequests] }
+        : undefined;
     const config = await client.discovery(
         new URL(providerConfig.issuer),
         providerConfig.clientId,
         providerConfig.clientSecret,
         client.ClientSecretBasic(providerConfig.clientSecret),
+        options,
     );
     configCache.set(providerConfig.key, config);
     return config;

--- a/src/utils/session/base-domain.js
+++ b/src/utils/session/base-domain.js
@@ -3,7 +3,13 @@ import microMatch from "micromatch";
 
 export const getBaseDomainFromUrl = (url) => {
     url = new URL(url)
-    let domain = parseDomain(url.hostname);
+    const domain = parseDomain(url.hostname);
+    // Non-registrable hosts (IP addresses, "localhost", single labels) have no
+    // domain/topLevelDomains. Fall back to the hostname itself so the app still
+    // boots in local/dev/test setups instead of throwing at import.
+    if (!domain.domain || !domain.topLevelDomains?.length) {
+        return url.hostname
+    }
     return [
         domain.domain,
         domain.topLevelDomains.join('.')

--- a/test/e2e/Caddyfile
+++ b/test/e2e/Caddyfile
@@ -1,0 +1,14 @@
+# TLS terminator for the e2e: passmower runs http on :3000 (as it does in
+# production behind a proxy), and Caddy fronts it with https on :8443 using an
+# internal self-signed CA. This satisfies oidc-provider v9's requirement that
+# the implicit-flow dashboard client use https redirect URIs. The browser trusts
+# the cert via Playwright's ignoreHTTPSErrors.
+{
+	auto_https disable_redirects
+	local_certs
+	admin off
+}
+
+https://passmower.localtest.me:8443 {
+	reverse_proxy 127.0.0.1:3000
+}

--- a/test/e2e/dex/config.yaml
+++ b/test/e2e/dex/config.yaml
@@ -18,7 +18,7 @@ staticClients:
     name: Passmower
     secret: passmower-dex-secret
     redirectURIs:
-      - http://passmower.localtest.me:3000/interaction/callback/dex
+      - https://passmower.localtest.me:8443/interaction/callback/dex
 
 enablePasswordDB: false
 

--- a/test/e2e/dex/config.yaml
+++ b/test/e2e/dex/config.yaml
@@ -1,0 +1,28 @@
+# Dex acts as the generic upstream OIDC IdP for the e2e login test.
+# The mockCallback connector returns a fixed identity with no login form, so the
+# browser flow exercises passmower's upstream-OIDC path (discovery + PKCE + JWKS
+# + userinfo) without us having to script a third-party login UI.
+issuer: http://127.0.0.1:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: passmower
+    name: Passmower
+    secret: passmower-dex-secret
+    redirectURIs:
+      - http://127.0.0.1:3000/interaction/callback/dex
+
+enablePasswordDB: false
+
+connectors:
+  - type: mockCallback
+    id: mock
+    name: Example

--- a/test/e2e/dex/config.yaml
+++ b/test/e2e/dex/config.yaml
@@ -18,7 +18,7 @@ staticClients:
     name: Passmower
     secret: passmower-dex-secret
     redirectURIs:
-      - http://127.0.0.1:3000/interaction/callback/dex
+      - http://passmower.localtest.me:3000/interaction/callback/dex
 
 enablePasswordDB: false
 

--- a/test/e2e/oidc-login.spec.js
+++ b/test/e2e/oidc-login.spec.js
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+// Full browser login through the generic upstream OIDC provider (Dex). Exercises
+// the real wire path: openid-client v6 discovery + PKCE + JWKS + userinfo against
+// a real IdP, oidc-provider v9, Redis, and real Kubernetes API CRUD (the user is
+// created as an OIDCUser custom resource).
+test('logs in through the Dex upstream OIDC provider', async ({ page }) => {
+    // 1. Unauthenticated dashboard -> passmower login page.
+    await page.goto('/')
+
+    // 2. Choose the Dex upstream. Dex's mockCallback connector returns a fixed
+    //    identity (kilgore@kilgore.trout / "Kilgore Trout") with no login form.
+    await page.getByRole('button', { name: /Sign in with Dex/i }).click()
+
+    // 3. First login for a new user requires accepting the Terms of Service.
+    const tosContinue = page.getByRole('button', { name: 'Continue' })
+    await tosContinue.waitFor({ state: 'visible' })
+    await tosContinue.click()
+
+    // 4. Land on the authenticated dashboard.
+    await expect(page.locator('#app')).toBeVisible()
+
+    // 5. The session is real: the profile API returns the upstream identity.
+    const me = await page.request.get('/api/me')
+    expect(me.ok()).toBeTruthy()
+    const body = await me.json()
+    expect(JSON.stringify(body)).toContain('kilgore@kilgore.trout')
+})

--- a/test/e2e/oidc-login.spec.js
+++ b/test/e2e/oidc-login.spec.js
@@ -12,17 +12,22 @@ test('logs in through the Dex upstream OIDC provider', async ({ page }) => {
     //    identity (kilgore@kilgore.trout / "Kilgore Trout") with no login form.
     await page.getByRole('button', { name: /Sign in with Dex/i }).click()
 
-    // 3. First login for a new user requires accepting the Terms of Service.
-    const tosContinue = page.getByRole('button', { name: 'Continue' })
-    await tosContinue.waitFor({ state: 'visible' })
-    await tosContinue.click()
+    // 3. First-time login requires accepting the Terms of Service; a returning
+    //    user (e.g. on a retry, since the OIDCUser persists in the cluster)
+    //    skips it — so the ToS step is optional.
+    try {
+        await page.getByRole('button', { name: 'Continue' }).click({ timeout: 15_000 })
+    } catch {
+        // ToS already accepted on a previous run — continue.
+    }
 
-    // 4. Land on the authenticated dashboard.
-    await expect(page.locator('#app')).toBeVisible()
-
-    // 5. The session is real: the profile API returns the upstream identity.
-    const me = await page.request.get('/api/me')
-    expect(me.ok()).toBeTruthy()
-    const body = await me.json()
-    expect(JSON.stringify(body)).toContain('kilgore@kilgore.trout')
+    // 4. Logged in: the profile API returns the upstream identity. This is the
+    //    definitive signed-in signal (depends only on the session cookie).
+    await expect.poll(
+        async () => {
+            const res = await page.request.get('/api/me')
+            return res.ok() ? await res.text() : ''
+        },
+        { timeout: 20_000, message: 'waiting for an authenticated /api/me' },
+    ).toContain('kilgore@kilgore.trout')
 })

--- a/test/e2e/passmower.env
+++ b/test/e2e/passmower.env
@@ -1,0 +1,24 @@
+# Environment for the passmower instance under e2e test. Sourced by run-local.sh
+# and mirrored by the CI workflow. OIDC_JWKS / OIDC_COOKIE_KEYS are generated at
+# runtime by run-local.sh (ephemeral) and exported there.
+ISSUER_URL=http://127.0.0.1:3000/
+PORT=3000
+REDIS_URI=redis://127.0.0.1:6379
+
+# Only the Dex upstream is offered, so the login page has a single button.
+GITHUB_ENABLED=false
+EMAIL_ENABLED=false
+WEBAUTHN_ENABLED=false
+
+# Generic upstream OIDC -> Dex (see test/e2e/dex/config.yaml).
+OIDC_PROVIDERS=[{"key":"dex","displayName":"Dex","issuer":"http://127.0.0.1:5556/dex","scopes":["openid","email","profile","groups"],"groupsClaim":"groups"}]
+DEX_CLIENT_ID=passmower
+DEX_CLIENT_SECRET=passmower-dex-secret
+
+# Enrolment: auto-create users with generated usernames.
+ENROLL_USERS=true
+USERNAME_SOURCE=generated
+
+# Kubernetes operator identity (namespace + KUBECONFIG are exported by run-local.sh).
+DEPLOYMENT_NAME=passmower
+POD_NAMESPACE=passmower-test

--- a/test/e2e/passmower.env
+++ b/test/e2e/passmower.env
@@ -2,12 +2,16 @@
 # and mirrored by the CI workflow. OIDC_JWKS / OIDC_COOKIE_KEYS are generated at
 # runtime by run-local.sh (ephemeral) and exported there.
 #
-# ISSUER_URL must be a registrable hostname (not a bare IP) because base-domain.js
-# derives the cookie/site-session domain from it. passmower.localtest.me resolves
-# to 127.0.0.1 (CI also pins it in /etc/hosts), so the browser reaches localhost.
-ISSUER_URL=http://passmower.localtest.me:3000/
+# ISSUER_URL is https (Caddy terminates TLS on :8443 in front of passmower)
+# because oidc-provider v9 requires https redirect URIs for the implicit-flow
+# dashboard client. passmower itself still listens http on PORT=3000.
+# passmower.localtest.me resolves to 127.0.0.1 (CI also pins it in /etc/hosts).
+ISSUER_URL=https://passmower.localtest.me:8443/
 PORT=3000
 REDIS_URI=redis://127.0.0.1:6379
+
+# The Dex upstream runs over http; allow openid-client to talk to it (test only).
+OIDC_ALLOW_INSECURE_UPSTREAM=true
 
 # Only the Dex upstream is offered, so the login page has a single button.
 GITHUB_ENABLED=false

--- a/test/e2e/passmower.env
+++ b/test/e2e/passmower.env
@@ -1,7 +1,11 @@
 # Environment for the passmower instance under e2e test. Sourced by run-local.sh
 # and mirrored by the CI workflow. OIDC_JWKS / OIDC_COOKIE_KEYS are generated at
 # runtime by run-local.sh (ephemeral) and exported there.
-ISSUER_URL=http://127.0.0.1:3000/
+#
+# ISSUER_URL must be a registrable hostname (not a bare IP) because base-domain.js
+# derives the cookie/site-session domain from it. passmower.localtest.me resolves
+# to 127.0.0.1 (CI also pins it in /etc/hosts), so the browser reaches localhost.
+ISSUER_URL=http://passmower.localtest.me:3000/
 PORT=3000
 REDIS_URI=redis://127.0.0.1:6379
 

--- a/test/e2e/passmower.env
+++ b/test/e2e/passmower.env
@@ -15,7 +15,9 @@ EMAIL_ENABLED=false
 WEBAUTHN_ENABLED=false
 
 # Generic upstream OIDC -> Dex (see test/e2e/dex/config.yaml).
-OIDC_PROVIDERS=[{"key":"dex","displayName":"Dex","issuer":"http://127.0.0.1:5556/dex","scopes":["openid","email","profile","groups"],"groupsClaim":"groups"}]
+# Single-quoted: this file is sourced with `set -a; . passmower.env`, and bash
+# would otherwise strip the inner double quotes and corrupt the JSON.
+OIDC_PROVIDERS='[{"key":"dex","displayName":"Dex","issuer":"http://127.0.0.1:5556/dex","scopes":["openid","email","profile","groups"],"groupsClaim":"groups"}]'
 DEX_CLIENT_ID=passmower
 DEX_CLIENT_SECRET=passmower-dex-secret
 

--- a/test/e2e/run-local.sh
+++ b/test/e2e/run-local.sh
@@ -44,9 +44,9 @@ node src/app.js & APP_PID=$!
 
 echo "==> Wait for passmower"
 for i in $(seq 1 30); do
-    curl -sf http://127.0.0.1:3000/.well-known/openid-configuration >/dev/null && break
+    curl -sf http://passmower.localtest.me:3000/.well-known/openid-configuration >/dev/null && break
     sleep 1
 done
 
 echo "==> Playwright"
-npx playwright test
+PASSMOWER_URL=http://passmower.localtest.me:3000 npx playwright test

--- a/test/e2e/run-local.sh
+++ b/test/e2e/run-local.sh
@@ -12,6 +12,7 @@ CLUSTER=passmower-e2e
 APP_PID=""
 cleanup() {
     [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true
+    caddy stop --config test/e2e/Caddyfile 2>/dev/null || true
     docker compose -f docker-compose.test.yml down -v || true
     kind delete cluster --name "$CLUSTER" || true
 }
@@ -42,11 +43,18 @@ export OIDC_COOKIE_KEYS='["e2e-cookie-secret-0123456789abcdef0123456789"]'
 export OIDC_JWKS="$(node -e "const {generateKeyPairSync}=require('crypto');const {privateKey}=generateKeyPairSync('rsa',{modulusLength:2048});const j=privateKey.export({format:'jwk'});j.use='sig';j.alg='RS256';j.kid='e2e';console.log(JSON.stringify([j]))")"
 node src/app.js & APP_PID=$!
 
-echo "==> Wait for passmower"
+echo "==> Wait for passmower (http :3000)"
 for i in $(seq 1 30); do
-    curl -sf http://passmower.localtest.me:3000/.well-known/openid-configuration >/dev/null && break
+    curl -sf http://127.0.0.1:3000/.well-known/openid-configuration >/dev/null && break
+    sleep 1
+done
+
+echo "==> Start Caddy (https :8443 -> :3000)  [needs caddy on PATH]"
+caddy start --config test/e2e/Caddyfile
+for i in $(seq 1 20); do
+    curl -ksf https://passmower.localtest.me:8443/.well-known/openid-configuration >/dev/null && break
     sleep 1
 done
 
 echo "==> Playwright"
-PASSMOWER_URL=http://passmower.localtest.me:3000 npx playwright test
+PASSMOWER_URL=https://passmower.localtest.me:8443 npx playwright test

--- a/test/e2e/run-local.sh
+++ b/test/e2e/run-local.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bring up the full e2e stack locally and run the Playwright login test:
+#   Redis + Dex (docker compose) + a kind Kubernetes cluster (CRDs applied) +
+#   passmower (host node process, built frontend) + Playwright.
+#
+# Requires: docker/podman, kind, kubectl, node. CI does the equivalent inline.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+CLUSTER=passmower-e2e
+APP_PID=""
+cleanup() {
+    [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null || true
+    docker compose -f docker-compose.test.yml down -v || true
+    kind delete cluster --name "$CLUSTER" || true
+}
+trap cleanup EXIT
+
+echo "==> Redis + Dex"
+docker compose -f docker-compose.test.yml up -d
+
+echo "==> Kubernetes (kind) + CRDs"
+kind create cluster --name "$CLUSTER"
+kubectl apply -f charts/passmower/templates/crds.yaml
+kubectl create namespace passmower-test --dry-run=client -o yaml | kubectl apply -f -
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+echo "==> Build frontend + styles"
+npm --prefix frontend ci && npm --prefix frontend run build
+npm --prefix styles ci && npm --prefix styles run sass-prod
+
+echo "==> Wait for Dex discovery"
+for i in $(seq 1 30); do
+    curl -sf http://127.0.0.1:5556/dex/.well-known/openid-configuration >/dev/null && break
+    sleep 1
+done
+
+echo "==> Start passmower"
+set -a; . test/e2e/passmower.env; set +a
+export OIDC_COOKIE_KEYS='["e2e-cookie-secret-0123456789abcdef0123456789"]'
+export OIDC_JWKS="$(node -e "const {generateKeyPairSync}=require('crypto');const {privateKey}=generateKeyPairSync('rsa',{modulusLength:2048});const j=privateKey.export({format:'jwk'});j.use='sig';j.alg='RS256';j.kid='e2e';console.log(JSON.stringify([j]))")"
+node src/app.js & APP_PID=$!
+
+echo "==> Wait for passmower"
+for i in $(seq 1 30); do
+    curl -sf http://127.0.0.1:3000/.well-known/openid-configuration >/dev/null && break
+    sleep 1
+done
+
+echo "==> Playwright"
+npx playwright test

--- a/test/fakes/email-capture.js
+++ b/test/fakes/email-capture.js
@@ -1,0 +1,10 @@
+// Mock for src/adapters/email.js: instead of sending SMTP, capture messages so
+// tests can read the magic-link out of the rendered email.
+export const sentEmails = []
+
+export default class EmailAdapter {
+    async sendMail(to, subject, text, html) {
+        sentEmails.push({ to, subject, text, html })
+        return true
+    }
+}

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -1,0 +1,115 @@
+// In-memory stand-in for src/adapters/kubernetes.js used by unit/integration
+// tests. It stores custom resources in a Map keyed by `${kind}/${name}` and
+// reproduces the exact object shape the real adapter hands to mapper functions
+// (top-level spec keys + metadata + status), so the real KubeOIDCUserService /
+// models run unchanged on top of it.
+//
+// Inject it with:  vi.mock('../../src/adapters/kubernetes.js', () => ({ KubernetesAdapter: FakeKubernetesAdapter }))
+// or by passing an instance into KubeOIDCUserService(adapter) / operators.
+
+const SPEC_KEYS = ['spec', 'passmower', 'slack', 'github', 'identities', 'webauthn']
+
+export class FakeKubernetesAdapter {
+    constructor({ namespace = 'test', instance = 'test-passmower' } = {}) {
+        this.namespace = namespace
+        this.instance = instance
+        this.store = new Map()       // `${kind}/${name}` -> stored CR object
+        this.secrets = new Map()     // `${namespace}/${name}` -> secret data
+        this.watchHandlers = []      // for operator tests
+        this._rv = 0
+    }
+
+    #key(kind, name) { return `${kind}/${name}` }
+    #nextRv() { return String(++this._rv) }
+
+    // --- Custom objects -----------------------------------------------------
+
+    async listNamespacedCustomObject(kind, _namespace, mapperFunction) {
+        const items = [...this.store.entries()]
+            .filter(([k]) => k.startsWith(`${kind}/`))
+            .map(([, v]) => v)
+        return Promise.all(items.map((v) => mapperFunction(structuredClone(v))))
+    }
+
+    async getNamespacedCustomObject(kind, _namespace, id, mapperFunction) {
+        const stored = this.store.get(this.#key(kind, id))
+        if (!stored) return undefined // real adapter returns undefined on 404
+        return mapperFunction(structuredClone(stored))
+    }
+
+    async createNamespacedCustomObject(kind, _namespace, name, spec, mapperFunction, _owner, labels = {}) {
+        const key = this.#key(kind, name)
+        if (this.store.has(key)) return null // name already taken -> real adapter swallows the conflict
+        const obj = {
+            apiVersion: 'codemowers.cloud/v1beta1',
+            kind,
+            metadata: { name, labels, resourceVersion: this.#nextRv() },
+            status: {},
+            ...structuredClone(spec),
+        }
+        this.store.set(key, obj)
+        this.#emit('ADDED', kind, obj)
+        return mapperFunction(structuredClone(obj))
+    }
+
+    async patchNamespacedCustomObject(kind, _namespace, id, values, _existingValues, mapperFunction) {
+        const stored = this.store.get(this.#key(kind, id))
+        if (!stored) return null
+        for (const [k, v] of Object.entries(values)) {
+            if (k === '/metadata') {
+                stored.metadata = { ...stored.metadata, ...structuredClone(v) }
+            } else if (SPEC_KEYS.includes(k)) {
+                stored[k] = structuredClone(v)
+            }
+        }
+        stored.metadata.resourceVersion = this.#nextRv()
+        this.#emit('MODIFIED', kind, stored)
+        return mapperFunction(structuredClone(stored))
+    }
+
+    async replaceNamespacedCustomObjectStatus(kind, _namespace, id, _resourceVersion, status, mapperFunction) {
+        const stored = this.store.get(this.#key(kind, id))
+        if (!stored) return undefined
+        stored.status = structuredClone(status)
+        stored.metadata.resourceVersion = this.#nextRv()
+        this.#emit('MODIFIED', kind, stored)
+        return mapperFunction(structuredClone(stored))
+    }
+
+    // --- Secrets (used by the client operator) ------------------------------
+
+    async getSecret(namespace, id) { return this.secrets.get(`${namespace}/${id}`) }
+    async createSecret(namespace, id, data) { this.secrets.set(`${namespace}/${id}`, data); return data }
+    async replaceSecret(namespace, id, data) { this.secrets.set(`${namespace}/${id}`, data); return data }
+
+    // --- Watch (used by operators) ------------------------------------------
+
+    // Operators call setWatchParameters(...) then watchObjects(); for tests we
+    // expose a hook to push synthetic events through whatever the operator
+    // registered. Operators that don't use this can ignore it.
+    onWatch(handler) { this.watchHandlers.push(handler) }
+    #emit(type, kind, obj) {
+        for (const h of this.watchHandlers) h(type, kind, structuredClone(obj))
+    }
+
+    // Test helpers -----------------------------------------------------------
+
+    /** Seed a custom resource directly (bypassing create) for test fixtures. */
+    seed(kind, obj) {
+        const name = obj.metadata.name
+        this.store.set(this.#key(kind, name), {
+            apiVersion: 'codemowers.cloud/v1beta1',
+            kind,
+            status: {},
+            ...structuredClone(obj),
+            metadata: { resourceVersion: this.#nextRv(), labels: {}, ...obj.metadata },
+        })
+    }
+
+    /** All stored resources of a kind, as raw objects. */
+    list(kind) {
+        return [...this.store.entries()].filter(([k]) => k.startsWith(`${kind}/`)).map(([, v]) => v)
+    }
+}
+
+export default FakeKubernetesAdapter

--- a/test/fakes/shared-kube.js
+++ b/test/fakes/shared-kube.js
@@ -1,0 +1,13 @@
+// Module used to mock src/adapters/kubernetes.js so that every `new
+// KubernetesAdapter()` in the app returns ONE shared in-memory fake the test can
+// seed and inspect. A constructor that returns an object overrides `this`, so
+// `new KubernetesAdapter()` yields the singleton.
+import { FakeKubernetesAdapter } from './fake-kubernetes-adapter.js'
+
+export const fakeKube = new FakeKubernetesAdapter()
+
+export class KubernetesAdapter {
+    constructor() {
+        return fakeKube
+    }
+}

--- a/test/integration/discovery.test.js
+++ b/test/integration/discovery.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import { setupLogger } from '../../src/providers/setup-logger.js'
+
+// Smoke-level HTTP integration: build the real provider (with the real Redis
+// adapter) and assert the OIDC surface is correctly wired and served.
+describe('OIDC discovery + authorization endpoint', () => {
+    let provider
+    let agent
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        setupLogger()
+        const { buildProvider } = await import('../../src/app.js')
+        provider = await buildProvider()
+        agent = request(provider.callback())
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    it('serves a discovery document with the configured issuer and endpoints', async () => {
+        const res = await agent.get('/.well-known/openid-configuration').expect(200)
+        expect(res.body.issuer).toBe(process.env.ISSUER_URL)
+        expect(res.body.authorization_endpoint).toContain('/auth')
+        expect(res.body.token_endpoint).toContain('/token')
+        expect(res.body.jwks_uri).toContain('/jwks')
+        expect(res.body.code_challenge_methods_supported).toContain('S256')
+    })
+
+    it('publishes signing keys at the jwks endpoint', async () => {
+        const res = await agent.get('/jwks').expect(200)
+        expect(Array.isArray(res.body.keys)).toBe(true)
+        expect(res.body.keys.length).toBeGreaterThan(0)
+        expect(res.body.keys[0]).toMatchObject({ kty: 'RSA', use: 'sig' })
+        // Private material must never be published.
+        expect(res.body.keys[0].d).toBeUndefined()
+    })
+})

--- a/test/integration/email-login.test.js
+++ b/test/integration/email-login.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import request from 'supertest'
+import { createHash, randomBytes } from 'node:crypto'
+
+// Replace the Kubernetes adapter and email adapter before the app is imported.
+vi.mock('../../src/adapters/kubernetes.js', () => import('../fakes/shared-kube.js'))
+vi.mock('../../src/adapters/email.js', () => import('../fakes/email-capture.js'))
+
+import { fakeKube } from '../fakes/shared-kube.js'
+import { sentEmails } from '../fakes/email-capture.js'
+
+const ISSUER = process.env.ISSUER_URL // e.g. https://oidc.test.example.com/
+const RP = {
+    client_id: 'test-rp',
+    client_secret: 'test-rp-secret',
+    redirect_uri: 'https://rp.test/callback',
+}
+
+function base64url(buf) {
+    return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+describe('email magic-link login (HTTP)', () => {
+    let callback
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        process.env.EMAIL_ENABLED = 'true'  // route is gated on this
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        const provider = await buildProvider()
+        callback = provider.callback()
+
+        // Register a downstream relying-party client directly in Redis (the
+        // oidc-provider adapter), mirroring what the kube client operator would do.
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        await new RedisAdapter('Client').upsert(RP.client_id, {
+            client_id: RP.client_id,
+            client_secret: RP.client_secret,
+            redirect_uris: [RP.redirect_uri],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'client_secret_basic',
+            // extraClientMetadata fields real clients always carry (addGrant reads availableScopes)
+            availableScopes: ['openid'],
+            allowedCORSOrigins: [],
+        })
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    beforeEach(() => {
+        fakeKube.store.clear()
+        sentEmails.length = 0
+        // Seed an existing, fully-onboarded user so the post-login policy only
+        // has to clear the (auto-resolved) consent prompt.
+        fakeKube.seed('OIDCUser', {
+            metadata: { name: 'testuser', labels: {} },
+            spec: { email: 'test@example.com', name: 'Test User' },
+            passmower: { email: 'test@example.com' },
+            status: {
+                primaryEmail: 'test@example.com',
+                emails: ['test@example.com'],
+                groups: [],
+                profile: { name: 'Test User' },
+                conditions: [{ type: 'ToSv1', status: 'True' }],
+            },
+        })
+    })
+
+    // --- tiny cookie-jar HTTP driver ---------------------------------------
+    const jar = () => new Map()
+    const cookieHeader = (j) => [...j.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+    function store(j, res) {
+        for (const c of res.headers['set-cookie'] ?? []) {
+            const pair = c.split(';')[0]
+            const i = pair.indexOf('=')
+            const name = pair.slice(0, i).trim()
+            const val = pair.slice(i + 1)
+            if (val === '') j.delete(name)
+            else j.set(name, val)
+        }
+    }
+    async function req(j, method, path, form) {
+        let r = request(callback)[method](path).set('Cookie', cookieHeader(j))
+        if (form) r = r.type('form').send(form)
+        const res = await r
+        store(j, res)
+        if (process.env.DEBUG_FLOW) {
+            console.error(`[hop] ${method.toUpperCase()} ${path.slice(0, 60)} -> ${res.status} loc=${res.headers.location ?? '-'} jar=[${[...j.keys()].join(',')}]`)
+        }
+        return res
+    }
+    // Follow redirects by path until we hit the relying party's callback host.
+    // (oidc-provider builds resume URLs from the request Host, which under
+    // supertest is an ephemeral 127.0.0.1:port — so we can't key off the issuer
+    // host; we stop specifically at the RP redirect_uri host.)
+    const rpHost = new URL(RP.redirect_uri).host
+    async function follow(j, res, maxHops = 12) {
+        let cur = res
+        for (let i = 0; i < maxHops && cur.status >= 300 && cur.status < 400; i++) {
+            const loc = cur.headers.location
+            if (!loc) break
+            const u = loc.startsWith('http') ? new URL(loc) : new URL(loc, ISSUER)
+            if (u.host === rpHost) return cur // RP callback reached
+            cur = await req(j, 'get', u.pathname + u.search)
+        }
+        return cur
+    }
+
+    it('logs in via the magic link, creates a grant and returns an auth code', async () => {
+        const j = jar()
+        const verifier = base64url(randomBytes(32))
+        const challenge = base64url(createHash('sha256').update(verifier).digest())
+        const authQuery = new URLSearchParams({
+            client_id: RP.client_id,
+            redirect_uri: RP.redirect_uri,
+            response_type: 'code',
+            scope: 'openid',
+            state: 'state-123',
+            nonce: 'nonce-123',
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+        })
+
+        // 1. Authorization request -> interaction
+        let res = await req(j, 'get', `/auth?${authQuery}`)
+        res = await follow(j, res)
+        expect(res.headers.location ?? res.request.url).toMatch(/\/interaction\//)
+        const uid = (res.headers.location ?? res.request.url).match(/\/interaction\/([^/?]+)/)[1]
+
+        // 2. Submit the email -> magic link is "sent"
+        res = await req(j, 'post', `/interaction/${uid}/email`, { email: 'test@example.com' })
+        expect(sentEmails).toHaveLength(1)
+        const linkPath = sentEmails[0].html.match(/\/interaction\/[^/]+\/verify-email\/[0-9a-f-]+/)[0]
+
+        // 3. Click the magic link -> login completes, consent auto-resolves, code issued
+        res = await req(j, 'get', linkPath)
+        const final = await follow(j, res)
+
+        const loc = final.headers.location ?? ''
+        expect(loc).toContain(RP.redirect_uri)
+        const code = new URL(loc).searchParams.get('code')
+        expect(code).toBeTruthy()
+        expect(new URL(loc).searchParams.get('state')).toBe('state-123')
+
+        // 4. Exchange the code for tokens
+        const tokenRes = await request(callback)
+            .post('/token')
+            .auth(RP.client_id, RP.client_secret)
+            .type('form')
+            .send({
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: RP.redirect_uri,
+                code_verifier: verifier,
+            })
+            .expect(200)
+
+        expect(tokenRes.body.access_token).toBeTruthy()
+        const idClaims = JSON.parse(Buffer.from(tokenRes.body.id_token.split('.')[1], 'base64url').toString())
+        expect(idClaims.sub).toBe('testuser')
+        expect(idClaims.nonce).toBe('nonce-123')
+    })
+})

--- a/test/integration/kube-user-service.test.js
+++ b/test/integration/kube-user-service.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { KubeOIDCUserService } from '../../src/services/kube-oidc-user-service.js'
+import { FakeKubernetesAdapter } from '../fakes/fake-kubernetes-adapter.js'
+
+// Exercises the real user-service + Account model against the in-memory fake
+// adapter — i.e. the exact code path that reads/writes OIDCUser custom resources.
+describe('KubeOIDCUserService over the fake Kubernetes adapter', () => {
+    let adapter
+    let service
+
+    beforeAll(() => {
+        globalThis.logger ??= { info() {}, warn() {}, error() {}, debug() {} }
+    })
+
+    beforeEach(() => {
+        adapter = new FakeKubernetesAdapter()
+        service = new KubeOIDCUserService(adapter)
+    })
+
+    it('creates a user and computes its status', async () => {
+        const account = await service.createUser('alice', 'alice@example.com', [])
+        expect(account.accountId).toBe('alice')
+
+        const stored = adapter.list('OIDCUser')
+        expect(stored).toHaveLength(1)
+        expect(stored[0].passmower.email).toBe('alice@example.com')
+        expect(stored[0].status.primaryEmail).toBe('alice@example.com')
+        expect(stored[0].metadata.labels).toMatchObject({
+            'codemowers.cloud/claimed-by': adapter.instance,
+        })
+    })
+
+    it('finds a user by id and by email', async () => {
+        await service.createUser('bob', 'bob@example.com', [])
+        expect((await service.findUser('bob')).accountId).toBe('bob')
+        expect(await service.findUser('nope')).toBeUndefined()
+
+        const byEmail = await service.findUserByEmails(['bob@example.com'])
+        expect(byEmail.accountId).toBe('bob')
+        expect(await service.findUserByEmails(['nobody@example.com'])).toBeUndefined()
+    })
+
+    it('refuses to create a user whose name is already taken', async () => {
+        await service.createUser('carol', 'carol@example.com', [])
+        expect(await service.createUser('carol', 'carol2@example.com', [])).toBeNull()
+        expect(adapter.list('OIDCUser')).toHaveLength(1)
+    })
+
+    it('merges an upstream identity into specs and recomputes status', async () => {
+        await service.createUser('dave', 'dave@example.com', [])
+        await service.updateUserSpecs('dave', {
+            identities: {
+                google: {
+                    sub: 'g-1',
+                    emails: [{ email: 'dave@corp.example.com', primary: false }],
+                    groups: [{ prefix: 'google.com', name: 'eng' }],
+                },
+            },
+        })
+
+        const stored = adapter.list('OIDCUser')[0]
+        expect(stored.identities.google.sub).toBe('g-1')
+        expect(stored.status.emails).toContain('dave@corp.example.com')
+        expect(stored.status.groups.map(g => `${g.prefix}:${g.name}`)).toContain('google.com:eng')
+    })
+
+    it('adds, renames and removes a passkey', async () => {
+        await service.createUser('erin', 'erin@example.com', [])
+        const cred = { id: 'cred-1', publicKey: 'pk', counter: 0, name: 'YubiKey' }
+
+        await service.addPasskey('erin', cred)
+        expect((await service.findUserByPasskeyId('cred-1')).accountId).toBe('erin')
+
+        await service.renamePasskey('erin', 'cred-1', 'Phone')
+        expect(adapter.list('OIDCUser')[0].webauthn.credentials[0].name).toBe('Phone')
+
+        await service.updatePasskeyCounter('erin', 'cred-1', 5)
+        expect(adapter.list('OIDCUser')[0].webauthn.credentials[0].counter).toBe(5)
+
+        await service.removePasskey('erin', 'cred-1')
+        expect(adapter.list('OIDCUser')[0].webauthn.credentials).toHaveLength(0)
+    })
+})

--- a/test/setup/env.js
+++ b/test/setup/env.js
@@ -1,0 +1,23 @@
+// Vitest setup file: establishes the minimum environment every src module needs
+// to be *imported* (configuration.js evaluates OIDC_COOKIE_KEYS / OIDC_JWKS at
+// module load). Individual tests override these as needed.
+import { generateKeyPairSync } from 'node:crypto'
+
+function ephemeralJwks() {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const jwk = privateKey.export({ format: 'jwk' })
+    jwk.use = 'sig'
+    jwk.alg = 'RS256'
+    jwk.kid = 'test-key'
+    return [jwk]
+}
+
+process.env.ISSUER_URL ??= 'https://oidc.test.example.com/'
+process.env.OIDC_COOKIE_KEYS ??= JSON.stringify(['test-cookie-secret-0123456789abcdef0123456789'])
+process.env.OIDC_JWKS ??= JSON.stringify(ephemeralJwks())
+process.env.DEPLOYMENT_NAME ??= 'passmower-test'
+
+// Upstream auth methods that reach external services are off unless a test opts in.
+process.env.GITHUB_ENABLED ??= 'false'
+process.env.EMAIL_ENABLED ??= 'false'
+process.env.WEBAUTHN_ENABLED ??= 'false'

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import Account from '../../src/models/account.js'
+
+// Build an Account the way the Kubernetes adapter would, from an OIDCUser-shaped object.
+function account(overrides = {}) {
+    return new Account().fromKubernetes({
+        metadata: { name: 'u-test', labels: {}, ...overrides.metadata },
+        spec: overrides.spec,
+        passmower: overrides.passmower,
+        slack: overrides.slack,
+        github: overrides.github,
+        identities: overrides.identities,
+        webauthn: overrides.webauthn,
+        status: overrides.status,
+    })
+}
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('Account.getIntendedStatus', () => {
+    it('aggregates and de-duplicates emails across spec, github and identities', () => {
+        const status = account({
+            spec: { email: 'a@spec.com' },
+            github: { emails: [{ email: 'a@spec.com', primary: true }, { email: 'gh@x.com' }] },
+            identities: { google: { emails: [{ email: 'g@corp.example.com' }] } },
+        }).getIntendedStatus()
+
+        expect(status.emails).toEqual(['a@spec.com', 'gh@x.com', 'g@corp.example.com'])
+    })
+
+    it('falls back to spec.email as primary when no preferred domain is set', () => {
+        const status = account({
+            spec: { email: 'a@spec.com' },
+            identities: { google: { emails: [{ email: 'g@corp.example.com' }] } },
+        }).getIntendedStatus()
+
+        expect(status.primaryEmail).toBe('a@spec.com')
+    })
+
+    it('prefers an email in PREFERRED_EMAIL_DOMAIN when set', () => {
+        vi.stubEnv('PREFERRED_EMAIL_DOMAIN', 'corp.example.com')
+        const status = account({
+            spec: { email: 'a@spec.com' },
+            identities: { google: { emails: [{ email: 'g@corp.example.com' }] } },
+        }).getIntendedStatus()
+
+        expect(status.primaryEmail).toBe('g@corp.example.com')
+    })
+
+    it('merges groups from all sources and de-duplicates by prefix:name', () => {
+        const status = account({
+            spec: { groups: [{ prefix: 'local', name: 'team' }] },
+            github: { groups: [{ prefix: 'gh', name: 'org' }, { prefix: 'local', name: 'team' }] },
+            identities: { google: { groups: [{ prefix: 'google.com', name: 'eng' }] } },
+        }).getIntendedStatus()
+
+        const keys = status.groups.map(g => `${g.prefix}:${g.name}`)
+        expect(keys).toEqual(['local:team', 'gh:org', 'google.com:eng'])
+    })
+
+    it('resolves profile name/company from the highest-priority source', () => {
+        const status = account({
+            github: { name: 'GH Name', company: 'GH Co' },
+            identities: { google: { name: 'Google Name' } },
+        }).getIntendedStatus()
+
+        expect(status.profile.name).toBe('GH Name')
+        expect(status.profile.company).toBe('GH Co')
+    })
+})
+
+describe('Account.claims', () => {
+    it('returns sub/username/email for openid scope', async () => {
+        const a = account({
+            status: { primaryEmail: 'a@x.com', emails: [{ email: 'a@x.com', primary: true }], groups: [], profile: {} },
+        })
+        const claims = await a.claims('id_token', 'openid', {}, [])
+        expect(claims.sub).toBe('u-test')
+        expect(claims.username).toBe('u-test')
+        expect(claims.email).toBe('a@x.com')
+    })
+
+    it('adds profile fields and emails for the profile scope', async () => {
+        const a = account({
+            status: {
+                primaryEmail: 'a@x.com',
+                emails: [{ email: 'a@x.com', primary: true }],
+                groups: [],
+                profile: { name: 'Jane', company: 'Acme' },
+            },
+        })
+        const claims = await a.claims('id_token', 'openid profile', {}, [])
+        expect(claims.name).toBe('Jane')
+        expect(claims.company).toBe('Acme')
+        expect(claims.emails).toEqual([{ email: 'a@x.com', primary: true }])
+    })
+})
+
+describe('Account.getRemoteHeaders', () => {
+    it('maps account fields onto the configured forward-auth header names', () => {
+        const a = account({
+            status: {
+                primaryEmail: 'a@x.com',
+                profile: { name: 'Jane' },
+                groups: [{ prefix: 'gh', name: 'org' }, { prefix: 'local', name: 'team' }],
+            },
+        })
+        const headers = a.getRemoteHeaders({
+            user: 'X-User', name: 'X-Name', email: 'X-Email', groups: 'X-Groups',
+        })
+        expect(headers['X-User']).toBe('u-test')
+        expect(headers['X-Name']).toBe('Jane')
+        expect(headers['X-Email']).toBe('a@x.com')
+        expect(headers['X-Groups'].split(',').sort()).toEqual(['gh:org', 'local:team'])
+    })
+})

--- a/test/unit/check-account-groups.test.js
+++ b/test/unit/check-account-groups.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import Account from '../../src/models/account.js'
+import { checkAccountGroups } from '../../src/utils/user/check-account-groups.js'
+
+function accountWithGroups(groups) {
+    return new Account().fromKubernetes({ metadata: { name: 'u', labels: {} }, status: { groups } })
+}
+
+describe('checkAccountGroups', () => {
+    const account = accountWithGroups([{ prefix: 'gh', name: 'org' }, { prefix: 'local', name: 'team' }])
+
+    it('allows when the client restricts to no groups', () => {
+        expect(checkAccountGroups({}, account)).toBe(true)
+        expect(checkAccountGroups({ allowedGroups: [] }, account)).toBe(true)
+    })
+
+    it('allows when the account is in at least one allowed group', () => {
+        expect(checkAccountGroups({ allowedGroups: ['gh:org'] }, account)).toBe(true)
+        expect(checkAccountGroups({ allowedGroups: ['x:y', 'local:team'] }, account)).toBe(true)
+    })
+
+    it('denies when the account is in none of the allowed groups', () => {
+        expect(checkAccountGroups({ allowedGroups: ['x:y'] }, account)).toBe(false)
+    })
+})

--- a/test/unit/conditions.test.js
+++ b/test/unit/conditions.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import Account from '../../src/models/account.js'
+import { ToSv1 } from '../../src/conditions/tosv1.js'
+import { Approved } from '../../src/conditions/approved.js'
+
+afterEach(() => vi.unstubAllEnvs())
+
+function accountWith({ conditions = [], groups = [] } = {}) {
+    return new Account().fromKubernetes({
+        metadata: { name: 'u-test', labels: {} },
+        status: { conditions, groups },
+    })
+}
+
+describe('ToSv1 condition', () => {
+    it('check() is true only when a True ToSv1 condition is present', () => {
+        const cond = new ToSv1()
+        expect(cond.check(accountWith({ conditions: [{ type: 'ToSv1', status: 'True' }] }))).toBe(true)
+        expect(cond.check(accountWith({ conditions: [{ type: 'ToSv1', status: 'False' }] }))).toBe(false)
+        expect(cond.check(accountWith({ conditions: [] }))).toBeFalsy()
+    })
+
+    it('set()/add() append a True condition that check() then accepts', () => {
+        const account = accountWith()
+        new ToSv1().setStatus(true).set(account)
+        expect(new ToSv1().check(account)).toBe(true)
+    })
+})
+
+describe('Approved condition', () => {
+    it('approves everyone when REQUIRED_GROUP is not set', () => {
+        vi.stubEnv('REQUIRED_GROUP', '')
+        expect(new Approved().check(accountWith())).toBe(true)
+    })
+
+    it('requires membership of REQUIRED_GROUP when set', () => {
+        vi.stubEnv('REQUIRED_GROUP', 'local:staff')
+        const member = accountWith({ groups: [{ prefix: 'local', name: 'staff' }] })
+        const nonMember = accountWith({ groups: [{ prefix: 'local', name: 'other' }] })
+        expect(new Approved().check(member)).toBeTruthy()
+        expect(new Approved().check(nonMember)).toBeFalsy()
+    })
+})

--- a/test/unit/is-origin.test.js
+++ b/test/unit/is-origin.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import isOrigin from '../../src/utils/session/is-origin.js'
+
+describe('isOrigin', () => {
+    it('accepts a bare origin', () => {
+        expect(isOrigin('https://example.com')).toBe(true)
+        expect(isOrigin('http://localhost:3000')).toBe(true)
+        expect(isOrigin('https://example.com:8443')).toBe(true)
+    })
+
+    it('rejects URLs that carry a path, query or trailing slash', () => {
+        expect(isOrigin('https://example.com/')).toBe(false)
+        expect(isOrigin('https://example.com/path')).toBe(false)
+        expect(isOrigin('https://example.com?a=1')).toBe(false)
+    })
+
+    it('rejects non-URLs and non-strings', () => {
+        expect(isOrigin('not a url')).toBe(false)
+        expect(isOrigin('')).toBe(false)
+        expect(isOrigin(null)).toBe(false)
+        expect(isOrigin(undefined)).toBe(false)
+        expect(isOrigin(42)).toBe(false)
+    })
+})

--- a/test/unit/markdown.test.js
+++ b/test/unit/markdown.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { renderMarkdown } from '../../src/utils/markdown.js'
+
+// Guards the marked v18 renderer migration: rendering works AND untrusted input
+// is neutralised (links open safely, unsafe schemes and raw HTML are defused).
+describe('renderMarkdown', () => {
+    it('renders basic markdown', () => {
+        expect(renderMarkdown('# Hi')).toContain('<h1>Hi</h1>')
+        expect(renderMarkdown('**bold**')).toContain('<strong>bold</strong>')
+    })
+
+    it('returns null for empty input', () => {
+        expect(renderMarkdown('')).toBeNull()
+        expect(renderMarkdown(null)).toBeNull()
+    })
+
+    it('opens links in a new tab and keeps safe hrefs', () => {
+        const html = renderMarkdown('[ok](https://example.com)')
+        expect(html).toContain('href="https://example.com"')
+        expect(html).toContain('target="_blank"')
+        expect(html).toContain('rel="noreferrer noopener"')
+    })
+
+    it('neutralises javascript: links to #', () => {
+        const html = renderMarkdown('[bad](javascript:alert(1))')
+        expect(html).toContain('href="#"')
+        expect(html).not.toContain('javascript:')
+    })
+
+    it('escapes raw embedded HTML', () => {
+        const html = renderMarkdown('text <img src=x onerror=alert(1)>')
+        expect(html).not.toContain('<img')
+        expect(html).toContain('&lt;img')
+    })
+})

--- a/test/unit/misc-utils.test.js
+++ b/test/unit/misc-utils.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import kebabCase from '../../src/utils/kebab-case.js'
+import sortObject from '../../src/utils/sort-object.js'
+
+describe('kebabCase', () => {
+    it('converts camelCase, spaces and underscores to kebab-case', () => {
+        expect(kebabCase('fooBar')).toBe('foo-bar')
+        expect(kebabCase('foo bar')).toBe('foo-bar')
+        expect(kebabCase('foo_bar')).toBe('foo-bar')
+        expect(kebabCase('Foo Bar_bazQux')).toBe('foo-bar-baz-qux')
+    })
+})
+
+describe('sortObject', () => {
+    it('returns a new object with keys in sorted order', () => {
+        const sorted = sortObject({ c: 3, a: 1, b: 2 })
+        expect(Object.keys(sorted)).toEqual(['a', 'b', 'c'])
+        expect(sorted).toEqual({ a: 1, b: 2, c: 3 })
+    })
+})

--- a/test/unit/oidc-providers.test.js
+++ b/test/unit/oidc-providers.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getOidcProviders, getOidcProvider, oidcRedirectUri } from '../../src/utils/oidc-providers.js'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('getOidcProviders', () => {
+    it('returns [] when OIDC_PROVIDERS is unset or invalid JSON', () => {
+        vi.stubEnv('OIDC_PROVIDERS', '')
+        expect(getOidcProviders()).toEqual([])
+        vi.stubEnv('OIDC_PROVIDERS', 'not json')
+        expect(getOidcProviders()).toEqual([])
+    })
+
+    it('surfaces a provider only when both client id and secret are present', () => {
+        vi.stubEnv('OIDC_PROVIDERS', JSON.stringify([{ key: 'google', issuer: 'https://accounts.google.com' }]))
+        // No creds yet -> not enabled -> filtered out
+        expect(getOidcProviders()).toEqual([])
+
+        vi.stubEnv('GOOGLE_CLIENT_ID', 'id')
+        vi.stubEnv('GOOGLE_CLIENT_SECRET', 'secret')
+        const providers = getOidcProviders()
+        expect(providers).toHaveLength(1)
+        expect(providers[0]).toMatchObject({
+            key: 'google',
+            displayName: 'google',
+            clientId: 'id',
+            clientSecret: 'secret',
+            enabled: true,
+        })
+    })
+
+    it('defaults groupPrefix to the issuer host and scopes to openid/email/profile', () => {
+        vi.stubEnv('OIDC_PROVIDERS', JSON.stringify([{ key: 'gitlab', issuer: 'https://gitlab.example.com' }]))
+        vi.stubEnv('GITLAB_CLIENT_ID', 'id')
+        vi.stubEnv('GITLAB_CLIENT_SECRET', 'secret')
+        const [p] = getOidcProviders()
+        expect(p.groupPrefix).toBe('gitlab.example.com')
+        expect(p.scopes).toEqual(['openid', 'email', 'profile'])
+    })
+
+    it('maps a provider key with non-alphanumerics to an underscored env prefix', () => {
+        vi.stubEnv('OIDC_PROVIDERS', JSON.stringify([{ key: 'entra-id', issuer: 'https://login.microsoftonline.com' }]))
+        vi.stubEnv('ENTRA_ID_CLIENT_ID', 'id')
+        vi.stubEnv('ENTRA_ID_CLIENT_SECRET', 'secret')
+        expect(getOidcProvider('entra-id')).toMatchObject({ key: 'entra-id', enabled: true })
+    })
+})
+
+describe('oidcRedirectUri', () => {
+    it('builds the upstream callback URL under ISSUER_URL', () => {
+        vi.stubEnv('ISSUER_URL', 'https://oidc.test/')
+        expect(oidcRedirectUri('google')).toBe('https://oidc.test/interaction/callback/google')
+    })
+})

--- a/test/unit/username-source.test.js
+++ b/test/unit/username-source.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// getUsernameSource memoises its result in module scope, so each case re-imports
+// the module fresh under a stubbed environment.
+async function resolveWith(env) {
+    vi.resetModules()
+    for (const [k, v] of Object.entries(env)) vi.stubEnv(k, v)
+    const mod = await import('../../src/utils/username-source.js')
+    return mod.getUsernameSource()
+}
+
+beforeEach(() => {
+    // Clear the deprecated/explicit vars that env.js or other cases may have set.
+    vi.stubEnv('USERNAME_SOURCE', '')
+    vi.stubEnv('USE_GITHUB_USERNAME', '')
+    vi.stubEnv('REQUIRE_CUSTOM_USERNAME', '')
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe('getUsernameSource', () => {
+    it('defaults to "generated" when nothing is set', async () => {
+        expect(await resolveWith({})).toBe('generated')
+    })
+
+    it('honours an explicit USERNAME_SOURCE', async () => {
+        expect(await resolveWith({ USERNAME_SOURCE: 'upstream' })).toBe('upstream')
+        expect(await resolveWith({ USERNAME_SOURCE: 'prompt' })).toBe('prompt')
+    })
+
+    it('throws on an invalid USERNAME_SOURCE', async () => {
+        await expect(resolveWith({ USERNAME_SOURCE: 'bogus' })).rejects.toThrow(/Invalid USERNAME_SOURCE/)
+    })
+
+    it('maps the deprecated USE_GITHUB_USERNAME flag to "upstream"', async () => {
+        expect(await resolveWith({ USE_GITHUB_USERNAME: 'true' })).toBe('upstream')
+    })
+
+    it('maps REQUIRE_CUSTOM_USERNAME (which wins over USE_GITHUB_USERNAME) to "prompt"', async () => {
+        expect(await resolveWith({ REQUIRE_CUSTOM_USERNAME: 'true' })).toBe('prompt')
+        expect(await resolveWith({ REQUIRE_CUSTOM_USERNAME: 'true', USE_GITHUB_USERNAME: 'true' })).toBe('prompt')
+    })
+})

--- a/test/unit/username.test.js
+++ b/test/unit/username.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeUsername, isUsernameValid } from '../../src/utils/user/username.js'
+
+describe('sanitizeUsername', () => {
+    it('takes the local part of an email and strips non-alphanumerics', () => {
+        expect(sanitizeUsername('John.Doe@example.com')).toBe('johndoe')
+        expect(sanitizeUsername('a-b_c.d')).toBe('abcd')
+    })
+
+    it('drops leading digits so the result starts with a letter', () => {
+        expect(sanitizeUsername('123abc')).toBe('abc')
+    })
+
+    it('caps length at 15 characters', () => {
+        expect(sanitizeUsername('averylongusernamewaytoolong')).toHaveLength(15)
+    })
+
+    it('returns null when nothing usable remains', () => {
+        expect(sanitizeUsername('!!!')).toBeNull()
+        expect(sanitizeUsername('12345')).toBeNull()
+        expect(sanitizeUsername('')).toBeNull()
+        expect(sanitizeUsername(null)).toBeNull()
+    })
+})
+
+describe('isUsernameValid', () => {
+    it('accepts a well-formed username', () => {
+        expect(isUsernameValid('johndoe')).toBe(true)
+    })
+
+    it('rejects on each individual rule', () => {
+        expect(isUsernameValid('jo')).toBe(false)              // too short
+        expect(isUsernameValid('johndoeexceeds')).toBe(true)   // 14 chars, still ok
+        expect(isUsernameValid('johndoeexceedsxx')).toBe(false) // 16 chars, too long
+        expect(isUsernameValid('john.doe')).toBe(false)        // not alphanumeric
+        expect(isUsernameValid('1johndoe')).toBe(false)        // must start with a letter
+        expect(isUsernameValid('JohnDoe')).toBe(false)         // must be lowercase
+    })
+
+    it('rejects falsy input', () => {
+        expect(isUsernameValid('')).toBe(false)
+        expect(isUsernameValid(null)).toBe(false)
+        expect(isUsernameValid(undefined)).toBe(false)
+    })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vitest/config'
+
+// Two backend projects:
+//  - unit:        pure logic, no I/O, fast (this is what `npm test` runs)
+//  - integration: HTTP-level flows needing real Redis + fake kube + mock IdP
+// The frontend (Vue) has its own vitest config under frontend/.
+export default defineConfig({
+    test: {
+        projects: [
+            {
+                test: {
+                    name: 'unit',
+                    include: ['test/unit/**/*.test.js'],
+                    environment: 'node',
+                    setupFiles: ['test/setup/env.js'],
+                },
+            },
+            {
+                test: {
+                    name: 'integration',
+                    include: ['test/integration/**/*.test.js'],
+                    environment: 'node',
+                    setupFiles: ['test/setup/env.js'],
+                    // Integration tests share a Redis instance; keep them serial
+                    // and give flows room to complete.
+                    fileParallelism: false,
+                    testTimeout: 20000,
+                    hookTimeout: 20000,
+                },
+            },
+        ],
+    },
+})


### PR DESCRIPTION
Adds the first automated test suite for passmower. Until now there were **zero tests** and CI only built images, so the recent dependency upgrades (oidc-provider 8→9, openid-client 5→6, ejs 3→6, …) shipped with no behavioural safety net. Plan: `.claude/plans/async-dreaming-volcano.md`.

## 🐞 Bug fixed along the way
**The app currently fails to boot on `develop`.** The `ejs` 3→6 bump removed the named `renderFile` ESM export, so `src/utils/get-email-content.js` throws at import — and it's in the `app.js` import chain. Fixed by importing `ejs`'s default export. *(Worth cherry-picking to a hotfix — see note below.)*

## What's here
**Testability seams** (defaults unchanged in prod):
- `redis.js` connects lazily (not at import) and `unref`s its health-check intervals — importing app code no longer opens Redis or pins the event loop.
- `kubernetes.js` falls back to an out-of-cluster kubeconfig when not in a pod.
- `KubeOIDCUserService` + operators accept an injected adapter; `app.js` exposes `buildProvider()` and only boots when run directly.

**Unit (42 tests, `npm test`, no services)** — username rules, OIDC-provider env parsing, `Account.getIntendedStatus`/`claims`/`getRemoteHeaders`, conditions, group checks, markdown sanitisation.

**Integration (8 tests, real Redis + in-memory fake kube + mock IdP)** — the real `KubeOIDCUserService`/`Account` over the fake adapter; discovery + JWKS; and a **full email magic-link login over HTTP** (`/auth` → interaction → email → verify → auto-consent → code → token), asserting `id_token` `sub`/`nonce`.

**E2E (Playwright + Dex + kind)** — a real browser logging in through the generic upstream OIDC provider (Dex), exercising openid-client v6 ↔ a real IdP, oidc-provider v9, Redis, and real Kubernetes CRUD.

**CI** (`.github/workflows/test.yml`) — `unit` / `integration` (Redis service) / `e2e` (kind + Dex + Playwright, report uploaded) on Node 22.

## Verification
- `npm test` → 42 unit, green, no services.
- `npm run test:integration` (local Redis) → 8 integration, green.
- e2e components verified locally (Dex discovery, frontend build, Playwright discovery); the full orchestrated run is intended for CI.

## ⚠️ Notes
- The **ejs boot fix** is included here but the broken app is on `develop` now — consider cherry-picking it to a standalone hotfix so it lands without waiting on this PR.
- E2E uses **kind** for the Kubernetes API (turnkey in CI + locally) rather than raw envtest binaries, which are awkward to bootstrap outside Go; same "miniature kube API" intent. The in-memory fake covers unit/integration as planned.
- Frontend eslint is **not** wired into CI yet — the flat-config migration surfaced 28 pre-existing violations; cleaning those up is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)