### PR TITLE
refactor(chart): camelCase values, drop deprecated keys, fix anti-patterns

### DIFF
--- a/charts/passmower/templates/NOTES.txt
+++ b/charts/passmower/templates/NOTES.txt
@@ -1,2 +1,2 @@
 Find the application on URL:
-{{ .Values.passmower.url }}
+{{ include "passmower.url" . }}

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -37,46 +37,46 @@ spec:
                    commented-out/empty value falls back to the app default
                    instead of being forced to "" (#67). Booleans are always
                    emitted because `false` is meaningful. */}}
-            {{- with .Values.passmower.group_prefix }}
+            {{- with .Values.passmower.groupPrefix }}
             - name: GROUP_PREFIX
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.passmower.admin_group }}
+            {{- with .Values.passmower.adminGroup }}
             - name: ADMIN_GROUP
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.passmower.required_group }}
+            {{- with .Values.passmower.requiredGroup }}
             - name: REQUIRED_GROUP
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.passmower.github_organization }}
+            {{- with .Values.passmower.githubOrganization }}
             - name: GITHUB_ORGANIZATION
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.passmower.username_source }}
+            {{- with .Values.passmower.usernameSource }}
             - name: USERNAME_SOURCE
               value: {{ . | quote }}
             {{- end }}
             - name: ENROLL_USERS
-              value: {{ .Values.passmower.enroll_users | quote }}
+              value: {{ .Values.passmower.enrollUsers | quote }}
             - name: DISABLE_FRONTEND_EDIT
-              value: {{ .Values.passmower.disable_frontend_edit | quote }}
-            {{- with .Values.passmower.namespace_selector }}
+              value: {{ .Values.passmower.disableFrontendEdit | quote }}
+            {{- with .Values.passmower.namespaceSelector }}
             - name: NAMESPACE_SELECTOR
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.passmower.preferred_email_domain }}
+            {{- with .Values.passmower.preferredEmailDomain }}
             - name: PREFERRED_EMAIL_DOMAIN
               value: {{ . | quote }}
             {{- end }}
             - name: NORMALIZE_EMAIL_ADDRESSES
-              value: {{ .Values.passmower.normalize_email_addresses | quote }}
+              value: {{ .Values.passmower.normalizeEmailAddresses | quote }}
             - name: WEBAUTHN_ENABLED
-              value: {{ .Values.passmower.webauthn_enabled | quote }}
+              value: {{ .Values.passmower.webauthnEnabled | quote }}
             - name: GITHUB_ENABLED
-              value: {{ .Values.passmower.github_enabled | quote }}
+              value: {{ .Values.passmower.githubEnabled | quote }}
             - name: EMAIL_ENABLED
-              value: {{ .Values.passmower.email_enabled | quote }}
+              value: {{ .Values.passmower.emailEnabled | quote }}
             - name: OIDC_PROVIDERS
               value: {{ .Values.passmower.oidcProviders | default list | toJson | quote }}
             - name: REDIS_IP_FAMILY
@@ -100,13 +100,13 @@ spec:
           envFrom:
             - secretRef:
                 name: oidc-keys
-            {{- if .Values.passmower.email_credentials_secretRef }}
+            {{- if .Values.passmower.emailCredentialsSecretRef }}
             - secretRef:
-                name: {{ .Values.passmower.email_credentials_secretRef }}
+                name: {{ .Values.passmower.emailCredentialsSecretRef }}
             {{- end }}
-            {{- if .Values.passmower.github_client_secretRef }}
+            {{- if .Values.passmower.githubClientSecretRef }}
             - secretRef:
-                name: {{ .Values.passmower.github_client_secretRef }}
+                name: {{ .Values.passmower.githubClientSecretRef }}
             {{- end }}
             {{- /* One secretRef per distinct OIDC provider credentials secret. */}}
             {{- $seen := dict }}
@@ -117,9 +117,9 @@ spec:
                 name: {{ .clientSecretRef }}
             {{- end }}
             {{- end }}
-            {{- if .Values.passmower.slack_client_secretRef }}
+            {{- if .Values.passmower.slackClientSecretRef }}
             - secretRef:
-                name: {{ .Values.passmower.slack_client_secretRef }}
+                name: {{ .Values.passmower.slackClientSecretRef }}
             {{- end }}
           readinessProbe:
             httpGet:
@@ -172,8 +172,8 @@ spec:
       volumes:
         - name: tos
           configMap:
