### PR TITLE
feat(impersonation): incognito one-time links to prevent cookie leakage (#51)

### DIFF
--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -1,11 +1,19 @@
 <template>
     <div class="profile-section">
-        <Notice
-            v-if="impersonation"
-            :text="`You are now impersonating ${impersonation.accountId}. Your own session cookie has been removed. Navigate to desired client service and initiate login - login prompt will enable you to act as impersonated user.`"
-            button-text="End impersonation"
-            :button-action="endImpersonation"
-        />
+        <div v-if="impersonationLink" class="notice">
+            <Exclamation />
+            <div>
+                <p>
+                    Impersonation link for <strong>{{ impersonationFor }}</strong>.
+                    Open it in a <strong>private/incognito window</strong> or another device.
+                    Opening it in this browser (with your existing session) will be refused,
+                    to avoid mixing your and applications' cookies with the impersonated user's.
+                </p>
+                <p><a :href="impersonationLink">{{ impersonationLink }}</a></p>
+                <button @click="copyImpersonationLink">Copy link</button>
+                <button @click="impersonationLink = null">Dismiss</button>
+            </div>
+        </div>
         <div class="profile-section-header">
             <h2>Users</h2>
         </div>
@@ -32,8 +40,7 @@ import {useAccountsStore} from "@/stores/accounts";
 import Impersonate from "@/components/Icons/Impersonate.vue";
 import Info from "@/components/Icons/Info.vue";
 import {useToast} from "vue-toast-notification";
-import {useImpersonationStore} from "@/stores/impersonation";
-import Notice from "@/components/Admin/Notice.vue";
+import Exclamation from "@/components/Icons/Exclamation.vue";
 import EditProfile from "@/components/Admin/Modals/EditProfile.vue";
 import {openModal} from "jenesius-vue-modal";
 import {useAccountStore} from "@/stores/account";
@@ -41,24 +48,24 @@ import Check from "../Icons/Check.vue";
 
 export default {
     name: "Accounts",
-    components: {Check, Notice, Info, Impersonate},
+    components: {Check, Exclamation, Info, Impersonate},
+    data() {
+        return {
+            impersonationLink: null,
+            impersonationFor: null,
+        }
+    },
     created() {
-        fetch('/admin/api/account/impersonation').then((r) => r.json()).then((r) => {
-            this.setImpersonation(r.impersonation)
-        })
-
         fetch('/admin/api/accounts').then((r) => r.json()).then((r) => {
             this.setAccounts(r.accounts)
         })
     },
     computed: {
         ...mapState(useAccountsStore, ['accounts']),
-        ...mapState(useImpersonationStore, ['impersonation']),
     },
     methods: {
         ...mapActions(useAccountStore, ['setAccount', 'originalAccount']),
         ...mapActions(useAccountsStore, ['setAccounts']),
-        ...mapActions(useImpersonationStore, ['setImpersonation']),
         async editProfile(account) {
             this.setAccount(account)
             const modal = await openModal(EditProfile);
@@ -75,7 +82,11 @@ export default {
                     'Content-Type': 'application/json'
                 },
             }).then((r) => r.json()).then((r) => {
-                this.setImpersonation(r.impersonation)
+                if (!r.impersonation) {
+                    throw new Error('Impersonation link was not created')
+                }
+                this.impersonationLink = r.impersonation.link
+                this.impersonationFor = r.impersonation.accountId
             }).catch((e) => {
                 console.error(e)
                 const $toast = useToast();
@@ -84,21 +95,14 @@ export default {
                 });
             })
         },
