### PR TITLE
chore(rbac): tighten middlewares verbs; reap secret-refresh Jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ frontend/ styles/     # Vue frontend + SCSS (built into the image)
 - **`secretRefreshJobSpec` → a Job (not a Pod).** When a client wants its consuming
   workload restarted after its secret rotates, it sets `spec.secretRefreshJobSpec`
   (a `batch/v1` JobSpec). Passmower wraps it in a `Job` owned by the `OIDCClient`,
-  defaults `restartPolicy: OnFailure`, and stamps
+  defaults `restartPolicy: OnFailure` and `ttlSecondsAfterFinished: 3600`, and stamps
   `app.kubernetes.io/managed-by=passmower`, `app.kubernetes.io/component=secret-refresh`,
   `codemowers.cloud/oidc-client=<name>` labels so the shipped `PrometheusRule`
   (`prometheusRule.enabled`) can alert on `kube_job_failed`.

--- a/charts/passmower/templates/serviceaccount.yaml
+++ b/charts/passmower/templates/serviceaccount.yaml
@@ -46,9 +46,7 @@ rules:
   - verbs:
       - get
       - create
-      - update
       - patch
-      - delete
     apiGroups:
       - traefik.io
     resources:

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -104,6 +104,7 @@ spec:
             command: ["kubectl", "rollout", "restart", "deployment/my-app"]
     # any other JobSpec fields are allowed, e.g.:
     # backoffLimit: 4
+    # ttlSecondsAfterFinished: 600   # defaults to 3600 if unset
 ```
 
 Passmower still owns the resulting Job (owner-referenced to the `OIDCClient`, so it is

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -199,6 +199,10 @@ class OIDCClient {
         jobSpec.template = jobSpec.template || {}
         jobSpec.template.spec = jobSpec.template.spec || {}
         jobSpec.template.spec.restartPolicy = jobSpec.template.spec.restartPolicy || 'OnFailure'
+        // Reap finished refresh Jobs instead of letting them pile up across
+        // rotations (they're owner-referenced to the client, so only the
+        // client's deletion would otherwise clean them). Overridable per client.
+        jobSpec.ttlSecondsAfterFinished = jobSpec.ttlSecondsAfterFinished ?? 3600
         return {
             apiVersion: 'batch/v1',
             kind: 'Job',

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -67,8 +67,10 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         const job = adapter.jobs[0].jobManifest
         expect(job.kind).toBe('Job')
         expect(job.spec.template.spec.containers[0].image).toBe('busybox')
-        // Job gets a restartPolicy (so failures are retried) and alerting labels
+        // Job gets a restartPolicy (so failures are retried), a TTL (so finished
+        // Jobs are reaped) and alerting labels
         expect(job.spec.template.spec.restartPolicy).toBe('OnFailure')
+        expect(job.spec.ttlSecondsAfterFinished).toBe(3600)
         expect(job.metadata.labels['app.kubernetes.io/component']).toBe('secret-refresh')
         expect(job.metadata.labels['codemowers.cloud/oidc-client']).toBe('app-b')
         // owner reference back to the OIDCClient so the Job is GC'd with it


### PR DESCRIPTION
The two refinements from the RBAC audit.

## 1. Trim `traefik.io/middlewares` verbs
The middleware operator only does get/create/patch; middleware deletion happens via owner-reference GC (each middleware is owner-ref'd to its `OIDCMiddlewareClient`), so `update` and `delete` were granted but never exercised. Now: `get, create, patch`.

## 2. Reap finished secret-refresh Jobs
Each secret rotation creates a new refresh Job (name includes the resourceVersion). They're owner-ref'd to the `OIDCClient`, so without a TTL they accumulate until the client itself is deleted. Default `ttlSecondsAfterFinished: 3600` on the wrapped Job (overridable per client via `secretRefreshJobSpec.ttlSecondsAfterFinished`). The 1h TTL is well clear of the `PrometheusRule`'s `for: 5m`, so a failed Job is still alertable before it's reaped.

Docs (AGENTS.md, migrating-to-2.0.md) and the operator integration test updated.

## Verification
- `vitest run` → 75 passed (asserts the TTL default).
- `helm template` renders middlewares rule as `get/create/patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)