### PR TITLE
fix: accept unicode display names (#64); random accountId (#13)

### DIFF
--- a/src/models/account.js
+++ b/src/models/account.js
@@ -272,7 +272,11 @@ class Account {
         const uid = new ShortUniqueId({
             dictionary: 'alphanum_lower',
         });
-        return 'u' + uid.stamp(10);
+        // rnd() not stamp(): stamp() embeds the creation timestamp, leaving only a
+        // couple of random chars, so two accounts created in the same millisecond can
+        // collide (the CR create then silently fails) and the creation time leaks from
+        // the id (#13). A fully random 10-char id over 36 symbols avoids both.
+        return 'u' + uid.rnd(10);
     }
 
     static async createOrUpdateByEmails(ctx, provider, email, githubEmails, username, preferredUsername) {

--- a/src/utils/session/validator.js
+++ b/src/utils/session/validator.js
@@ -4,6 +4,14 @@ import validatorLib from "validator";
 import {getText} from "../get-text.js";
 import {USERNAME_RULES} from "../user/username.js";
 
+// Display-name / company validation (#64). Upstream IdPs (GitHub, OIDC) legitimately
+// supply names with unicode letters, accents, apostrophes, hyphens, "&", etc. — an
+// en-US alphanumeric allowlist rejected those, so a name pulled from GitHub could not
+// be re-submitted on edit. Accept any printable input and reject only genuinely unsafe
+// characters: angle brackets (HTML/markup injection) and control chars (incl. newlines,
+// which would otherwise allow Remote-* forward-auth header injection).
+export const isSafeDisplayName = (value) => /^[^<>\x00-\x1f\x7f]*$/.test(value ?? '')
+
 // Custom validators
 const customValidators = {
     startsWithLetter: (value) => (new RegExp('^[a-z].*')).test(value),
@@ -35,12 +43,8 @@ const customValidators = {
             }).catch(reject);
         }
     }),
-    isValidName: (value) => validatorLib.isAlphanumeric(value, 'en-US', {
-        ignore: ' ÜÕÖÄüõöä'
-    }),
-    isValidCompanyName: (value) => validatorLib.isAlphanumeric(value, 'en-US', {
-        ignore: ' ÜÕÖÄüõöä'
-    }),
+    isValidName: (value) => isSafeDisplayName(value),
+    isValidCompanyName: (value) => isSafeDisplayName(value),
     disableFrontendEdit: () => process.env.DISABLE_FRONTEND_EDIT !== 'true'
 }
 

--- a/test/unit/account-uid.test.js
+++ b/test/unit/account-uid.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import Account from '../../src/models/account.js'
+
+// Regression for #13: getUid() used ShortUniqueId.stamp(), which embeds the
+// creation timestamp and leaves only a couple of random characters — so
+// same-millisecond signups could collide and the creation time leaked from the
+// id. It now uses a fully random id.
+describe('Account.getUid (#13)', () => {
+    it('produces a u-prefixed, 11-char lowercase-alphanumeric id', () => {
+        const id = Account.getUid()
+        expect(id).toMatch(/^u[a-z0-9]{10}$/)
+    })
+
+    it('does not collide across many same-tick generations', () => {
+        const ids = new Set()
+        for (let i = 0; i < 5000; i++) ids.add(Account.getUid())
+        expect(ids.size).toBe(5000)
+    })
+
+    it('is not timestamp-ordered (random, not a stamp)', () => {
+        // stamp()-based ids share a long common prefix when generated together;
+        // random ids do not. Assert the first random char varies across a batch.
+        const firstRandomChars = new Set(
+            Array.from({ length: 50 }, () => Account.getUid()[1])
+        )
+        expect(firstRandomChars.size).toBeGreaterThan(1)
+    })
+})

--- a/test/unit/display-name-validation.test.js
+++ b/test/unit/display-name-validation.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { isSafeDisplayName } from '../../src/utils/session/validator.js'
+
+// Regression for #64: names/companies pulled from upstream IdPs (GitHub, OIDC)
+// contain unicode that the old en-US alphanumeric allowlist rejected, so an edit
+// of a pulled-in value failed validation. We now accept printable input and only
+// reject genuinely unsafe characters.
+describe('isSafeDisplayName (#64)', () => {
+    it('accepts unicode letters, accents, punctuation that upstreams supply', () => {
+        for (const name of [
+            'Søren Kierkegaard',
+            'José Núñez',
+            "O'Brien",
+            'Jean-Luc Picard',
+            'Müller & Sons',
+            'Łukasz Żółć',
+            '山田 太郎',
+            'Acme, Inc.',
+        ]) {
+            expect(isSafeDisplayName(name), name).toBe(true)
+        }
+    })
+
+    it('rejects angle brackets (markup injection)', () => {
+        expect(isSafeDisplayName('<script>alert(1)</script>')).toBe(false)
+        expect(isSafeDisplayName('a < b')).toBe(false)
+        expect(isSafeDisplayName('x > y')).toBe(false)
+    })
+
+    it('rejects control characters incl. newlines (header injection)', () => {
+        expect(isSafeDisplayName('Evil\nRemote-Groups: admins')).toBe(false)
+        expect(isSafeDisplayName('a\tb')).toBe(false)
+        expect(isSafeDisplayName('a\r\nb')).toBe(false)
+        expect(isSafeDisplayName('a\x00b')).toBe(false)
+    })
+
+    it('treats empty/nullish as safe (length is enforced separately)', () => {
+        expect(isSafeDisplayName('')).toBe(true)
+        expect(isSafeDisplayName(null)).toBe(true)
+        expect(isSafeDisplayName(undefined)).toBe(true)
+    })
+})


### PR DESCRIPTION
Two small latent-bug fixes from the issue triage.

## #64 — Fields pulled from GitHub are not editable
`isValidName`/`isValidCompanyName` used `validator.isAlphanumeric('en-US', {ignore: ' ÜÕÖÄüõöä'})`, which rejects any other unicode an upstream IdP legitimately supplies (accents, apostrophes like `O'Brien`, `&`, non-Latin scripts). So a name/company pulled from GitHub couldn't be re-submitted on the profile edit form.

Replaced with an exported `isSafeDisplayName` predicate that accepts printable input and rejects only genuinely unsafe characters: **angle brackets** (`< >`, markup injection) and **control characters** (incl. newlines — which would otherwise allow injection into the `Remote-*` forward-auth headers). Length is still enforced separately.

## #13 — Possible AccountId collision
`Account.getUid()` used `ShortUniqueId.stamp(10)`, which **embeds the creation timestamp** and leaves only ~2 random characters. Two accounts created in the same millisecond could collide (the OIDCUser CR create then silently fails), and the creation time was extractable from the id. Switched to `rnd(10)` — a fully random 10-char id over 36 symbols.

(Only affects newly generated `generated`-source usernames; ids are opaque, nothing downstream depends on the format.)

## Tests
- `test/unit/display-name-validation.test.js` — accepts unicode names, rejects `< >` and control/newline chars.
- `test/unit/account-uid.test.js` — format, no collisions across 5000 same-tick generations, randomness.
- Full suite: 82 passed (was 75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)