### PR TITLE
feat(crd): promote custom resources to codemowers.cloud/v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ It does **not** replace your org IdP (GitHub, Google, EntraID, …) — it bridg
 those upstreams into your Kubernetes ecosystem:
 
 - **Users and enrolled applications are Kubernetes Custom Resources** (`OIDCUser`,
-  `OIDCClient`, `OIDCMiddlewareClient`, all in group `codemowers.cloud/v1beta1`).
-  Passmower is therefore also an **operator** — it watches these CRDs and reconciles.
+  `OIDCClient`, `OIDCMiddlewareClient`, group `codemowers.cloud`, version `v1` —
+  `v1beta1` is still served but deprecated). Passmower is therefore also an
+  **operator** — it watches these CRDs and reconciles.
 - **Session/OIDC runtime state lives in Redis** (the `oidc-provider` storage adapter).
 - **Upstream login** is via GitHub OAuth2, generic standards-compliant OIDC
   (Google/GitLab/EntraID/Dex/…), email magic-links, WebAuthn passkeys, and Slack.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ authentication, you can use the following Kubernetes manifest:
 
 ```
 ---
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCClient
 metadata:
   name: grafana
@@ -227,7 +227,7 @@ controller needs specific metadata to pick up the secret — for example, ArgoCD
 requires the `app.kubernetes.io/part-of: argocd` label to read it:
 
 ```
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCClient
 metadata:
   name: grafana
@@ -260,7 +260,7 @@ upstream provider) is controlled by `USERNAME_SOURCE`. See
 If automatic enrollment is disabled users can be managed GitOps style.
 
 ```
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCUser
 metadata:
   name: johnsmith
@@ -284,7 +284,7 @@ For legacy applications `forwardAuth` based middleware option is supported.
 
 ```
 ---
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCMiddlewareClient
 metadata:
   name: webmail

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -12,11 +12,15 @@ spec:
     listKind: OIDCUserList
   scope: Namespaced
   versions:
-    - name: v1beta1
+    # v1 and v1beta1 are served with the SAME schema (shared via the YAML anchor
+    # below) so conversion strategy None is valid. v1 is the storage version;
+    # v1beta1 is kept served-but-deprecated for one release so existing
+    # `codemowers.cloud/v1beta1` resources keep working while consumers migrate.
+    - name: v1
       served: true
       storage: true
       schema:
-        openAPIV3Schema:
+        openAPIV3Schema: &oidcUserSchema
           type: object
           required:
             - spec
@@ -221,9 +225,9 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 slackId:
                   type: string
-      subresources:
+      subresources: &oidcUserSubresources
         status: {}
-      additionalPrinterColumns:
+      additionalPrinterColumns: &oidcUserPrinterColumns
         - name: Type
           type: string
           jsonPath: .spec.type
@@ -248,6 +252,15 @@ spec:
         - name: Groups
           type: string
           jsonPath: .status.groups
+    - name: v1beta1
+      served: true
+      storage: false
+      deprecated: true
+      deprecationWarning: "codemowers.cloud/v1beta1 OIDCUser is deprecated; use codemowers.cloud/v1"
+      schema:
+        openAPIV3Schema: *oidcUserSchema
+      subresources: *oidcUserSubresources
+      additionalPrinterColumns: *oidcUserPrinterColumns
   conversion:
     strategy: None
 ---
@@ -264,11 +277,11 @@ spec:
     listKind: OIDCClientList
   scope: Namespaced
   versions:
-    - name: v1beta1
+    - name: v1
       served: true
       storage: true
       schema:
-        openAPIV3Schema:
+        openAPIV3Schema: &oidcClientSchema
           type: object
           required:
             - spec
@@ -391,9 +404,9 @@ spec:
                     x-kubernetes-embedded-resource: true
                 instance:
                   type: string
-      subresources:
+      subresources: &oidcClientSubresources
         status: {}
-      additionalPrinterColumns:
+      additionalPrinterColumns: &oidcClientPrinterColumns
         - name: Instance
           type: string
           description: Passmower deployment which manages this client
@@ -406,6 +419,15 @@ spec:
           type: string
           description: Groups allowed to this client
           jsonPath: .spec.allowedGroups
+    - name: v1beta1
+      served: true
+      storage: false
+      deprecated: true
+      deprecationWarning: "codemowers.cloud/v1beta1 OIDCClient is deprecated; use codemowers.cloud/v1"
+      schema:
+        openAPIV3Schema: *oidcClientSchema
+      subresources: *oidcClientSubresources
+      additionalPrinterColumns: *oidcClientPrinterColumns
   conversion:
     strategy: None
 ---