-            {{- if .Values.passmower.texts.terms_of_service.configMapRef }}
-            name: {{ .Values.passmower.texts.terms_of_service.configMapRef.name }}
+            {{- if .Values.passmower.texts.termsOfService.configMapRef }}
+            name: {{ .Values.passmower.texts.termsOfService.configMapRef.name }}
             {{- else }}
             name: {{ include "passmower.fullname" . }}-tos
             {{- end }}
@@ -186,8 +186,8 @@ spec:
             {{- end }}
         - name: disable-frontend-edit
           configMap:
-            {{- if .Values.passmower.texts.disable_frontend_edit.configMapRef }}
-            name: {{ .Values.passmower.texts.disable_frontend_edit.configMapRef.name }}
+            {{- if .Values.passmower.texts.disableFrontendEdit.configMapRef }}
+            name: {{ .Values.passmower.texts.disableFrontendEdit.configMapRef.name }}
             {{- else }}
             name: {{ include "passmower.fullname" . }}-disable-frontend-edit
             {{- end }}

--- a/charts/passmower/templates/redis.yaml
+++ b/charts/passmower/templates/redis.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis
+          image: {{ .Values.redis.internal.image | default "redis:7-alpine" }}
           command:
             - redis-server
           env:

--- a/charts/passmower/templates/serviceaccount.yaml
+++ b/charts/passmower/templates/serviceaccount.yaml
@@ -40,9 +40,9 @@ rules:
   - verbs:
       - create
     apiGroups:
-      - ''
+      - batch
     resources:
-      - pods
+      - jobs
   - verbs:
       - get
       - create

--- a/charts/passmower/templates/texts.yaml
+++ b/charts/passmower/templates/texts.yaml
@@ -1,10 +1,10 @@
-{{- if not .Values.passmower.texts.terms_of_service.configMapRef }}
+{{- if not .Values.passmower.texts.termsOfService.configMapRef }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "passmower.fullname" . }}-tos
 data:
-  tos.md: "{{ .Values.passmower.texts.terms_of_service.content }}"
+  tos.md: {{ .Values.passmower.texts.termsOfService.content | quote }}
 {{- end }}
 ---
 {{- if not .Values.passmower.texts.approval.configMapRef }}
@@ -13,16 +13,16 @@ kind: ConfigMap
 metadata:
   name: {{ include "passmower.fullname" . }}-approval
 data:
-  approval.txt: "{{ .Values.passmower.texts.approval.content }}"
+  approval.txt: {{ .Values.passmower.texts.approval.content | quote }}
 {{- end }}
 ---
-{{- if not .Values.passmower.texts.disable_frontend_edit.configMapRef }}
+{{- if not .Values.passmower.texts.disableFrontendEdit.configMapRef }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "passmower.fullname" . }}-disable-frontend-edit
 data:
-  disable_frontend_edit.md: "{{ .Values.passmower.texts.disable_frontend_edit.content }}"
+  disable_frontend_edit.md: {{ .Values.passmower.texts.disableFrontendEdit.content | quote }}
 {{- end }}
 ---
 {{- if not .Values.passmower.texts.emails.configMapRef }}
@@ -31,10 +31,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "passmower.fullname" . }}-email-templates
 data:
-  link.subject: "{{ .Values.passmower.texts.emails.login_link.subject }}"
-  link.txt: "{{ .Values.passmower.texts.emails.login_link.text }}"
-  link.ejs: "{{ .Values.passmower.texts.emails.login_link.body }}"
-  tos.subject: "{{ .Values.passmower.texts.emails.terms_of_service.subject }}"
-  tos.txt: "{{ .Values.passmower.texts.emails.terms_of_service.text }}"
-  tos.ejs: "{{ .Values.passmower.texts.emails.terms_of_service.body }}"
+  link.subject: {{ .Values.passmower.texts.emails.loginLink.subject | quote }}
+  link.txt: {{ .Values.passmower.texts.emails.loginLink.text | quote }}
+  link.ejs: {{ .Values.passmower.texts.emails.loginLink.body | quote }}
+  tos.subject: {{ .Values.passmower.texts.emails.termsOfService.subject | quote }}
+  tos.txt: {{ .Values.passmower.texts.emails.termsOfService.text | quote }}
+  tos.ejs: {{ .Values.passmower.texts.emails.termsOfService.body | quote }}
 {{- end }}

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -5,44 +5,40 @@ passmower:
   # Hostname on which Passmower will be deployed to. Will be used as ingress host.
   host: ""
   # Local groups will be created with given prefix.
-  group_prefix: "passmower"
+  groupPrefix: "passmower"
   # Local or remote group which members will automatically become admins.
-  admin_group: ""
+  adminGroup: ""
   # If set, require all users to be member of the given local or remote group.
-  required_group: ""
+  requiredGroup: ""
   # GitHub organization to pull groups from. Set to keep users other organizations private from Passmower.
