### PR TITLE
fix: app fails to boot — ejs 6 has no named renderFile export

### DIFF
--- a/src/utils/get-email-content.js
+++ b/src/utils/get-email-content.js
@@ -1,7 +1,11 @@
 import {dirname} from "desm";
-import {renderFile} from "ejs";
+// ejs 6 is CommonJS and only exposes renderFile on its default export
+// (no named ESM export), so import the default and destructure.
+import ejs from "ejs";
 import path from "path";
 import fs from "fs";
+
+const {renderFile} = ejs;
 
 export const getEmailContent = async (template, variables) => {
     return {


### PR DESCRIPTION
**Hotfix: the app currently fails to boot on \`develop\`.**

The \`ejs\` 3→6 bump (from an earlier dependency PR) removed the named \`renderFile\` ESM export. \`src/utils/get-email-content.js\` did \`import {renderFile} from "ejs"\`, which now throws \`SyntaxError: The requested module 'ejs' does not provide an export named 'renderFile'\` at module instantiation. Because this file is in the \`src/app.js\` import chain (routes → email-login → get-email-content), **`node src/app.js` throws on startup**.

Fix: import ejs's default export and destructure \`renderFile\` from it.

```js
import ejs from "ejs";
const {renderFile} = ejs;
```

Verified: `node --check` passes and `app.js` imports cleanly after the change. This shipped untested because there was no test suite — the forthcoming #128 (test suite) catches exactly this via the email-login integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)