@@ -422,11 +444,11 @@ spec:
     listKind: OIDCMiddlewareClientList
   scope: Namespaced
   versions:
-    - name: v1beta1
+    - name: v1
       served: true
       storage: true
       schema:
-        openAPIV3Schema:
+        openAPIV3Schema: &oidcMiddlewareClientSchema
           type: object
           required:
             - spec
@@ -472,9 +494,9 @@ spec:
                     x-kubernetes-embedded-resource: true
                 instance:
                   type: string
-      subresources:
+      subresources: &oidcMiddlewareClientSubresources
         status: {}
-      additionalPrinterColumns:
+      additionalPrinterColumns: &oidcMiddlewareClientPrinterColumns
         - name: Instance
           type: string
           description: Passmower deployment which manages this client
@@ -487,5 +509,14 @@ spec:
           type: string
           description: Groups allowed to this client
           jsonPath: .spec.allowedGroups
+    - name: v1beta1
+      served: true
+      storage: false
+      deprecated: true
+      deprecationWarning: "codemowers.cloud/v1beta1 OIDCMiddlewareClient is deprecated; use codemowers.cloud/v1"
+      schema:
+        openAPIV3Schema: *oidcMiddlewareClientSchema
+      subresources: *oidcMiddlewareClientSubresources
+      additionalPrinterColumns: *oidcMiddlewareClientPrinterColumns
   conversion:
     strategy: None

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -118,7 +118,39 @@ labels.
 
 ---
 
