### PR TITLE
feat(email-login): magic links openable on another device/browser

### DIFF
--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -322,16 +322,37 @@ export default (provider) => {
             const success = ctx.request.query[q] === 'true'
             return success ? (q === 'email' ? 'e-mail' : 'Slack') : null;
         }).filter(a => a);
-        return render(provider, ctx, 'message', 'Link sent', {
+        // The 'link-sent' view polls /email-status and continues automatically on
+        // this (original) device once the link is opened — possibly on another
+        // device/browser.
+        return render(provider, ctx, 'link-sent', 'Link sent', {
             message: `Login link sent to ${recipients.join(' and ')}`
         })
     });
 
-    router.get('/interaction/:uid/verify-email/:token', (ctx) => {
+    // Opened from the email — on any device/browser. Marks the email verified
+    // (and finishes immediately if opened in the original browser).
+    router.get('/interaction/:uid/verify-email/:token', async (ctx) => {
         const emailLogin = new EmailLogin()
-        const result = emailLogin.verifyLink(ctx, provider)
-        auditLog(ctx, {params: ctx.request.params, result}, 'Login link used')
-        return result
+        auditLog(ctx, {params: ctx.request.params}, 'Login link used')
+        return await emailLogin.verifyLink(ctx, provider)
+    });
+
+    // Polled by the original device's "link sent" page.
+    router.get('/interaction/:uid/email-status', async (ctx) => {
+        ctx.body = { verified: await new EmailLogin().isVerified(provider, ctx.params.uid) }
+    });
+
+    // Completes the login on the original device once the email is verified.
+    router.get('/interaction/:uid/email-complete', async (ctx) => {
+        const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res)
+        if (!interactionDetails.result?.emailVerified) {
+            return render(provider, ctx, 'message', 'Not verified yet', {
+                message: 'Open the link sent to your email to continue signing in.'
+            })
+        }
+        auditLog(ctx, {uid: ctx.params.uid}, 'Completing email login on original device')
+        return new EmailLogin().completeLogin(ctx, provider, interactionDetails.result.email)
     });
 
     // ============================================

--- a/src/services/login/email-login.js
+++ b/src/services/login/email-login.js
@@ -66,26 +66,64 @@ export class EmailLogin {
         }
     }
 
+    // Open the magic link. Works on any device/browser: the interaction is
+    // looked up by its uid (from the URL), not the interaction cookie. Validating
+    // the token only marks the interaction as email-verified, so the original
+    // device (which holds the interaction cookie and full context) can finish the
+    // login via /email-complete. If the link is opened in the original browser we
+    // complete immediately.
     async verifyLink(ctx, provider) {
-        const params = ctx.request.params
-        const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res)
-        if (!interactionDetails.result || interactionDetails.result.token !== params.token || interactionDetails.jti !== params.uid) {
-            auditLog(ctx, {interactionDetails, params, error: true}, 'Invalid login link')
-            return accessDenied(ctx, provider, 'Invalid login link')
+        const {uid, token} = ctx.request.params
+        const interaction = await provider.Interaction.find(uid)
+        if (!interaction?.result || interaction.result.token !== token) {
+            auditLog(ctx, {uid, error: true}, 'Invalid login link')
+            return this.#renderMessage(ctx, 'Invalid login link',
+                'This login link is invalid or has expired. Please request a new one.')
         }
 
-        const account = await Account.createOrUpdateByEmails(
-            ctx,
-            provider,
-            interactionDetails.result.email
-        );
+        // Mark verified so the original device's polling can complete the login.
+        const ttl = interaction.exp ? Math.max(1, Math.floor(interaction.exp - Date.now() / 1000)) : 3600
+        interaction.result = {...interaction.result, emailVerified: true}
+        await interaction.save(ttl)
+        auditLog(ctx, {uid, email: interaction.result.email}, 'Email verified via login link')
 
