### PR TITLE
feat(policy): skip Terms of Service for non-person accounts (#62)

### DIFF
--- a/src/models/account.js
+++ b/src/models/account.js
@@ -210,6 +210,12 @@ class Account {
         return this.accountId
     }
 
+    // OIDCUser spec.type: person | org | service | banned | group (may be unset
+    // for accounts created before the field was populated — treated as person).
+    get type() {
+        return this.#spec?.type ?? null
+    }
+
     addCondition(condition) {
         return condition.add(this)
     }

--- a/src/providers/setup-policies.js
+++ b/src/providers/setup-policies.js
@@ -1,9 +1,9 @@
 import {interactionPolicy} from "oidc-provider";
-import {ToSv1} from "../conditions/tosv1.js";
 import {Approved} from "../conditions/approved.js";
 import {updateSiteSession, validateSiteSession} from "../utils/session/site-session.js";
 import {OIDCMiddlewareClientCrd} from "../utils/kubernetes/kube-constants.js";
 import {checkAccountGroups} from "../utils/user/check-account-groups.js";
+import {tosRequired} from "../utils/user/tos-required.js";
 import {clientId} from "../utils/session/self-oidc-client.js";
 
 export default () => {
@@ -36,7 +36,7 @@ export default () => {
     const tosPolicy = new Prompt(
         { name: 'tos', requestable: true },
         new Check('tos_not_accepted', 'ToS needs to be accepted', 'interaction_required', async (ctx) => {
-                return !(new ToSv1()).check(ctx.currentAccount)
+                return tosRequired(ctx.currentAccount)
             },
         ),
     )

--- a/src/utils/user/tos-required.js
+++ b/src/utils/user/tos-required.js
@@ -1,0 +1,12 @@
+import { ToSv1 } from "../../conditions/tosv1.js"
+
+// Whether the account must accept the Terms of Service before continuing.
+// ToS only applies to people — service accounts, orgs and groups skip it
+// (#62). An account with no type set is treated as a person.
+export const tosRequired = (account) => {
+    const type = account?.type
+    if (type && type !== 'person') {
+        return false
+    }
+    return !(new ToSv1()).check(account)
+}

--- a/test/unit/tos-required.test.js
+++ b/test/unit/tos-required.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import Account from '../../src/models/account.js'
+import { tosRequired } from '../../src/utils/user/tos-required.js'
+
+function account({ type, tosAccepted = false } = {}) {
+    return new Account().fromKubernetes({
+        metadata: { name: 'u', labels: {} },
+        spec: type ? { type } : {},
+        status: { conditions: tosAccepted ? [{ type: 'ToSv1', status: 'True' }] : [] },
+    })
+}
+
+describe('tosRequired (#62: ToS only applies to people)', () => {
+    it('requires ToS for a person who has not accepted it', () => {
+        expect(tosRequired(account({ type: 'person' }))).toBe(true)
+    })
+
+    it('does not require ToS once a person has accepted it', () => {
+        expect(tosRequired(account({ type: 'person', tosAccepted: true }))).toBe(false)
+    })
+
+    it('treats an account with no type as a person', () => {
+        expect(tosRequired(account({}))).toBe(true)
+    })
+
+    it('skips ToS for non-person accounts regardless of acceptance', () => {
+        for (const type of ['service', 'org', 'group']) {
+            expect(tosRequired(account({ type }))).toBe(false)
+        }
+    })
+
+    it('exposes spec.type via Account.type', () => {
+        expect(account({ type: 'service' }).type).toBe('service')
+        expect(account({}).type).toBeNull()
+    })
+})


### PR DESCRIPTION
Closes #62.

Service accounts, orgs and groups don't need to accept the Terms of Service — only people do.

## Change
- Extract a small, testable `tosRequired(account)` helper: returns `false` when the OIDCUser `spec.type` is set and not `person` (`service`/`org`/`group`); an **unset** type is treated as a person (current behaviour preserved). Otherwise it falls back to the existing `ToSv1` condition check.
- Use it in the `tos` interaction policy (`setup-policies.js`).
- Add an `Account.type` getter.

## Tests
Unit tests for `tosRequired`: person (not accepted → required; accepted → not), unset type (treated as person), and `service`/`org`/`group` (skipped). Provider still builds (integration suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)