### PR TITLE
test(operator): reconciliation coverage for the OIDCClient operator

### DIFF
--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -14,8 +14,10 @@ export class FakeKubernetesAdapter {
         this.namespace = namespace
         this.instance = instance
         this.store = new Map()       // `${kind}/${name}` -> stored CR object
-        this.secrets = new Map()     // `${namespace}/${name}` -> secret data
+        this.secrets = new Map()     // `${namespace}/${name}` -> { data, metadata }
+        this.pods = []               // pods created via createPod (e.g. secretRefreshPod)
         this.watchHandlers = []      // for operator tests
+        this.watchParameters = null  // set by setWatchParameters()
         this._rv = 0
     }
 
@@ -76,17 +78,40 @@ export class FakeKubernetesAdapter {
         return mapperFunction(structuredClone(stored))
     }
 
-    // --- Secrets (used by the client operator) ------------------------------
+    // --- Secrets + pods (used by the client operator) -----------------------
 
     async getSecret(namespace, id) { return this.secrets.get(`${namespace}/${id}`) }
-    async createSecret(namespace, id, data) { this.secrets.set(`${namespace}/${id}`, data); return data }
-    async replaceSecret(namespace, id, data) { this.secrets.set(`${namespace}/${id}`, data); return data }
+    async createSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
+    async patchSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
+    async deleteSecret(namespace, id) { this.secrets.delete(`${namespace}/${id}`) }
+    async createPod(namespace, podSpec) { this.pods.push({ namespace, podSpec: structuredClone(podSpec) }); return { phase: 'Pending' } }
 
     // --- Watch (used by operators) ------------------------------------------
 