+        // If opened in the original browser, finish right away.
+        let sameBrowser = false
+        try {
+            const details = await provider.interactionDetails(ctx.req, ctx.res)
+            sameBrowser = details.jti === uid
+        } catch { /* different device/browser — no interaction cookie */ }
+
+        if (sameBrowser) {
+            return this.completeLogin(ctx, provider, interaction.result.email)
+        }
+        return this.#renderMessage(ctx, 'Email verified',
+            'Your email is verified. Return to the window or device where you started signing in — it will continue automatically.')
+    }
+
+    // Whether the interaction's email has been verified (polled by the original
+    // device's "link sent" page).
+    async isVerified(provider, uid) {
+        const interaction = await provider.Interaction.find(uid)
+        return !!interaction?.result?.emailVerified
+    }
+
+    // Complete the login in the original browser (interaction cookie present),
+    // where account creation / username prompt have full context. Relies on the
+    // server-side emailVerified flag, which only a valid token could have set.
+    async completeLogin(ctx, provider, email) {
+        const account = await Account.createOrUpdateByEmails(ctx, provider, email)
         if (!account) {
-            auditLog(ctx,{interactionDetails, params}, 'Unable to determine account from login link')
+            auditLog(ctx, {email}, 'Unable to determine account from login link')
         }
-
         return provider.interactionFinished(ctx.req, ctx.res, await getLoginResult(ctx, provider, account, 'LoginLink'), {
             mergeWithLastSubmission: true,
         });
+    }
+
+    #renderMessage(ctx, title, message) {
+        return ctx.render('message', {
+            title, message, wide: false, uid: null, dbg: undefined, nonce: ctx.res.locals.cspNonce,
+        })
     }
 }

--- a/src/views/link-sent.ejs
+++ b/src/views/link-sent.ejs
@@ -1,0 +1,17 @@
+<% if (message) { %>
+<p><%= message %></p>
+<% } %>
+<p id="waiting">Open the link to continue. You can open it on this or another device — this page will continue automatically once you do.</p>
+<script nonce="<%= nonce %>">
+  (function () {
+    var uid = '<%= uid %>';
+    function poll() {
+      fetch('/interaction/' + uid + '/email-status', { headers: { 'Accept': 'application/json' } })
+        .then(function (r) { return r.json(); })
+        .then(function (d) { if (d && d.verified) { window.location = '/interaction/' + uid + '/email-complete'; } })
+        .catch(function () { /* keep polling */ });
+    }
+    setInterval(poll, 2000);
+    poll();
+  })();
+</script>

