### PR TITLE
fix(redis): honor REDIS_IP_FAMILY in the DNS-change watcher

### DIFF
--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -12,6 +12,17 @@ let readyPromise = new Promise(resolve => { readyResolve = resolve; });
 const MAX_ERROR_COUNT = 5;
 const DNS_REFRESH_INTERVAL = 30000; // 30 seconds
 
+// Resolve a host to its current set of IPs, honoring REDIS_IP_FAMILY
+// (0 = both, 4 = IPv4 only, 6 = IPv6 only) so the DNS-change watcher resolves
+// the same address family the connection itself uses. dns.resolve() only
+// queries A (IPv4) records, so on an IPv6-only Service it threw ENODATA on
+// every check — spamming errors and preventing the change-triggered reconnect
+// from ever running. dns.lookup() respects the family hint (and getaddrinfo).
+export async function resolveHostIps(host, family = parseInt(process.env.REDIS_IP_FAMILY ?? '0')) {
+    const records = await dns.lookup(host, { all: true, family });
+    return records.map(record => record.address).sort();
+}
+
 // The single shared client and the timers that keep it healthy. These are
 // created lazily by connect() rather than at import time so that importing a
 // module that transitively pulls in this adapter does NOT open a Redis
@@ -92,8 +103,7 @@ export function connect() {
 
         const checkDnsAndReconnect = async () => {
             try {
-                const currentIps = await dns.resolve(redisHost);
-                currentIps.sort();
+                const currentIps = await resolveHostIps(redisHost);
 
                 if (lastKnownIps.length > 0 && JSON.stringify(lastKnownIps) !== JSON.stringify(currentIps)) {
                     globalThis.logger?.warn({ oldIps: lastKnownIps, newIps: currentIps }, 'Redis: DNS changed, reconnecting...')

--- a/test/unit/redis-dns.test.js
+++ b/test/unit/redis-dns.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock node:dns/promises before importing the adapter so resolveHostIps picks
+// up the fake. The adapter imports the default export and calls dns.lookup().
+const { lookup } = vi.hoisted(() => ({ lookup: vi.fn() }))
+vi.mock('node:dns/promises', () => ({ default: { lookup } }))
+
+const { resolveHostIps } = await import('../../src/adapters/redis.js')
+
+describe('resolveHostIps — IP-family-aware Redis DNS watcher', () => {
+    beforeEach(() => {
+        lookup.mockReset()
+        delete process.env.REDIS_IP_FAMILY
+    })
+    afterEach(() => {
+        delete process.env.REDIS_IP_FAMILY
+    })
+
+    it('queries the requested family (6) instead of IPv4-only A records', async () => {
+        lookup.mockResolvedValue([{ address: '2001:db8::1', family: 6 }])
+
+        const ips = await resolveHostIps('redis.passmower.svc.cluster.local', 6)
+
+        expect(lookup).toHaveBeenCalledWith('redis.passmower.svc.cluster.local', { all: true, family: 6 })
+        expect(ips).toEqual(['2001:db8::1'])
+    })
+
+    it('returns a sorted list of addresses so change detection is stable', async () => {
+        lookup.mockResolvedValue([
+            { address: '10.0.0.2', family: 4 },
+            { address: '10.0.0.1', family: 4 },
+        ])
+
+        expect(await resolveHostIps('redis', 4)).toEqual(['10.0.0.1', '10.0.0.2'])
+    })
+
+    it('defaults the family from REDIS_IP_FAMILY', async () => {
+        process.env.REDIS_IP_FAMILY = '6'
+        lookup.mockResolvedValue([{ address: '2001:db8::2', family: 6 }])
+
+        await resolveHostIps('redis')
+
+        expect(lookup).toHaveBeenCalledWith('redis', { all: true, family: 6 })
+    })
+
+    it('defaults to family 0 (both) when REDIS_IP_FAMILY is unset', async () => {
+        lookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }])
+
+        await resolveHostIps('redis')
+
+        expect(lookup).toHaveBeenCalledWith('redis', { all: true, family: 0 })
+    })
+})


### PR DESCRIPTION
The headless-service DNS watcher resolved the Redis host with `dns.resolve()`, which only queries A (IPv4) records. On an IPv6-only Service this threw `ENODATA` on every 30s check, both spamming error-level logs ("Redis: DNS lookup failed") and preventing the change-triggered reconnect from ever running — even though the connection itself was healthy (it already passes `family` to ioredis).

Resolve via `dns.lookup(host, { all: true, family })` using the same REDIS_IP_FAMILY the connection uses (0 = both, 4 = IPv4, 6 = IPv6), so the watcher matches the connection's address family. Extracted as `resolveHostIps()` and covered by unit tests.