-## 3. RBAC change — automatic
+## 3. CRDs promoted to `codemowers.cloud/v1` — **no immediate action, but migrate your manifests**
+
+The custom resources (`OIDCUser`, `OIDCClient`, `OIDCMiddlewareClient`) are promoted
+from `codemowers.cloud/v1beta1` to **`codemowers.cloud/v1`**. This is done the
+non-breaking way:
+
+- The CRDs serve **both** versions. `v1` is now the **storage** version; `v1beta1` is
+  still **served but marked deprecated** (the API server returns a deprecation warning —
+  e.g. `kubectl` prints "codemowers.cloud/v1beta1 ... is deprecated; use
+  codemowers.cloud/v1"). The two versions share an identical schema, so conversion is
+  `strategy: None` (no conversion webhook needed).
+- **Nothing breaks on upgrade.** Your existing `apiVersion: codemowers.cloud/v1beta1`
+  resources keep working and Passmower reconciles them unchanged. As they are re-applied
+  or updated they are rewritten to `v1` storage.
+
+**What to do (at your own pace):** update the `apiVersion` in your `OIDCUser` /
+`OIDCClient` / `OIDCMiddlewareClient` manifests from `codemowers.cloud/v1beta1` to
+`codemowers.cloud/v1`. The `spec` is unchanged — only the `apiVersion` line moves.
+
+```diff
+- apiVersion: codemowers.cloud/v1beta1
++ apiVersion: codemowers.cloud/v1
+  kind: OIDCClient
+  # spec unchanged
+```
+
+> `v1beta1` will be **removed in a future release**. Migrate your manifests during the
+> 2.0 window so the eventual removal is a no-op for you. (A version can only be dropped
+> once no stored objects remain on it — re-applying your resources as `v1` ensures that.)
+
+---
+
+## 4. RBAC change — automatic
 
 The chart's `ClusterRole` now grants `create` on `batch/jobs` instead of core `pods`
 (the operator creates the refresh **Job** described above). This is applied for you by
@@ -128,7 +160,7 @@ you may drop the old `pods` `create` grant.
 
 ---
 
-## 4. Major dependency upgrades — informational
+## 5. Major dependency upgrades — informational
 
 2.0 upgrades several runtime dependencies across major versions, most notably
 `oidc-provider` 8 → 9, `openid-client` 5 → 6, and `koa` 2 → 3 (also `helmet` 8,
@@ -140,7 +172,7 @@ exists specifically to guard these upgrades.
 
 ---
 
-## 5. What's new (non-breaking)
+## 6. What's new (non-breaking)
 
 You don't have to do anything to get these, but they're the reason to upgrade:
 
@@ -158,7 +190,7 @@ You don't have to do anything to get these, but they're the reason to upgrade:
 
 ---
 
-## 6. Upgrade
+## 7. Upgrade
 
 After editing your values (section 1) and any `OIDCClient`s that used
 `secretRefreshPod` (section 2):

--- a/examples/authorization-code-sample-client.yaml
+++ b/examples/authorization-code-sample-client.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCClient
 metadata:
   name: authorization-code-sample-client

--- a/examples/implicit-id-token-sample-client.yaml
+++ b/examples/implicit-id-token-sample-client.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCClient
 metadata:
   name: implicit-id-token-sample-client

--- a/examples/middleware-sample-client.yaml
+++ b/examples/middleware-sample-client.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCMiddlewareClient
 metadata:
   name: whoami

--- a/examples/native-app-sample-client.yaml
+++ b/examples/native-app-sample-client.yaml
@@ -3,7 +3,7 @@
 # use a custom-scheme or http-loopback redirect URI, which is only valid for
 # clients with applicationType: native. They are public clients (no usable
 # secret), so authenticate with PKCE and tokenEndpointAuthMethod: none.
-apiVersion: codemowers.cloud/v1beta1
+apiVersion: codemowers.cloud/v1
 kind: OIDCClient
 metadata:
   name: native-app-sample-client

--- a/src/utils/kubernetes/kube-constants.js
+++ b/src/utils/kubernetes/kube-constants.js
@@ -7,7 +7,10 @@ export const OIDCClients = 'oidcclients';
 export const OIDCMiddlewareClientCrd = 'OIDCMiddlewareClient';
 export const OIDCMiddlewareClients = 'oidcmiddlewareclients';
 export const defaultApiGroup = 'codemowers.cloud'
-export const defaultApiGroupVersion = 'v1beta1'
+// v1 is the served + storage version as of 2.0. v1beta1 is still served
+// (deprecated) by the CRDs, so existing v1beta1 objects remain visible through
+// the v1 watch/read path via conversion (strategy None, identical schema).
+export const defaultApiGroupVersion = 'v1'
 export const OIDCClientSecretName = (clientName) => `oidc-client-${clientName}-owner-secrets`
 export const OIDCClientId = (namespace, clientName) => `${namespace}.${clientName}`
 // Dot is chosen as the delimiting character as it is one of the few characters that is not encoded in URL and therefore avoids problematic clients that do not properly encode the client parameters for token endpoint.

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -43,7 +43,7 @@ export class FakeKubernetesAdapter {
         const key = this.#key(kind, name)
         if (this.store.has(key)) return null // name already taken -> real adapter swallows the conflict
         const obj = {
-            apiVersion: 'codemowers.cloud/v1beta1',
+            apiVersion: 'codemowers.cloud/v1',
             kind,
             metadata: { name, labels, resourceVersion: this.#nextRv() },
             status: {},
@@ -123,7 +123,7 @@ export class FakeKubernetesAdapter {
     seed(kind, obj) {
         const name = obj.metadata.name
         this.store.set(this.#key(kind, name), {
-            apiVersion: 'codemowers.cloud/v1beta1',
+            apiVersion: 'codemowers.cloud/v1',
             kind,
             status: {},
             ...structuredClone(obj),


### PR DESCRIPTION
Promotes `OIDCUser`, `OIDCClient`, `OIDCMiddlewareClient` from `codemowers.cloud/v1beta1` to **`codemowers.cloud/v1`**, the non-breaking way. Supersedes #144 (we decided to do this in 2.0 rather than defer).

## How it works
- Each CRD now serves **two versions**: `v1` (`storage: true`) and `v1beta1` (`served: true`, `storage: false`, `deprecated: true` with a `deprecationWarning`).
- Both versions share an **identical schema** via YAML anchors (`&oidcUserSchema` etc.), so `conversion.strategy: None` remains valid — no conversion webhook required.
- Existing `v1beta1` resources keep working and are reconciled unchanged; the API server emits a deprecation warning on `v1beta1` use; objects migrate to `v1` storage as they're re-applied.
- `v1beta1` can be removed in a future release once `status.storedVersions` clears.

## Changes
- `charts/passmower/templates/crds.yaml`: dual-version + anchored schema + deprecation warnings.
- `src/utils/kubernetes/kube-constants.js`: `defaultApiGroupVersion` `v1beta1` → `v1` (operator watches/reads/writes v1; sees v1beta1 objects via conversion).
- `examples/`, `README.md`, `test/fakes`: bumped to `v1`.
- `docs/migrating-to-2.0.md`: new section 3 explaining the promotion + manifest migration.

## Verification
- `helm template` + parse: 3 CRDs, each with exactly one storage version (`v1`), `conversion: None`, and **schemas identical across v1/v1beta1** (anchors resolve correctly under Helm).
- `helm lint` clean.
- `vitest run` → 75 passed.

> Note: I validated structure and anchor resolution via `helm template` + a YAML parse. A full apply against a live API server (CRD accepted, v1beta1↔v1 round-trip) isn't covered by CI — worth a manual check on a dev cluster before cutting `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)