--- a/test/integration/email-login-cross-device.test.js
+++ b/test/integration/email-login-cross-device.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import request from 'supertest'
+import { createHash, randomBytes } from 'node:crypto'
+
+vi.mock('../../src/adapters/kubernetes.js', () => import('../fakes/shared-kube.js'))
+vi.mock('../../src/adapters/email.js', () => import('../fakes/email-capture.js'))
+
+import { fakeKube } from '../fakes/shared-kube.js'
+import { sentEmails } from '../fakes/email-capture.js'
+
+const ISSUER = process.env.ISSUER_URL
+const RP = { client_id: 'xd-rp', client_secret: 'xd-secret', redirect_uri: 'https://rp.test/cb' }
+const b64url = (buf) => buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+// "Original device continues": opening the magic link on another device/browser
+// only marks the email verified; the original device polls and completes (#).
+describe('cross-device email magic link', () => {
+    let callback
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        process.env.EMAIL_ENABLED = 'true'
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        callback = (await buildProvider()).callback()
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        await new RedisAdapter('Client').upsert(RP.client_id, {
+            client_id: RP.client_id, client_secret: RP.client_secret, redirect_uris: [RP.redirect_uri],
+            grant_types: ['authorization_code'], response_types: ['code'],
+            token_endpoint_auth_method: 'client_secret_basic', availableScopes: ['openid'], allowedCORSOrigins: [],
+        })
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    beforeEach(() => {
+        fakeKube.store.clear()
+        sentEmails.length = 0
+        fakeKube.seed('OIDCUser', {
+            metadata: { name: 'xduser', labels: {} },
+            spec: { email: 'xd@example.com', name: 'XD User' },
+            passmower: { email: 'xd@example.com' },
+            status: {
+                primaryEmail: 'xd@example.com', emails: ['xd@example.com'], groups: [],
+                profile: { name: 'XD User' }, conditions: [{ type: 'ToSv1', status: 'True' }],
+            },
+        })
+    })
+
+    // minimal cookie jar
+    const cookieHeader = (j) => [...j.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+    const store = (j, res) => {
+        for (const c of res.headers['set-cookie'] ?? []) {
+            const pair = c.split(';')[0]; const i = pair.indexOf('=')
+            const name = pair.slice(0, i).trim(); const val = pair.slice(i + 1)
+            if (val === '') j.delete(name); else j.set(name, val)
+        }
+    }
+    async function req(j, method, path, form) {
+        let r = request(callback)[method](path).set('Cookie', j ? cookieHeader(j) : '')
+        if (form) r = r.type('form').send(form)
+        const res = await r
+        if (j) store(j, res)
+        return res
+    }
+    async function follow(j, res, rpHost, max = 12) {
+        let cur = res
+        for (let i = 0; i < max && cur.status >= 300 && cur.status < 400; i++) {
+            const loc = cur.headers.location
+            const u = loc.startsWith('http') ? new URL(loc) : new URL(loc, ISSUER)
+            if (u.host === rpHost) return cur
+            cur = await req(j, 'get', u.pathname + u.search)
+        }
+        return cur
+    }
+
+    it('verifies on another device and completes on the original device', async () => {
+        const j = new Map() // original device A
+        const verifier = b64url(randomBytes(32))
+        const challenge = b64url(createHash('sha256').update(verifier).digest())
+        const authQuery = new URLSearchParams({
+            client_id: RP.client_id, redirect_uri: RP.redirect_uri, response_type: 'code', scope: 'openid',
+            state: 'st', nonce: 'no', code_challenge: challenge, code_challenge_method: 'S256',
+        })
+
+        // A starts the flow and submits the email
+        let res = await follow(j, await req(j, 'get', `/auth?${authQuery}`), 'rp.test')
+        const uid = (res.headers.location ?? res.request.url).match(/\/interaction\/([^/?]+)/)[1]
+        res = await req(j, 'post', `/interaction/${uid}/email`, { email: 'xd@example.com' })
+        const linkPath = sentEmails[0].html.match(/\/interaction\/[^/]+\/verify-email\/[0-9a-f-]+/)[0]
+
+        // Link opened on ANOTHER device (no cookies): only verifies, does not redirect
+        const onOtherDevice = await req(null, 'get', linkPath)
+        expect(onOtherDevice.status).toBe(200)
+        expect(onOtherDevice.text).toMatch(/verified|return/i)
+
+        // Original device's poll now sees it verified
+        const status = await req(null, 'get', `/interaction/${uid}/email-status`)
+        expect(status.body).toEqual({ verified: true })
+
+        // Original device (with its cookies) completes the login
+        res = await req(j, 'get', `/interaction/${uid}/email-complete`)
+        const final = await follow(j, res, 'rp.test')
+        const loc = final.headers.location ?? ''
+        expect(loc).toContain(RP.redirect_uri)
+        const code = new URL(loc).searchParams.get('code')
+        expect(code).toBeTruthy()
+
+        const tokenRes = await request(callback).post('/token').auth(RP.client_id, RP.client_secret).type('form').send({
+            grant_type: 'authorization_code', code, redirect_uri: RP.redirect_uri, code_verifier: verifier,
+        }).expect(200)
+        const claims = JSON.parse(Buffer.from(tokenRes.body.id_token.split('.')[1], 'base64url').toString())
+        expect(claims.sub).toBe('xduser')
+    })
+
+    it('reports not-verified before the link is opened', async () => {
+        const j = new Map()
+        const authQuery = new URLSearchParams({
+            client_id: RP.client_id, redirect_uri: RP.redirect_uri, response_type: 'code', scope: 'openid',
+            state: 'st2', nonce: 'no2', code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM', code_challenge_method: 'S256',
+        })
+        let res = await follow(j, await req(j, 'get', `/auth?${authQuery}`), 'rp.test')
+        const uid = (res.headers.location ?? res.request.url).match(/\/interaction\/([^/?]+)/)[1]
+        await req(j, 'post', `/interaction/${uid}/email`, { email: 'xd@example.com' })
+        const status = await req(null, 'get', `/interaction/${uid}/email-status`)
+        expect(status.body).toEqual({ verified: false })
+    })
+})


### PR DESCRIPTION
The email magic link previously required the **original interaction cookie**, so opening it on a different device/browser failed with *"interaction session id cookie not found."* This makes it work anywhere, using the **"original device continues"** model.

## How
The link is looked up by its **uid from the URL** (`Interaction.find`) rather than the interaction cookie:
- Opening the link only **marks the interaction email-verified** (works with no cookie).
- The original device's **"link sent" page polls** `GET /interaction/:uid/email-status` and, once verified, completes the login via `GET /interaction/:uid/email-complete` — so the user finishes on the device where they started.
- If the link is opened in the **original browser**, it finishes immediately (single-device UX unchanged).
- Account creation / username-prompt still run on the original device, where the full interaction context exists. The completion trusts the server-side `emailVerified` flag, which only a valid token (sent to the email owner) can set, and `/email-complete` still requires the original interaction cookie.

New endpoints: `/interaction/:uid/email-status` (poll) and `/interaction/:uid/email-complete` (finish); `link-sent.ejs` polls and continues automatically.

## Tests
- Cross-device: verify on a cookieless "device" → only a confirmation page; `email-status` flips to `verified`; the original device (with its cookie) completes through to a valid `id_token`. Plus the not-yet-verified state.
- Same-browser flow unchanged (existing test still green). Full suite **71 passing**.

Addresses the requested "email links should also support being opened in another device/browser." (Related: #78.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)