-  github_organization: ""
+  githubOrganization: ""
   # How a new user's username (OIDCUser CRD name / accountId / OIDC `sub`) is determined at enrollment:
   #   generated - random system-generated id (u<...>)
   #   prompt    - user must pick a custom username via a form
   #   upstream  - derived from the upstream provider (GitHub login, OIDC preferred_username),
   #               falling back to the prompt form when unavailable/taken/invalid
   # `sub` always equals the stored accountId regardless of this setting.
-  username_source: prompt
-  # DEPRECATED, no longer wired by this chart — use username_source (upstream) instead.
-  use_github_username: false
-  # Allow enrolling new users automatically. Actual access will be based on required_group parameter. Disable to only manually provision users.
-  enroll_users: true
+  usernameSource: prompt
+  # Allow enrolling new users automatically. Actual access will be based on requiredGroup parameter. Disable to only manually provision users.
+  enrollUsers: true
   # Disable making changes to users on their profile or via admin panel - use for enforcing GitOps practices via OIDCUser spec.
-  disable_frontend_edit: false
+  disableFrontendEdit: false
   # Comma-separated, wildcard enabled namespace selector to select, in which namespaces Passmower looks for client CRDs.
-  namespace_selector: "*"
+  namespaceSelector: "*"
   # Domain which will be preferred for determining primary emails.
-  preferred_email_domain: "gmail.com"
-  # DEPRECATED, no longer wired by this chart — use username_source (prompt) instead.
-  require_custom_username: true
+  preferredEmailDomain: "gmail.com"
   # Normalize incoming email addresses by removing aliases (e.g. username+alias@gmail.com) etc.
-  normalize_email_addresses: true
+  normalizeEmailAddresses: true
   # Enable WebAuthn/Passkey authentication. Allows users to register passkeys for faster login.
-  webauthn_enabled: true
-  # Enable GitHub OAuth login. Requires github_client_secretRef to be set.
-  github_enabled: true
-  # Enable email magic-link login. Requires email_credentials_secretRef to be set.
-  email_enabled: true
+  webauthnEnabled: true
+  # Enable GitHub OAuth login. Requires githubClientSecretRef to be set.
+  githubEnabled: true
+  # Enable email magic-link login. Requires emailCredentialsSecretRef to be set.
+  emailEnabled: true
   # Email credentials secret name. Secret must contain EMAIL_HOST, EMAIL_PASSWORD, EMAIL_PORT, EMAIL_SSL and EMAIL_USERNAME
-  email_credentials_secretRef: "email-credentials"
+  emailCredentialsSecretRef: "email-credentials"
   # GitHub OAuth client secret name. Secret must contain GH_CLIENT_ID and GH_CLIENT_SECRET
-  github_client_secretRef: "github-client"
+  githubClientSecretRef: "github-client"
   # Generic OIDC upstream login providers. Add an entry per provider — any
   # standards-compliant OIDC provider works (Google, GitLab, EntraID, Keycloak,
   # Okta, Authentik, Zitadel, ...). Each entry:
@@ -80,7 +76,7 @@ passmower:
   #    groupPrefix: entraid
   #    clientSecretRef: entraid-client
   # Slack API client secret name. Secret must contain SLACK_TOKEN
-  # slack_client_secretRef: "slack-client"
+  # slackClientSecretRef: "slack-client"
   # Different texts displayed and sent to the user
   texts:
     approval:
@@ -90,19 +86,19 @@ passmower:
     emails:
       #configMapRef:
       #  name: ""
-      login_link:
+      loginLink:
         subject: "Passmower login link"
         text: "Open the following link to log in: <%= url %>"
         body: ""
-      terms_of_service:
+      termsOfService:
         subject: "Terms of Service agreement confirmation"
         text: ""
         body: ""
-    terms_of_service:
+    termsOfService:
         #configMapRef:
         #  name: ""
         content: ""
-    disable_frontend_edit:
+    disableFrontendEdit:
         #configMapRef:
         #  name: ""
         content: "Editing profile is disabled. Please see [our Git](https://github.com)"
@@ -120,6 +116,8 @@ redis:
   # Deploys a simple, non persistent Redis deployment.
   internal:
     enabled: true
+    # Image for the internal (non-persistent) Redis. Pinned rather than :latest.
+    image: redis:7-alpine
   # Use your own implementation - just provide a secret with a valid Redis URL.
   external:
     enabled: false
@@ -159,7 +157,7 @@ ingress:
 image:
   repository: ghcr.io/passmower/passmower
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart version.
   # tag: "develop"
 
 podSecurityContext: {}

