### PR TITLE
feat(operator): run secret-refresh as a Job with alerting (#70)

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -357,10 +357,16 @@ spec:
                     labels:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                secretRefreshPod:
+                secretRefreshJobSpec:
                   type: object
+                  description: >-
+                    A Kubernetes JobSpec (the .spec of a batch/v1 Job) run after
+                    the client's owner Secret is created or updated — e.g. to
+                    restart/redeploy the consuming workload. Passmower wraps it in
+                    a Job owned by this OIDCClient, with labels for alerting. Use a
+                    Job (not a bare Pod) so failed refreshes are retried and
+                    surfaced via the kube_job_failed metric.
                   x-kubernetes-preserve-unknown-fields: true
-                  x-kubernetes-embedded-resource: true
                 tokenEndpointAuthMethod:
                   type: string
                   enum:

--- a/charts/passmower/templates/prometheusrule.yaml
+++ b/charts/passmower/templates/prometheusrule.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "passmower.fullname" . }}-secret-refresh
+  labels:
+    {{- include "passmower.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: passmower-secret-refresh
+      rules:
+        # Alerts when an OIDCClient secret-refresh Job (spec.secretRefreshJobSpec)
+        # has exhausted its retries and failed. Relies on kube-state-metrics
+        # (kube_job_failed + kube_job_labels). The secret-refresh Jobs carry
+        # app.kubernetes.io/component=secret-refresh and the oidc-client label.
+        - alert: PassmowerSecretRefreshJobFailed
+          expr: >-
+            kube_job_failed{condition="true"}
+            * on(namespace, job_name) group_left(label_codemowers_cloud_oidc_client)
+            kube_job_labels{label_app_kubernetes_io_managed_by="passmower", label_app_kubernetes_io_component="secret-refresh"}
+            > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Passmower secret-refresh Job failed
+            description: >-
+              The secret-refresh Job {{ "{{ $labels.namespace }}/{{ $labels.job_name }}" }}
+              for OIDCClient {{ "{{ $labels.label_codemowers_cloud_oidc_client }}" }}
+              has failed. The consuming workload may not have picked up the new
+              client secret.
+{{- end }}

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -135,6 +135,13 @@ podMonitor:
   # Scrape interval
   interval: 30s
 
+prometheusRule:
+  # Enable a PrometheusRule alerting on failed secret-refresh Jobs (requires
+  # kube-state-metrics). See OIDCClient spec.secretRefreshJobSpec.
+  enabled: false
+  # Additional labels for the PrometheusRule (e.g. to match your Prometheus ruleSelector)
+  labels: {}
+
 service:
   type: ClusterIP
   port: 80

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -29,6 +29,7 @@ export class KubernetesAdapter {
         const userAgentMiddleware = setHeaderMiddleware('User-Agent', this.instance)
         this.customObjectsApi = kc.makeApiClient(k8s.CustomObjectsApi);
         this.coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
+        this.batchV1Api = kc.makeApiClient(k8s.BatchV1Api);
         this.defaultOptions = { middleware: [userAgentMiddleware] }
     }
 
@@ -218,17 +219,17 @@ export class KubernetesAdapter {
         })
     }
 
