### PR TITLE
fix: small-bug batch — invalid_redirect_uri message (#75), health check writes Redis (#77), chart empty-value handling (#67)

### DIFF
--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -33,24 +33,42 @@ spec:
               value: {{ include "passmower.url" . }}
             - name: DEPLOYMENT_NAME
               value: {{ .Chart.Name }}
+            {{- /* Optional string settings: only emit when set & non-empty so a
+                   commented-out/empty value falls back to the app default
+                   instead of being forced to "" (#67). Booleans are always
+                   emitted because `false` is meaningful. */}}
+            {{- with .Values.passmower.group_prefix }}
             - name: GROUP_PREFIX
-              value: {{ .Values.passmower.group_prefix | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.passmower.admin_group }}
             - name: ADMIN_GROUP
-              value: {{ .Values.passmower.admin_group | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.passmower.required_group }}
             - name: REQUIRED_GROUP
-              value: {{ .Values.passmower.required_group | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.passmower.github_organization }}
             - name: GITHUB_ORGANIZATION
-              value: {{ .Values.passmower.github_organization | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.passmower.username_source }}
             - name: USERNAME_SOURCE
-              value: {{ .Values.passmower.username_source | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             - name: ENROLL_USERS
               value: {{ .Values.passmower.enroll_users | quote }}
             - name: DISABLE_FRONTEND_EDIT
               value: {{ .Values.passmower.disable_frontend_edit | quote }}
+            {{- with .Values.passmower.namespace_selector }}
             - name: NAMESPACE_SELECTOR
-              value: {{ .Values.passmower.namespace_selector | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.passmower.preferred_email_domain }}
             - name: PREFERRED_EMAIL_DOMAIN
-              value: {{ .Values.passmower.preferred_email_domain | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             - name: NORMALIZE_EMAIL_ADDRESSES
               value: {{ .Values.passmower.normalize_email_addresses | quote }}
             - name: WEBAUTHN_ENABLED

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -7,11 +7,11 @@ passmower:
   # Local groups will be created with given prefix.
   group_prefix: "passmower"
   # Local or remote group which members will automatically become admins.
-  admin_group: "github.com:foo:bar"
+  admin_group: ""
   # If set, require all users to be member of the given local or remote group.
   required_group: ""
   # GitHub organization to pull groups from. Set to keep users other organizations private from Passmower.
-  github_organization: "passmower"
+  github_organization: ""
   # How a new user's username (OIDCUser CRD name / accountId / OIDC `sub`) is determined at enrollment:
   #   generated - random system-generated id (u<...>)
   #   prompt    - user must pick a custom username via a form

--- a/src/routes/metrics-server.js
+++ b/src/routes/metrics-server.js
@@ -3,7 +3,19 @@ import Koa from 'koa';
 import Router from "@koa/router";
 import { setupOidcMetrics } from "../utils/session/handle-oidc-flow-metrics.js";
 import {KubeOIDCUserService} from "../services/kube-oidc-user-service.js";
-import {getSelfOidcClient} from "../utils/session/self-oidc-client.js";
+import RedisAdapter from "../adapters/redis.js";
+
+// Health check: verifies the Kubernetes API is reachable AND that Redis is
+// actually writable (a read-only replica or failing writes would pass a
+// read-only check but break the app — #77). Throws if a dependency is down.
+export const checkHealth = async (userService) => {
+    const redis = new RedisAdapter('HealthCheck')
+    const token = `${Date.now()}-${process.pid}`
+    await redis.upsert('probe', { token }, 60)
+    const probe = await redis.find('probe')
+    const usersReachable = Array.isArray(await userService.listUsers())
+    return Boolean(usersReachable && probe?.token === token)
+}
 
 export default async () => {
     collectDefaultMetrics({
@@ -26,7 +38,12 @@ export default async () => {
     })
 
     router.get('/health', async (ctx, next) => {
-        ctx.status = await userService.listUsers() && await getSelfOidcClient() ? 200 : 500;
+        try {
+            ctx.status = await checkHealth(userService) ? 200 : 500;
+        } catch (err) {
+            globalThis.logger?.error({ err }, 'health check failed');
+            ctx.status = 500;
+        }
     })
     metricsServer.use(router.routes())
     metricsServer.listen(9090)

--- a/src/utils/render-error.js
+++ b/src/utils/render-error.js
@@ -2,6 +2,19 @@ import htmlSafe from "oidc-provider/lib/helpers/html_safe.js";
 
 const renderError = (ctx, out, error) => {
     globalThis.logger.debug({ctx, out, error})
+    // redirect_uri mismatches are hard to debug from the generic message, so
+    // surface the attempted URI and the client's registered ones (#75).
+    if (out.error === 'invalid_redirect_uri') {
+        const attempted = ctx.oidc?.params?.redirect_uri
+        const registered = ctx.oidc?.client?.redirectUris
+        const detail = [
+            attempted ? `got: ${attempted}` : null,
+            registered?.length ? `registered: ${registered.join(', ')}` : null,
+        ].filter(Boolean).join('; ')
+        if (detail) {
+            out = { ...out, error_description: `${out.error_description} (${detail})` }
+        }
+    }
     ctx.type = 'html';
     ctx.body = `<!DOCTYPE html>
     <head>

--- a/test/integration/health-check.test.js
+++ b/test/integration/health-check.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { checkHealth } from '../../src/routes/metrics-server.js'
+
+// #77: the health check must verify Redis is writable, not just reachable.
+describe('checkHealth', () => {
+    beforeAll(() => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        globalThis.logger ??= { info() {}, warn() {}, error() {}, debug() {}, trace() {} }
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    it('returns true when Kubernetes is reachable and Redis is writable', async () => {
+        const userService = { async listUsers() { return [] } } // fake kube, reachable
+        expect(await checkHealth(userService)).toBe(true)
+
+        // confirm the probe was actually written to Redis
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        expect(await new RedisAdapter('HealthCheck').find('probe')).toBeTruthy()
+    })
+
+    it('propagates a Kubernetes failure (rejects) so /health can 500', async () => {
+        const userService = { async listUsers() { throw new Error('api down') } }
+        await expect(checkHealth(userService)).rejects.toThrow('api down')
+    })
+})

--- a/test/unit/render-error.test.js
+++ b/test/unit/render-error.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import renderError from '../../src/utils/render-error.js'
+
+beforeAll(() => {
+    globalThis.logger ??= { info() {}, warn() {}, error() {}, debug() {}, trace() {} }
+})
+
+function render(out, oidc) {
+    const ctx = { oidc }
+    renderError(ctx, out, new Error(out.error))
+    return ctx.body
+}
+
+describe('renderError', () => {
+    it('shows the attempted and registered redirect URIs for invalid_redirect_uri (#75)', () => {
+        const body = render(
+            { error: 'invalid_redirect_uri', error_description: 'redirect_uri did not match any of the client\'s registered redirect_uris' },
+            { params: { redirect_uri: 'https://evil.example/cb' }, client: { redirectUris: ['https://app.example/cb', 'https://app.example/cb2'] } },
+        )
+        expect(body).toContain('got: https://evil.example/cb')
+        expect(body).toContain('registered: https://app.example/cb, https://app.example/cb2')
+    })
+
+    it('leaves other errors untouched', () => {
+        const body = render({ error: 'access_denied', error_description: 'nope' }, {})
+        expect(body).toContain('nope')
+        expect(body).not.toContain('registered:')
+    })
+
+    it('does not break when oidc context is missing', () => {
+        const body = render({ error: 'invalid_redirect_uri', error_description: 'mismatch' }, undefined)
+        expect(body).toContain('mismatch')
+    })
+})


### PR DESCRIPTION
Three small, independent fixes (one commit each).

### #75 — Better `invalid_redirect_uri` error message
`renderError` now appends the **attempted** redirect URI and the client's **registered** ones, e.g. `… (got: https://x/cb; registered: https://app/cb)`, read from `ctx.oidc.params`/`ctx.oidc.client`. Unit-tested.

### #77 — Health check verifies Redis is *writable*
`/health` previously only read Redis (`getSelfOidcClient`); a read-only replica or failing writes still passed. Extracted `checkHealth()` which does a Redis **write+read roundtrip** (plus the Kubernetes reachability check), and `/health` wraps it in try/catch → 500 on any dependency failure. Integration-tested.

### #67 — Chart: don't force empty env values / ship placeholder defaults
Optional string settings were rendered unconditionally, so a commented-out/empty value became `value: ""` instead of being absent — overriding the app's own default. They're now emitted only when set & non-empty (booleans stay unconditional). Also neutralised the placeholder defaults `admin_group: github.com:foo:bar` and `github_organization: passmower` → `""`. Verified with `helm template` (empty → omitted; set → rendered).

## Tests
Full suite **64 passing** (added 5: render-error ×3, health-check ×2). Closes #75, #77, #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)