--- a/docs/username-configuration.md
+++ b/docs/username-configuration.md
@@ -14,7 +14,7 @@ A single setting controls how the username is chosen when a **new** user is enro
 | `prompt` | The user must pick a custom username via a form. The username is validated (3–15 chars, lowercase alphanumeric, starts with a letter, not blacklisted) and must be unique. |
 | `upstream` | Derived from the upstream provider's username — GitHub `login`, or the OIDC `preferred_username`/`nickname`. It is sanitized and run through the same validation/uniqueness checks; if it is missing, invalid, or already taken, Passmower **falls back to the `prompt` form** (pre-filled with the candidate). Email magic-link logins have no upstream username and therefore always fall back to `prompt`. |
 
-Default (Helm `passmower.username_source`): `prompt`.
+Default (Helm `passmower.usernameSource`): `prompt`.
 
 `sub` always equals the stored `accountId` regardless of this setting — it is stable and unique.
 This is intentional: relying parties key off `sub`.
@@ -41,7 +41,7 @@ These two flags are replaced by `USERNAME_SOURCE`:
 
 If `USERNAME_SOURCE` is unset, Passmower still derives it from the old env vars and logs a
 deprecation warning (both-true resolves to `prompt`). The Helm chart no longer wires the old
-values — set `passmower.username_source` instead.
+values — set `passmower.usernameSource` instead.
 
 > **Breaking change for `USE_GITHUB_USERNAME=true` deployments.** Previously `sub` was the GitHub
 > login while the stored `accountId` was a random id, so `sub` and `accountId` differed (and `sub`


### PR DESCRIPTION
Audit + cleanup of the Helm chart values, as part of the `2.0.0` line (breaking values changes are acceptable here).

## 1. camelCase all values keys (Helm convention)
Every snake_case key under `passmower.*` and `passmower.texts.*` is renamed to camelCase, and all template references updated:

| Old | New |
|---|---|
| `group_prefix` | `groupPrefix` |
| `admin_group` | `adminGroup` |
| `required_group` | `requiredGroup` |
| `github_organization` | `githubOrganization` |
| `username_source` | `usernameSource` |
| `enroll_users` | `enrollUsers` |
| `disable_frontend_edit` | `disableFrontendEdit` |
| `namespace_selector` | `namespaceSelector` |
| `preferred_email_domain` | `preferredEmailDomain` |
| `normalize_email_addresses` | `normalizeEmailAddresses` |
| `webauthn_enabled` | `webauthnEnabled` |
| `github_enabled` | `githubEnabled` |
| `email_enabled` | `emailEnabled` |
| `email_credentials_secretRef` | `emailCredentialsSecretRef` |
| `github_client_secretRef` | `githubClientSecretRef` |
| `slack_client_secretRef` | `slackClientSecretRef` |
| `texts.terms_of_service` | `texts.termsOfService` |
| `texts.disable_frontend_edit` | `texts.disableFrontendEdit` |
| `texts.emails.login_link` | `texts.emails.loginLink` |
| `texts.emails.terms_of_service` | `texts.emails.termsOfService` |

(Env var names like `GROUP_PREFIX` and ConfigMap data filenames like `tos.md` are unchanged — those aren't values keys.)

## 2. Remove deprecated keys
`use_github_username` and `require_custom_username` — both already documented as "DEPRECATED, no longer wired by this chart" and referenced by no template. Superseded by `usernameSource`.

## 3. Anti-patterns / bugs fixed
- **RBAC bug (from #70):** the operator now creates `batch/v1` Jobs (`createNamespacedJob`), but the ClusterRole still only granted `create` on core `pods` — so `secretRefreshJobSpec` would fail with a 403 at runtime. Now grants `create` on `batch/jobs`.
- **NOTES.txt** printed `.Values.passmower.url` (nonexistent → blank). Uses the `passmower.url` helper; now renders `https://<host>/`.
- **Unsafe ConfigMap interpolation:** texts content was wrapped in hand-written quotes (`"{{ ... }}"`), which breaks on quotes/newlines. Switched to `| quote`.
- **Unpinned dev Redis image:** `image: redis` (implicit `:latest`) → pinned `redis:7-alpine`, overridable via `redis.internal.image`.
- **Misleading comment:** `image.tag` defaults to the chart version, not appVersion (the chart has no appVersion).

## Verification
- `helm lint` clean; `helm template` renders cleanly with default and dev values.
- Spot-checked: env vars populated, RBAC grants `batch/jobs` (no `pods` rule), NOTES resolves the URL, texts ConfigMaps quoted, Redis image pinned.
- JS suite still 75/75 (chart-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)