-        endImpersonation() {
-            fetch('/admin/api/account/impersonation/end', {
-                method: 'POST',
-                headers: {
-                    'Accept': 'application/json',
-                },
-            }).then((r) => r.json()).then((r) => {
-                this.setImpersonation(r.impersonation)
-            }).catch((e) => {
-                console.error(e)
-                const $toast = useToast();
-                $toast.error('Ending impersonation failed', {
-                    position: 'top-right'
-                });
-            })
+        async copyImpersonationLink() {
+            const $toast = useToast();
+            try {
+                await navigator.clipboard.writeText(this.impersonationLink)
+                $toast.success('Link copied', {position: 'top-right'})
+            } catch {
+                $toast.error('Could not copy — select and copy manually', {position: 'top-right'})
+            }
         },
         approve(account) {
               fetch('/admin/api/account/approve', {

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -96,8 +96,8 @@ export default (provider) => {
             return
         }
         const accountId = ctx.request.body.accountId
-        const impersonation = await ctx.sessionService.impersonate(ctx, accountId)
-        auditLog(ctx, {accountId}, 'Admin enabled impersonation')
+        const impersonation = await ctx.sessionService.createImpersonation(ctx, accountId)
+        auditLog(ctx, {accountId}, 'Admin created impersonation link')
         ctx.body = {
             impersonation
         }

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -156,6 +156,29 @@ export default (provider) => {
         }
     });
 
+    // One-time impersonation link (#51). The admin generates it from the admin
+    // panel and opens it in a private/incognito window or another device, so
+    // their own and downstream apps' cookies are never mixed with the
+    // impersonated user's session. If any cookies are already present the link
+    // refuses to activate and tells the admin to use a clean window.
+    router.get('/impersonate/:jti', async (ctx) => {
+        const messagePage = (title, message) => ctx.render('message', {
+            title, message, wide: false, uid: null, dbg: undefined, nonce: ctx.res.locals.cspNonce,
+        })
+        if (ctx.headers.cookie) {
+            auditLog(ctx, {}, 'Impersonation link opened with existing cookies, refused')
+            return messagePage('Open in a private window',
+                'Existing cookies were detected. To impersonate safely, open this link in a private/incognito window (or another browser) so your own and applications’ sessions are not mixed with the impersonated user’s.')
+        }
+        const impersonation = await ctx.sessionService.activateImpersonation(ctx, ctx.params.jti)
+        if (!impersonation) {
+            return messagePage('Impersonation link invalid',
+                'This impersonation link is invalid or has already been used. Generate a new one from the admin panel.')
+        }
+        auditLog(ctx, {impersonation}, 'Impersonation link activated')
+        return ctx.redirect(process.env.ISSUER_URL)
+    });
+
     router.get('/interaction/:uid', async (ctx, next) => {
         const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
         const { prompt, session, params, grantId } = interactionDetails

--- a/src/services/session-service.js
+++ b/src/services/session-service.js
@@ -156,32 +156,42 @@ export class SessionService {
         return true
     }
 
-    async impersonate(ctx, accountId) {
-        let account = await Account.findAccount(ctx, accountId)
+    // Create a one-time impersonation link instead of activating impersonation
+    // in the admin's own browser. The admin opens the link in a private/incognito
+    // window (or another device) so their own and downstream apps' cookies never
+    // mix with the impersonated user's session (#51). No cookies are touched here.
+    async createImpersonation(ctx, accountId) {
+        const account = await Account.findAccount(ctx, accountId)
         if (!account) {
             ctx.statusCode = 404
-            return
+            return null
         }
-        // Remove the session cookie but keep the session itself intact - admin can later return to it.
-        // TODO: would back-channel log-out be required?
-        ctx.cookies.set(
-            this.provider.cookieName('session'),
-            null,
-        );
-        ctx.cookies.set(
-            this.provider.cookieName('session') + '.legacy',
-            null,
-        );
-
         const impersonation = {
             jti: nanoid(),
             actor: ctx.adminSession.accountId,
             accountId,
+            activated: false,
         }
         await this.impersonationRedis.upsert(impersonation.jti, impersonation, instance(this.provider).configuration.ttl.Impersonation)
+        return {
+            accountId,
+            link: `${process.env.ISSUER_URL}impersonate/${impersonation.jti}`,
+        }
+    }
+
+    // Consume a one-time impersonation link in the (clean) browser that opened
+    // it: set the impersonation cookie so the next login prompt offers to act as
+    // the target user. One-time: a link can only be activated once.
+    async activateImpersonation(ctx, jti) {
+        const impersonation = await this.impersonationRedis.find(jti)
+        if (!impersonation || impersonation.activated) {
+            return null
+        }
+        impersonation.activated = true
+        await this.impersonationRedis.upsert(jti, impersonation, instance(this.provider).configuration.ttl.Impersonation)
         ctx.cookies.set(
             this.provider.cookieName('impersonation'),
-            impersonation.jti,
+            jti,
             {
                 ...instance(this.provider).configuration.cookies.long,
                 maxAge: instance(this.provider).configuration.ttl.Impersonation * 1000,

--- a/test/integration/impersonation.test.js
+++ b/test/integration/impersonation.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+
+// #51: impersonation is started via a one-time link the admin opens in a clean
+// (incognito / other-device) browser, so their own and downstream apps' cookies
+// never mix with the impersonated user's session.
+describe('impersonation links', () => {
+    let provider
+    let callback
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        provider = await buildProvider()
+        callback = provider.callback()
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    async function seedLink(jti, overrides = {}) {
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        await new RedisAdapter('Impersonation').upsert(jti, {
+            jti, actor: 'admin', accountId: 'target-user', activated: false, ...overrides,
+        }, 3600)
+    }
+
+    it('refuses to activate when cookies are already present (not a clean browser)', async () => {
+        await seedLink('jti-cookies')
+        const res = await request(callback).get('/impersonate/jti-cookies').set('Cookie', '_session=abc')
+        expect(res.status).toBe(200)
+        expect(res.text).toMatch(/private|incognito/i)
+        expect(res.headers['set-cookie']).toBeUndefined() // impersonation NOT activated
+    })
+
+    it('activates in a clean browser and sets the impersonation cookie', async () => {
+        await seedLink('jti-clean')
+        const res = await request(callback).get('/impersonate/jti-clean')
+        expect(res.status).toBe(302)
+        expect(res.headers.location).toBe(process.env.ISSUER_URL)
+        expect((res.headers['set-cookie'] || []).join(';')).toMatch(/_impersonation=/)
+    })
+
+    it('is one-time: an already-activated link is rejected', async () => {
+        await seedLink('jti-used', { activated: true })
+        const res = await request(callback).get('/impersonate/jti-used')
+        expect(res.status).toBe(200)
+        expect(res.text).toMatch(/invalid|already been used/i)
+    })
+
+    it('rejects an unknown link', async () => {
+        const res = await request(callback).get('/impersonate/does-not-exist')
+        expect(res.status).toBe(200)
+        expect(res.text).toMatch(/invalid|already been used/i)
+    })
+
+    it('createImpersonation returns a link without touching cookies', async () => {
+        const { SessionService } = await import('../../src/services/session-service.js')
+        const service = new SessionService(provider)
+        const ctx = {
+            adminSession: { accountId: 'admin' },
+            kubeOIDCUserService: { async findUser() { return { accountId: 'target-user' } } },
+        }
+        const result = await service.createImpersonation(ctx, 'target-user')
+        expect(result.accountId).toBe('target-user')
+        expect(result.link).toMatch(/\/impersonate\/[\w-]+$/)
+    })
+})


### PR DESCRIPTION
Closes #51.

Previously, starting impersonation set the `_impersonation` cookie **in the admin's own browser**, leaving the admin's (and downstream apps') cookies in place — risking cross-user session/secret leakage and data mangling. Per the issue's suggested approach, impersonation is now started via a **one-time link the admin opens in a private/incognito window (or another device)**.

## Flow
- `POST /admin/api/account/impersonation` → `createImpersonation` stores a one-time token and returns `{ accountId, link }`. **No cookies touched.**
- `GET /impersonate/:jti` (public, capability = the unguessable token):
  - **If any cookies are present** (i.e. not a clean browser — including the admin's own session): refuses and shows *"open this in a private/incognito window…"*. This is exactly the "what happens in the same browser?" case: it's denied with guidance, never silently mixed.
  - **If clean**: consumes the one-time token, sets the `_impersonation` cookie, redirects to login, where the existing "Impersonate X" prompt completes login as the target user.
- One-time: a link can't be activated twice.
- Works naturally on **another device/browser** (clean context).

Admin panel now shows the generated link with copy + incognito instructions instead of activating impersonation in place.

## Tests
Integration: cookie-present → refused (no cookie set); clean → 302 + `_impersonation` cookie; already-used and unknown links → rejected; `createImpersonation` returns a link without touching cookies. Full suite **69 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)