### PR TITLE
feat: make the welcome page heading configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | Env | Purpose |
 |---|---|
 | `ISSUER_URL` | Public base URL of Passmower, **with trailing slash**. |
+| `WELCOME_MESSAGE` | Heading on the welcome/sign-in landing page; defaults to "Welcome to Passmower". |
 | `OIDC_COOKIE_KEYS` | JSON array of cookie-signing keys. |
 | `OIDC_JWKS` | JSON JWKS for token signing. |
 | `REDIS_URI`, `REDIS_IP_FAMILY` | Redis connection. |

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
                    commented-out/empty value falls back to the app default
                    instead of being forced to "" (#67). Booleans are always
                    emitted because `false` is meaningful. */}}
+            {{- with .Values.passmower.welcomeMessage }}
+            - name: WELCOME_MESSAGE
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.passmower.groupPrefix }}
             - name: GROUP_PREFIX
               value: {{ . | quote }}

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -4,6 +4,10 @@ fullnameOverride: ""
 passmower:
   # Hostname on which Passmower will be deployed to. Will be used as ingress host.
   host: ""
+  # Heading shown on the welcome / sign-in landing page (only rendered when more
+  # than one login method is enabled; a single method skips straight to sign-in).
+  # Empty falls back to "Welcome to Passmower".
+  welcomeMessage: ""
   # Local groups will be created with given prefix.
   groupPrefix: "passmower"
   # Local or remote group which members will automatically become admins.

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -135,7 +135,7 @@ export default (provider) => {
             if (enabledAuthMethodCount() === 1) {
                 return ctx.redirect(url.href)
             }
-            return render(provider, ctx, 'hi', `Welcome to Passmower`, {
+            return render(provider, ctx, 'hi', process.env.WELCOME_MESSAGE || 'Welcome to Passmower', {
                 url: url.href
             })
         }


### PR DESCRIPTION
A user wanted to change (or remove) the "Welcome to Passmower" heading on the sign-in landing page. It was a hardcoded string; this makes it configurable.

## Change
- `src/routes/oidcRoutes.js`: heading is now `process.env.WELCOME_MESSAGE || 'Welcome to Passmower'`.
- `charts/passmower/values.yaml`: new `passmower.welcomeMessage` (default `""`).
- `charts/passmower/templates/deployment.yaml`: emits `WELCOME_MESSAGE` only when set (same optional pattern as the other string settings), so empty/unset falls back to the default — existing deployments are unchanged.
- AGENTS.md env table updated.

## Context (no change needed for the "don't want to see it" case)
The welcome page is only rendered when **more than one** login method is enabled; with a single method, Passmower already skips straight to sign-in (added in the multi-provider work). So a deployment with one login method won't see this page at all.

## Verification
- `helm template`: `WELCOME_MESSAGE` absent when unset, present with the value when `passmower.welcomeMessage` is set.
- Suite: 82 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)