### PR TITLE
chore(release): promote develop to 2.0.0-dev

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -12,6 +12,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v7
+
+      - name: Get chart version
+        id: chart_version
+        run: |
+          echo "CHART_VERSION=$(cat charts/passmower/Chart.yaml | awk -F"[ ',]+" '/^version:/{print $2}')" >> $GITHUB_OUTPUT
+
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -41,12 +47,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ github.repository }}:1.2.0-dev
+            ${{ github.repository }}:${{ steps.chart_version.outputs.CHART_VERSION }}
 
       -
         name: Push Image to GHCR
         uses: akhilerm/tag-push-action@v2.3.0
         with:
-          src: docker.io/${{ github.repository }}:1.2.0-dev
+          src: docker.io/${{ github.repository }}:${{ steps.chart_version.outputs.CHART_VERSION }}
           dst: |
-            ghcr.io/${{ github.repository }}:1.2.0-dev
+            ghcr.io/${{ github.repository }}:${{ steps.chart_version.outputs.CHART_VERSION }}

--- a/.github/workflows/release-charts-dev.yml
+++ b/.github/workflows/release-charts-dev.yml
@@ -18,12 +18,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get chart version
+        id: chart_version
+        run: |
+          echo "CHART_VERSION=$(cat charts/passmower/Chart.yaml | awk -F"[ ',]+" '/^version:/{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Publish Helm chart to the ghcr.io registry
         uses: appany/helm-oci-chart-releaser@v0.5.0
         with:
           name: passmower
           repository: passmower/charts
-          tag: 1.2.0-dev
+          tag: ${{ steps.chart_version.outputs.CHART_VERSION }}
           path: ./charts/passmower
           registry: ghcr.io
           registry_username: ${{ secrets.GHCR_USERNAME }}

--- a/charts/passmower/Chart.yaml
+++ b/charts/passmower/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 2.0.0-dev


### PR DESCRIPTION
Promotes the `develop` line to **`2.0.0-dev`** so it can be rolled out to dev clusters, without merging the (still drastic) changes into `master`.

## Why 2.0.0
`develop` carries breaking changes relative to the `1.x` master line — oidc-provider 8→9, openid-client 5→6, and the `secretRefreshPod` → `secretRefreshJobSpec` CRD rename (#70) — so the next release is a major.

## Changes
- **`Chart.yaml`**: `version: 1.3.0` → `2.0.0-dev`. The deployment image tag defaults to `.Chart.Version`, so pods will pull `ghcr.io/passmower/passmower:2.0.0-dev`.
- **`docker-dev.yml` / `release-charts-dev.yml`**: stop hardcoding the dev tag. Both now derive `CHART_VERSION` from `Chart.yaml` (same step the master `docker.yml` already uses). They were stuck at `1.2.0-dev` while the chart had moved to `1.3.0`; now they track the chart and future bumps are a one-line change.

## Effect on merge
Merging to `develop` triggers the dev publish workflows, which will push:
- image `ghcr.io/passmower/passmower:2.0.0-dev` (+ Docker Hub)
- chart `ghcr.io/passmower/charts/passmower:2.0.0-dev`

No git tag or GitHub release is created (those only run on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)