-    // Operators call setWatchParameters(...) then watchObjects(); for tests we
-    // expose a hook to push synthetic events through whatever the operator
-    // registered. Operators that don't use this can ignore it.
+    setWatchParameters(kind, mapperFunction, addedCallback, modifiedCallback, deletedCallback) {
+        this.watchParameters = { kind, mapperFunction, addedCallback, modifiedCallback, deletedCallback }
+    }
+
+    // Real adapter opens a long-lived watch here; tests drive events explicitly
+    // via fireWatch() instead.
+    async watchObjects() { /* no-op for tests */ }
+
+    /**
+     * Drive a synthetic watch event for a seeded resource, mirroring what the
+     * real watch stream would deliver. Returns the reconcile callback's result.
+     */
+    async fireWatch(type, kind, name) {
+        const stored = this.store.get(this.#key(kind, name))
+        if (!stored) throw new Error(`fireWatch: ${kind}/${name} not seeded`)
+        const mapped = this.watchParameters.mapperFunction(structuredClone(stored))
+        const cb = {
+            ADDED: this.watchParameters.addedCallback,
+            MODIFIED: this.watchParameters.modifiedCallback,
+            DELETED: this.watchParameters.deletedCallback,
+        }[type]
+        return cb(mapped)
+    }
+
     onWatch(handler) { this.watchHandlers.push(handler) }
     #emit(type, kind, obj) {
         for (const h of this.watchHandlers) h(type, kind, structuredClone(obj))

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { FakeKubernetesAdapter } from '../fakes/fake-kubernetes-adapter.js'
+import { KubeOIDCClientOperator } from '../../src/operators/kube-oidc-client-operator.js'
+import OidcClient from '../../src/models/oidc-client.js'
+import RedisAdapter from '../../src/adapters/redis.js'
+
+// Reconciliation coverage for the OIDCClient operator (previously untested):
+// claim -> secret -> Redis, updates, the secretRefreshPod hook (#69) and delete.
+describe('KubeOIDCClientOperator reconciliation', () => {
+    let provider, adapter, operator
+    const clientRedis = () => new RedisAdapter('Client')
+
+    function rawClient(name, { secretRefreshPod } = {}) {
+        return {
+            metadata: { name, namespace: 'apps', resourceVersion: '1', uid: `uid-${name}`, annotations: {} },
+            spec: {
+                grantTypes: ['authorization_code'],
+                responseTypes: ['code'],
+                redirectUris: ['https://app.example.com/cb'],
+                availableScopes: ['openid'],
+                tokenEndpointAuthMethod: 'client_secret_basic',
+                ...(secretRefreshPod ? { secretRefreshPod } : {}),
+            },
+            status: {}, // unclaimed
+        }
+    }
+    const idOf = (name) => new OidcClient().fromIncomingClient(rawClient(name)).getClientId()
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        provider = await buildProvider()
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    beforeEach(async () => {
+        adapter = new FakeKubernetesAdapter({ namespace: 'apps', instance: 'test-passmower' })
+        operator = new KubeOIDCClientOperator(provider, adapter)
+        await operator.watchClients()
+    })
+
+    it('claims an unclaimed client, creates its secret and caches it in Redis', async () => {
+        adapter.seed('OIDCClient', rawClient('app-a'))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-a')
+
+        // claimed: status.instance set on the stored CR
+        expect(adapter.list('OIDCClient')[0].status.instance).toBe('test-passmower')
+        // secret created
+        expect(adapter.secrets.get('apps/oidc-client-app-a-owner-secrets')).toBeTruthy()
+        // cached in Redis with a generated secret
+        const cached = await clientRedis().find(idOf('app-a'))
+        expect(cached).toBeTruthy()
+        expect(cached.client_secret).toBeTruthy()
+    })
+
+    it('creates the secretRefreshPod when configured (#69)', async () => {
+        adapter.seed('OIDCClient', rawClient('app-b', {
+            secretRefreshPod: { spec: { containers: [{ name: 'refresh', image: 'busybox' }] } },
+        }))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-b')
+
+        expect(adapter.pods).toHaveLength(1)
+        expect(adapter.pods[0].podSpec.spec.containers[0].image).toBe('busybox')
+        // owner reference back to the OIDCClient so the pod is GC'd with it
+        expect(adapter.pods[0].podSpec.metadata.ownerReferences[0].name).toBe('app-b')
+    })
+
+    it('fires the refresh pod again on update', async () => {
+        adapter.seed('OIDCClient', rawClient('app-c', {
+            secretRefreshPod: { spec: { containers: [{ name: 'refresh', image: 'busybox' }] } },
+        }))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-c')
+        const afterCreate = adapter.pods.length
+        await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-c')
+        expect(adapter.pods.length).toBe(afterCreate + 1)
+    })
+
+    it('removes the client from Redis on delete', async () => {
+        adapter.seed('OIDCClient', rawClient('app-d'))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-d')
+        expect(await clientRedis().find(idOf('app-d'))).toBeTruthy()
+
+        await adapter.fireWatch('DELETED', 'OIDCClient', 'app-d')
+        expect(await clientRedis().find(idOf('app-d'))).toBeUndefined()
+    })
+})


### PR DESCRIPTION
The Kubernetes operators had **zero test coverage** — the riskiest untested code (watch + reconcile), and where #60's race concerns live. This adds the first operator coverage and verifies the `secretRefreshPod` trigger (#69).

## What
- Extends the fake Kubernetes adapter with the operator API: `setWatchParameters`/`watchObjects` + a `fireWatch()` helper that drives synthetic `ADDED`/`MODIFIED`/`DELETED` events through the operator's reconcile callbacks, plus secret CRUD and `createPod` recording.
- `KubeOIDCClientOperator` tests:
  - **claim** an unclaimed client → sets `status.instance`, creates the owner secret, caches it in Redis with a generated secret;
  - **secretRefreshPod** is created when configured, with an `ownerReference` back to the client, and **fires again on update** — verifying #69's trigger on the create + update paths;
  - **delete** → removes the client from Redis.

## Notes on the reliability issues
- **#69**: the refresh pod **does** trigger on create + update (now under test). It intentionally does *not* re-fire when an already-claimed client is merely re-observed (e.g. operator restart) with no change. If it "doesn't trigger" in practice, the likely culprit is `adapter.createPod` swallowing a failure (it logs and returns null) or a per-resourceVersion pod-name collision — worth surfacing/retrying.
- **#70** (Pod → Job): recommended as the real reliability win — a `Job` gets scheduler retries and a `kube_job_failed` metric for a shippable `PrometheusRule`. It's a CRD-field change, so it deserves its own PR/decision.
- **#60** (conditions/events + multi-instance races): the operators reconcile via plain upserts and don't write status back; adding conditions safely needs the suggested approach (ignore self-authored updates via the instance user-agent, or split the operator into its own pod). Larger architectural change.

Full suite: **75 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)