-    async createPod(namespace, podSpec, dryRun = false) {
-        await this.coreV1Api.createNamespacedPod({
+    async createJob(namespace, jobManifest) {
+        return await this.batchV1Api.createNamespacedJob({
             namespace,
-            body: podSpec
-        }, this.defaultOptions).then(async (r) => {
+            body: jobManifest
+        }, this.defaultOptions).then((r) => {
             return r.status
         }).catch((e) => {
-            if (e.code !== 404) {
-                globalThis.logger.error(e)
-                return null
-            }
+            // Surface failures (not just 404) — a swallowed secret-refresh
+            // failure was a source of "refresh not triggering" confusion (#69).
+            globalThis.logger.error({ err: e, job: jobManifest?.metadata?.name }, 'Failed to create secret-refresh Job')
+            return null
         })
     }
 

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -47,7 +47,7 @@ class OIDCClient {
     #conditions = {}
     #allowedCORSOrigins = null
     #secretMetadata = null
-    #secretRefreshPod = null
+    #secretRefreshJobSpec = null
     #displayOrder = 0
     #description = null
 
@@ -100,7 +100,7 @@ class OIDCClient {
         this.#pkce = incomingClient.spec.pkce ?? true
         this.#conditions = incomingClient.status?.conditions ?? []
         this.#secretMetadata = incomingClient.spec?.secretMetadata ?? {}
-        this.#secretRefreshPod = incomingClient.spec?.secretRefreshPod ?? null // TODO: validate
+        this.#secretRefreshJobSpec = incomingClient.spec?.secretRefreshJobSpec ?? null // TODO: validate
         this.#allowedCORSOrigins = incomingClient.spec?.allowedCORSOrigins
         this.#displayOrder = incomingClient.spec?.displayOrder ?? 0
         this.#description = incomingClient.metadata?.annotations?.['kubernetes.io/description'] ?? null
@@ -186,22 +186,35 @@ class OIDCClient {
         return this.#resourceVersion
     }
 
-    getSecretRefreshPod() {
-        let podSpec = this.#secretRefreshPod
-        if (!podSpec) {
+    // Build the secret-refresh Job from the user-supplied JobSpec. Using a Job
+    // (instead of a bare Pod) gets Kubernetes scheduler retries and a
+    // kube_job_failed metric for alerting; labels make alert rules specific and
+    // the ownerReference garbage-collects the Job with its OIDCClient (#70).
+    getSecretRefreshJob() {
+        const jobSpec = this.#secretRefreshJobSpec
+        if (!jobSpec) {
             return undefined
         }
-        podSpec.metadata = podSpec.metadata || {}
-        podSpec.metadata.name = podSpec.metadata.name || `${this.getClientName()}-${this.getResourceVersion()}`
-        podSpec.metadata.ownerReferences = [
-            new KubeOwnerMetadata(
-                OIDCClientCrd,
-                this.getClientName(),
-                this.#uid
-            )
-        ];
-        podSpec.spec.restartPolicy = podSpec.spec.restartPolicy || 'Never'
-        return podSpec
+        // Jobs require restartPolicy Never|OnFailure on the pod template.
+        jobSpec.template = jobSpec.template || {}
+        jobSpec.template.spec = jobSpec.template.spec || {}
+        jobSpec.template.spec.restartPolicy = jobSpec.template.spec.restartPolicy || 'OnFailure'
+        return {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            metadata: {
+                name: `${this.getClientName()}-secret-refresh-${this.getResourceVersion()}`,
+                ownerReferences: [
+                    new KubeOwnerMetadata(OIDCClientCrd, this.getClientName(), this.#uid)
+                ],
+                labels: {
+                    'app.kubernetes.io/managed-by': 'passmower',
+                    'app.kubernetes.io/component': 'secret-refresh',
+                    'codemowers.cloud/oidc-client': this.getClientName(),
+                },
+            },
+            spec: jobSpec,
+        }
     }
 }
 

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -99,10 +99,10 @@ export class KubeOIDCClientOperator {
             OIDCClient.toClientSecret(this.provider),
             OIDCClient.toClientSecretMetadata(),
         )
-        if (OIDCClient.getSecretRefreshPod()) {
-            await this.adapter.createPod(
+        if (OIDCClient.getSecretRefreshJob()) {
+            await this.adapter.createJob(
                 OIDCClient.getClientNamespace(),
-                OIDCClient.getSecretRefreshPod()
+                OIDCClient.getSecretRefreshJob()
             )
         }
     }
@@ -115,10 +115,10 @@ export class KubeOIDCClientOperator {
             OIDCClient.toClientSecretMetadata(),
             existingSecret
         )
-        if (OIDCClient.getSecretRefreshPod()) {
-            await this.adapter.createPod(
+        if (OIDCClient.getSecretRefreshJob()) {
+            await this.adapter.createJob(
                 OIDCClient.getClientNamespace(),
-                OIDCClient.getSecretRefreshPod()
+                OIDCClient.getSecretRefreshJob()
             )
         }
     }

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -15,7 +15,7 @@ export class FakeKubernetesAdapter {
         this.instance = instance
         this.store = new Map()       // `${kind}/${name}` -> stored CR object
         this.secrets = new Map()     // `${namespace}/${name}` -> { data, metadata }
-        this.pods = []               // pods created via createPod (e.g. secretRefreshPod)
+        this.jobs = []               // jobs created via createJob (e.g. secret-refresh)
         this.watchHandlers = []      // for operator tests
         this.watchParameters = null  // set by setWatchParameters()
         this._rv = 0
@@ -84,7 +84,7 @@ export class FakeKubernetesAdapter {
     async createSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
     async patchSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
     async deleteSecret(namespace, id) { this.secrets.delete(`${namespace}/${id}`) }
-    async createPod(namespace, podSpec) { this.pods.push({ namespace, podSpec: structuredClone(podSpec) }); return { phase: 'Pending' } }
+    async createJob(namespace, jobManifest) { this.jobs.push({ namespace, jobManifest: structuredClone(jobManifest) }); return { active: 1 } }
 
     // --- Watch (used by operators) ------------------------------------------
 

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -5,12 +5,12 @@ import OidcClient from '../../src/models/oidc-client.js'
 import RedisAdapter from '../../src/adapters/redis.js'
 
 // Reconciliation coverage for the OIDCClient operator (previously untested):
-// claim -> secret -> Redis, updates, the secretRefreshPod hook (#69) and delete.
+// claim -> secret -> Redis, updates, the secretRefreshJob hook (#69/#70) and delete.
 describe('KubeOIDCClientOperator reconciliation', () => {
     let provider, adapter, operator
     const clientRedis = () => new RedisAdapter('Client')
 
-    function rawClient(name, { secretRefreshPod } = {}) {
+    function rawClient(name, { secretRefreshJobSpec } = {}) {
         return {
             metadata: { name, namespace: 'apps', resourceVersion: '1', uid: `uid-${name}`, annotations: {} },
             spec: {
@@ -19,11 +19,12 @@ describe('KubeOIDCClientOperator reconciliation', () => {
                 redirectUris: ['https://app.example.com/cb'],
                 availableScopes: ['openid'],
                 tokenEndpointAuthMethod: 'client_secret_basic',
-                ...(secretRefreshPod ? { secretRefreshPod } : {}),
+                ...(secretRefreshJobSpec ? { secretRefreshJobSpec } : {}),
             },
             status: {}, // unclaimed
         }
     }
+    const refreshJobSpec = { template: { spec: { containers: [{ name: 'refresh', image: 'busybox' }] } } }
     const idOf = (name) => new OidcClient().fromIncomingClient(rawClient(name)).getClientId()
 
     beforeAll(async () => {
@@ -58,26 +59,28 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         expect(cached.client_secret).toBeTruthy()
     })
 
-    it('creates the secretRefreshPod when configured (#69)', async () => {
-        adapter.seed('OIDCClient', rawClient('app-b', {
-            secretRefreshPod: { spec: { containers: [{ name: 'refresh', image: 'busybox' }] } },
-        }))
+    it('creates the secretRefreshJob when configured (#69/#70)', async () => {
+        adapter.seed('OIDCClient', rawClient('app-b', { secretRefreshJobSpec: refreshJobSpec }))
         await adapter.fireWatch('ADDED', 'OIDCClient', 'app-b')
 
-        expect(adapter.pods).toHaveLength(1)
-        expect(adapter.pods[0].podSpec.spec.containers[0].image).toBe('busybox')
-        // owner reference back to the OIDCClient so the pod is GC'd with it
-        expect(adapter.pods[0].podSpec.metadata.ownerReferences[0].name).toBe('app-b')
+        expect(adapter.jobs).toHaveLength(1)
+        const job = adapter.jobs[0].jobManifest
+        expect(job.kind).toBe('Job')
+        expect(job.spec.template.spec.containers[0].image).toBe('busybox')
+        // Job gets a restartPolicy (so failures are retried) and alerting labels
+        expect(job.spec.template.spec.restartPolicy).toBe('OnFailure')
+        expect(job.metadata.labels['app.kubernetes.io/component']).toBe('secret-refresh')
+        expect(job.metadata.labels['codemowers.cloud/oidc-client']).toBe('app-b')
+        // owner reference back to the OIDCClient so the Job is GC'd with it
+        expect(job.metadata.ownerReferences[0].name).toBe('app-b')
     })
 
-    it('fires the refresh pod again on update', async () => {
-        adapter.seed('OIDCClient', rawClient('app-c', {
-            secretRefreshPod: { spec: { containers: [{ name: 'refresh', image: 'busybox' }] } },
-        }))
+    it('fires the refresh job again on update', async () => {
+        adapter.seed('OIDCClient', rawClient('app-c', { secretRefreshJobSpec: refreshJobSpec }))
         await adapter.fireWatch('ADDED', 'OIDCClient', 'app-c')
-        const afterCreate = adapter.pods.length
+        const afterCreate = adapter.jobs.length
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-c')
-        expect(adapter.pods.length).toBe(afterCreate + 1)
+        expect(adapter.jobs.length).toBe(afterCreate + 1)
     })
 
     it('removes the client from Redis on delete', async () => {


### PR DESCRIPTION
Closes #70 (relates to #69).

## What
Replace the bare secret-refresh **Pod** (`spec.secretRefreshPod`) with a **batch/v1 Job** (`spec.secretRefreshJobSpec`). Per #70, a Job means the kube scheduler retries failed refreshes itself and exposes the `kube_job_failed` metric, which we can alert on. Added labels make the alert rule specific.

## Changes
- **adapter** (`kubernetes.js`): `createPod` → `createJob` via `BatchV1Api`.
- **model** (`oidc-client.js`): `getSecretRefreshPod` → `getSecretRefreshJob` — wraps the user-supplied `JobSpec` in a `Job` owned by the `OIDCClient`, defaults `restartPolicy: OnFailure`, and stamps `app.kubernetes.io/managed-by=passmower`, `app.kubernetes.io/component=secret-refresh`, `codemowers.cloud/oidc-client=<name>` labels.
- **operator**: create the Job after secret create/patch.
- **CRD**: `secretRefreshPod` → `secretRefreshJobSpec` (documented).
- **chart**: opt-in `PrometheusRule` (`prometheusRule.enabled`) alerting on `kube_job_failed` joined to the secret-refresh Job labels (requires kube-state-metrics).
- **tests**: fake adapter + operator integration assert Job creation, labels, ownerReference and re-fire on update.

## Verification
- `vitest run` → 75 passed (20 files), incl. updated operator tests.
- `helm template --set prometheusRule.enabled=true` renders the rule cleanly.

> Note: this is a **breaking** CRD field rename (`secretRefreshPod` → `secretRefreshJobSpec`); existing consumers must migrate their manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)