### PR TITLE
feat: add audit logging and application activity tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ user is allowed to open — via the `applications` userinfo claim, or the full
 admin-only catalog at `GET /api/apps/all`. See
 [docs/application-listing.md](docs/application-listing.md).
 
+## Audit logging and application activity
+
+Passmower emits minimal structured audit records and maintains bounded recent
+application summaries on user and client CRDs. Production installations should
+forward the audit stream to durable storage. See
+[docs/audit-logging.md](docs/audit-logging.md) for the event schema, privacy
+controls, retention guidance, inactivity conditions, and reversible client
+disabling.
+
 ## User enrollment
 
 How usernames are assigned at enrollment (system-generated, user-prompted, or derived from the

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -517,6 +517,34 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 slackId:
                   type: string
+                recentApplications:
+                  type: array
+                  description: >-
+                    Bounded, most-recent-first summary of applications successfully
+                    authorized by this user. This is an operational projection, not
+                    a durable audit log.
+                  items:
+                    type: object
+                    required:
+                      - clientId
+                      - clientNamespace
+                      - clientName
+                      - lastAuthenticatedAt
+                    properties:
+                      clientId:
+                        type: string
+                      clientNamespace:
+                        type: string
+                      clientName:
+                        type: string
+                      clientKind:
+                        type: string
+                        enum:
+                          - OIDCClient
+                          - OIDCMiddlewareClient
+                      lastAuthenticatedAt:
+                        type: string
+                        format: date-time
       subresources: &oidcUserSubresources
         status: {}
       additionalPrinterColumns: &oidcUserPrinterColumns
@@ -621,6 +649,12 @@ spec:
                       - namespaces
                 displayName:
                   type: string
+                disabled:
+                  type: boolean
+                  default: false
+                  description: >-
+                    Remove this client from the active provider configuration while
+                    preserving its resource and generated Secret for later re-enabling.
                 grantTypes:
                   type: array
                   items:
@@ -697,6 +731,10 @@ spec:
                     x-kubernetes-embedded-resource: true
                 instance:
                   type: string
+                lastUsedAt:
+                  type: string
+                  format: date-time
+                  description: Latest successful authorization or token exchange.
       subresources: &oidcClientSubresources
         status: {}
       additionalPrinterColumns: &oidcClientPrinterColumns
@@ -704,6 +742,12 @@ spec:
           type: string
           description: Passmower deployment which manages this client
           jsonPath: .status.instance
+        - name: Disabled
+          type: boolean
+          jsonPath: .spec.disabled
+        - name: Last used
+          type: date
+          jsonPath: .status.lastUsedAt
         - name: Uris
           type: string
           description: Redirect URLs configured for this client
@@ -755,6 +799,12 @@ spec:
                     type: string
                 displayName:
                   type: string
+                disabled:
+                  type: boolean
+                  default: false
+                  description: >-
+                    Disable forward authentication while preserving this resource
+                    and its generated middleware configuration.
                 headerMapping:
                   type: object
                   default:
@@ -787,6 +837,10 @@ spec:
                     x-kubernetes-embedded-resource: true
                 instance:
                   type: string
+                lastUsedAt:
+                  type: string
+                  format: date-time
+                  description: Latest successful authorization or token exchange.
       subresources: &oidcMiddlewareClientSubresources
         status: {}
       additionalPrinterColumns: &oidcMiddlewareClientPrinterColumns
@@ -794,6 +848,12 @@ spec:
           type: string
           description: Passmower deployment which manages this client
           jsonPath: .status.instance
+        - name: Disabled
+          type: boolean
+          jsonPath: .spec.disabled
+        - name: Last used
+          type: date
+          jsonPath: .status.lastUsedAt
         - name: Uri
           type: string
           description: URL configured for this client

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -89,6 +89,20 @@ spec:
               value: {{ .Values.passmower.githubEnabled | quote }}
             - name: EMAIL_ENABLED
               value: {{ .Values.passmower.emailEnabled | quote }}
+            - name: AUDIT_ENABLED
+              value: {{ .Values.passmower.audit.enabled | quote }}
+            - name: AUDIT_INCLUDE_SOURCE_ADDRESS
+              value: {{ .Values.passmower.audit.includeSourceAddress | quote }}
+            - name: AUDIT_INCLUDE_USER_AGENT
+              value: {{ .Values.passmower.audit.includeUserAgent | quote }}
+            - name: ACTIVITY_TRACKING_ENABLED
+              value: {{ .Values.passmower.activityTracking.enabled | quote }}
+            - name: ACTIVITY_FLUSH_INTERVAL_SECONDS
+              value: {{ .Values.passmower.activityTracking.flushIntervalSeconds | quote }}
+            - name: ACTIVITY_RECENT_APPLICATION_LIMIT
+              value: {{ .Values.passmower.activityTracking.recentApplicationLimit | quote }}
+            - name: CLIENT_INACTIVE_AFTER_DAYS
+              value: {{ .Values.passmower.activityTracking.inactiveAfterDays | quote }}
             - name: OIDC_PROVIDERS
               value: {{ .Values.passmower.oidcProviders | default dict | toJson | quote }}
             - name: REDIS_IP_FAMILY

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -59,6 +59,25 @@ passmower:
   # bearer token.
   extraClaimsWebhookTokenSecretRef: ""
 
+  # Emit a minimal, versioned JSON audit record for successful application
+  # authorizations and token exchanges. Records go to stdout and should be
+  # collected into a durable audit backend; see docs/audit-logging.md.
+  audit:
+    enabled: true
+    # Personal data is excluded by default. Enable only when required by your
+    # audit policy and protect the resulting log stream accordingly.
+    includeSourceAddress: false
+    includeUserAgent: false
+
+  # Project recent successful application activity into OIDCUser/OIDCClient
+  # status. Writes are aggregated so login traffic does not become Kubernetes
+  # API traffic one-for-one.
+  activityTracking:
+    enabled: true
+    flushIntervalSeconds: 900
+    recentApplicationLimit: 20
+    inactiveAfterDays: 90
+
   # Generic OIDC upstream login providers. Add a provider-keyed entry — any
   # standards-compliant OIDC provider works (Google, GitLab, EntraID, Keycloak,
   # Okta, Authentik, Zitadel, ...). Each entry:

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -51,6 +51,9 @@ Successful activity is aggregated and periodically projected into Kubernetes:
 - `passmower_oidc_client_last_used_timestamp_seconds` exposes the same client
   summary to Prometheus.
 
+Each Passmower replica publishes its own view of the last-used gauge. Dashboards
+and alerts should use `max by (kind, namespace, client)` across replicas.
+
 These fields are summaries for administration and user interfaces, not an audit
 history. By default Passmower flushes at most every 15 minutes rather than
 writing to the Kubernetes API for every login:

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -68,6 +68,11 @@ Activity buffered since the previous flush may be lost if every Passmower pod
 terminates simultaneously. Audit records are emitted immediately and remain the
 historical source of truth once collected by a durable backend.
 
+The admin UI shows a refined, read-only view of each user's bounded recent
+application activity: application namespace/name, client kind, and last
+authentication time. It does not return raw CRD status, conditions beyond those
+already used by user administration, request metadata, or audit records.
+
 ## Reversibly disabling a client
 
 Set `OIDCClient.spec.disabled: true` or `OIDCMiddlewareClient.spec.disabled: true`

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -1,0 +1,78 @@
+# Audit logging and application activity
+
+Passmower emits a minimal structured audit record when a user successfully
+authorizes a downstream application and when a client successfully exchanges a
+grant. Audit logging is enabled by default. Records are written as JSON to
+stdout with `logType: audit` and a versioned `audit` object.
+
+```json
+{
+  "logType": "audit",
+  "audit": {
+    "schemaVersion": 1,
+    "event": "application.login.succeeded",
+    "timestamp": "2026-08-05T12:30:00.123Z",
+    "subject": {"id": "u123"},
+    "client": {"id": "apps.grafana", "namespace": "apps", "name": "grafana"},
+    "result": "success"
+  }
+}
+```
+
+The built-in logger is a useful minimum and deliberately does not turn Redis or
+the Kubernetes API into an audit database. Production installations should
+route records marked `logType: audit` through the cluster log collector into a
+durable, access-controlled backend such as Loki, OpenSearch, Splunk, or a SIEM.
+Configure retention, immutability, backup, and access separately from ordinary
+application logs.
+
+Tokens, authorization codes, client secrets, cookies, claims, and raw session
+identifiers are never included. Source addresses and user agents are personal
+data and are disabled by default:
+
+```yaml
+passmower:
+  audit:
+    enabled: true
+    includeSourceAddress: false
+    includeUserAgent: false
+```
+
+## Kubernetes activity projections
+
+Successful activity is aggregated and periodically projected into Kubernetes:
+
+- `OIDCClient.status.lastUsedAt` and `OIDCMiddlewareClient.status.lastUsedAt`
+  record the application's latest successful use.
+- Their `status.conditions[type=Inactive]` indicates whether the client has
+  exceeded `inactiveAfterDays`.
+- `OIDCUser.status.recentApplications` contains the most recent successful use
+  per application, sorted newest first and bounded by `recentApplicationLimit`.
+- `passmower_oidc_client_last_used_timestamp_seconds` exposes the same client
+  summary to Prometheus.
+
+These fields are summaries for administration and user interfaces, not an audit
+history. By default Passmower flushes at most every 15 minutes rather than
+writing to the Kubernetes API for every login:
+
+```yaml
+passmower:
+  activityTracking:
+    enabled: true
+    flushIntervalSeconds: 900
+    recentApplicationLimit: 20
+    inactiveAfterDays: 90
+```
+
+Activity buffered since the previous flush may be lost if every Passmower pod
+terminates simultaneously. Audit records are emitted immediately and remain the
+historical source of truth once collected by a durable backend.
+
+## Reversibly disabling a client
+
+Set `OIDCClient.spec.disabled: true` or `OIDCMiddlewareClient.spec.disabled: true`
+to remove a client from the active provider
+configuration. Passmower retains the resource and generated Secret, so setting
+it back to `false` restores the same client ID and credentials. Passmower does
+not automatically disable or delete inactive clients; use the condition or
+metric to drive an administrator-reviewed policy.

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -24,6 +24,17 @@
                 <p>Primary email: {{ account.email }}</p>
                 <p>Conditions: {{ account.conditions.filter(c => c.status === 'True').map(c => c.type).join(', ') }}</p>
                 <p v-if="account.groups.length">Groups: {{ account.groups.map(g => g.displayName).join(', ') }}</p>
+                <div class="recent-applications" v-if="account.recentApplications?.length">
+                    <p>Recent applications:</p>
+                    <ul>
+                        <li v-for="application in account.recentApplications" :key="application.clientId">
+                            <strong>{{ application.namespace }}/{{ application.name }}</strong>
+                            <span> ({{ application.kind === 'OIDCMiddlewareClient' ? 'forward auth' : 'OIDC' }})</span>
+                            — <time :datetime="application.lastAuthenticatedAt">{{ formatDate(application.lastAuthenticatedAt) }}</time>
+                        </li>
+                    </ul>
+                </div>
+                <p v-else>No recent application activity</p>
             </div>
             <div class="item-actions">
                 <Check v-if="!account.approved" @click="approve(account)" />
@@ -66,6 +77,13 @@ export default {
     methods: {
         ...mapActions(useAccountStore, ['setAccount', 'originalAccount']),
         ...mapActions(useAccountsStore, ['setAccounts']),
+        formatDate(value) {
+            if (!value) return 'Never'
+            return new Intl.DateTimeFormat(undefined, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+            }).format(new Date(value))
+        },
         async editProfile(account) {
             this.setAccount(account)
             const modal = await openModal(EditProfile);

--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -349,12 +349,12 @@ class RedisAdapter {
 
     async destroy(id) {
         const key = this.key(id);
-        const payload = this.find(id)
+        const payload = await this.find(id)
 
         await getClient().del(key);
 
         if (referencable[this.name]) {
-            const owner = payload[referencable[this.name]?.ownerKey] ?? 1
+            const owner = payload?.[referencable[this.name]?.ownerKey] ?? 1
             const key = `${referencable[this.name].listName}:${owner}`;
             await getClient().srem(key, id);
         }

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ import KubeOidcUserOperator from "./operators/kube-oidc-user-operator.js";
 import KubeScimConnectionOperator from "./operators/kube-scim-connection-operator.js";
 import metricsServer from "./routes/metrics-server.js";
 import {getUsernameSource} from "./utils/username-source.js";
+import {getActivityTracker} from './services/activity-tracker.js';
 
 const __dirname = dirname(import.meta.url);
 
@@ -45,6 +46,7 @@ export async function buildProvider() {
 
 // Start the operators that watch the cluster for OIDC client/user resources.
 export async function startOperators(provider) {
+    const activityTracker = getActivityTracker()
     const kubeClientOperator = new KubeOIDCClientOperator(provider)
     await kubeClientOperator.watchClients()
     const kubeMiddlewareClientOperator = new KubeOIDCMiddlewareClientOperator(provider)
@@ -53,6 +55,7 @@ export async function startOperators(provider) {
     await kubeUserOperator.watchUsers()
     const scimConnectionOperator = new KubeScimConnectionOperator()
     await scimConnectionOperator.watchConnections()
+    activityTracker.start()
 }
 
 // Boot the full application. Skipped when imported as a module (e.g. by tests),

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -183,6 +183,7 @@ export default {
     extraClientMetadata: {
         properties: [
             'allowedGroups',
+            'clientNamespace',
             'availableScopes',
             'kind',
             'uri',

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -39,6 +39,7 @@ class Account {
     #labels = {}
     #metadata = {}
     #ctx = null
+    #recentApplications = []
 
     fromKubernetes(apiResponse) {
         this.accountId = apiResponse.metadata.name
@@ -59,6 +60,7 @@ class Account {
         this.profile = apiResponse.status?.profile ?? {}
         this.slackId = apiResponse.status?.slackId ?? null
         this.#conditions = apiResponse.status?.conditions ?? []
+        this.#recentApplications = apiResponse.status?.recentApplications ?? []
         this.#labels = apiResponse.metadata?.labels ?? {}
         this.#metadata = apiResponse.metadata
         this.isAdmin = !!this.#mapGroups().find(g => g.displayName === AdminGroup)
@@ -171,6 +173,7 @@ class Account {
             slackId: this.#slack?.id ?? null,
             passkeyCount: this.#webauthn?.credentials?.length ?? 0,
             conditions: this.#conditions,
+            recentApplications: this.#recentApplications,
         }
     }
 
@@ -240,6 +243,15 @@ class Account {
 
     setConditions(conditions) {
         this.#conditions = conditions
+        return this
+    }
+
+    getRecentApplications() {
+        return this.#recentApplications
+    }
+
+    setRecentApplications(recentApplications) {
+        this.#recentApplications = recentApplications
         return this
     }
 

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -194,7 +194,16 @@ class Account {
                 accountId: this.accountId,
                 impersonationEnabled: requesterAccountId !== this.accountId,
                 approved: this.isAdmin || (new Approved()).check(this),
-                conditions: this.#conditions
+                conditions: this.#conditions,
+                // Refined read-only activity projection for the admin UI. Do not
+                // expose the rest of the CRD status or any raw audit-log fields.
+                recentApplications: this.#recentApplications.map(application => ({
+                    clientId: application.clientId,
+                    namespace: application.clientNamespace,
+                    name: application.clientName,
+                    kind: application.clientKind,
+                    lastAuthenticatedAt: application.lastAuthenticatedAt,
+                })),
             }
         }
         return profile

--- a/src/models/client-activity-state.js
+++ b/src/models/client-activity-state.js
@@ -1,0 +1,68 @@
+export class ClientActivityState {
+    constructor(resource) {
+        this.status = {instance: null, ...resource.status}
+        this.conditions = resource.status?.conditions ?? []
+        this.lastUsedAt = resource.status?.lastUsedAt ?? null
+        this.creationTimestamp = resource.metadata?.creationTimestamp ?? null
+        this.generation = resource.metadata?.generation ?? null
+        this.description = resource.metadata?.annotations?.['kubernetes.io/description'] ?? null
+    }
+
+    getIntendedStatus() {
+        return {
+            ...this.status,
+            lastUsedAt: this.lastUsedAt,
+            conditions: this.conditions,
+        }
+    }
+
+    updateActivityCondition(now, inactiveAfterDays) {
+        const reference = this.lastUsedAt ?? this.creationTimestamp
+        if (!reference) return
+        const inactive = now.getTime() - new Date(reference).getTime() >= inactiveAfterDays * 86400000
+        const previous = this.conditions.find(condition => condition.type === 'Inactive')
+        const status = inactive ? 'True' : 'False'
+        const condition = {
+            type: 'Inactive',
+            status,
+            reason: inactive ? 'NotUsedRecently' : 'RecentlyUsed',
+            message: inactive
+                ? `Client has not been used for at least ${inactiveAfterDays} days`
+                : `Client was used within the last ${inactiveAfterDays} days`,
+            lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : now.toISOString(),
+        }
+        this.conditions = [...this.conditions.filter(item => item.type !== 'Inactive'), condition]
+    }
+
+    // metadata.generation covers spec changes but not annotations. Description
+    // is the only annotation projected into Redis, so include it to distinguish
+    // status-only watch events from changes that require reconciliation.
+    getReconcileFingerprint() {
+        return JSON.stringify({generation: this.generation, description: this.description})
+    }
+}
+
+export class ClientReconcileState {
+    constructor(activityTracker) {
+        this.activityTracker = activityTracker
+        this.fingerprints = new Map()
+    }
+
+    register(client) {
+        this.activityTracker.registerClient(client)
+        this.fingerprints.set(client.getClientId(), client.getReconcileFingerprint())
+    }
+
+    shouldReconcile(client) {
+        this.activityTracker.registerClient(client)
+        const fingerprint = client.getReconcileFingerprint()
+        const unchanged = this.fingerprints.get(client.getClientId()) === fingerprint
+        this.fingerprints.set(client.getClientId(), fingerprint)
+        return !unchanged
+    }
+
+    unregister(client) {
+        this.activityTracker.unregisterClient(client.getClientId())
+        this.fingerprints.delete(client.getClientId())
+    }
+}

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -21,6 +21,7 @@ import {
 } from "../utils/kubernetes/kube-constants.js";
 import {KubeOwnerMetadata} from "../utils/kubernetes/kube-owner-metadata.js";
 import sortObject from "../utils/sort-object.js";
+import {ClientActivityState} from './client-activity-state.js';
 
 class OIDCClient {
     #clientName = null
@@ -39,21 +40,14 @@ class OIDCClient {
     #uri = null
     #displayName = null
     #resourceVersion = null
-    #status = {
-        instance: null
-    }
     #uid = null
     #pkce = true
-    #conditions = {}
     #allowedCORSOrigins = null
     #secretMetadata = null
     #secretRefreshJobSpec = null
     #displayOrder = 0
-    #description = null
     #disabled = false
-    #lastUsedAt = null
-    #creationTimestamp = null
-    #generation = null
+    #activityState = null
 
     constructor() {
     }
@@ -79,7 +73,7 @@ class OIDCClient {
             overrideIncomingScopes: this.#overrideIncomingScopes,
             allowedCORSOrigins: this.#allowedCORSOrigins,
             displayOrder: this.#displayOrder,
-            description: this.#description,
+            description: this.#activityState.description,
             kind: OIDCClientCrd,
         }
     }
@@ -100,19 +94,14 @@ class OIDCClient {
         this.#uri = incomingClient.spec.uri
         this.#displayName = incomingClient.spec.displayName
         this.#resourceVersion = incomingClient.metadata.resourceVersion
-        this.#status = {...this.#status, ...incomingClient.status}
         this.#uid = incomingClient.metadata.uid
         this.#pkce = incomingClient.spec.pkce ?? true
-        this.#conditions = incomingClient.status?.conditions ?? []
         this.#secretMetadata = incomingClient.spec?.secretMetadata ?? {}
         this.#secretRefreshJobSpec = incomingClient.spec?.secretRefreshJobSpec ?? null // TODO: validate
         this.#allowedCORSOrigins = incomingClient.spec?.allowedCORSOrigins
         this.#displayOrder = incomingClient.spec?.displayOrder ?? 0
-        this.#description = incomingClient.metadata?.annotations?.['kubernetes.io/description'] ?? null
         this.#disabled = incomingClient.spec?.disabled === true
-        this.#lastUsedAt = incomingClient.status?.lastUsedAt ?? null
-        this.#creationTimestamp = incomingClient.metadata?.creationTimestamp ?? null
-        this.#generation = incomingClient.metadata?.generation ?? null
+        this.#activityState = new ClientActivityState(incomingClient)
         return this
     }
 
@@ -149,11 +138,11 @@ class OIDCClient {
     }
 
     getConditions() {
-        return this.#conditions
+        return this.#activityState.conditions
     }
 
     setConditions(conditions) {
-        this.#conditions = conditions
+        this.#activityState.conditions = conditions
         return this
     }
 
@@ -184,7 +173,7 @@ class OIDCClient {
     }
 
     getInstance() {
-        return this.#status.instance
+        return this.#activityState.status.instance
     }
 
     getClientName() {
@@ -199,50 +188,30 @@ class OIDCClient {
         return this.#resourceVersion
     }
 
-    getGeneration() {
-        return this.#generation
-    }
-
     isDisabled() {
         return this.#disabled
     }
 
     getLastUsedAt() {
-        return this.#lastUsedAt
+        return this.#activityState.lastUsedAt
     }
 
     setLastUsedAt(lastUsedAt) {
-        this.#lastUsedAt = lastUsedAt
+        this.#activityState.lastUsedAt = lastUsedAt
         return this
     }
 
     getIntendedStatus() {
-        return {
-            ...this.#status,
-            instance: this.#status.instance,
-            lastUsedAt: this.#lastUsedAt,
-            conditions: this.#conditions,
-        }
+        return this.#activityState.getIntendedStatus()
     }
 
     updateActivityCondition(now, inactiveAfterDays) {
-        const reference = this.#lastUsedAt ?? this.#creationTimestamp
-        if (!reference) return this
-        const inactive = now.getTime() - new Date(reference).getTime() >= inactiveAfterDays * 86400000
-        const previous = this.#conditions.find(condition => condition.type === 'Inactive')
-        const condition = {
-            type: 'Inactive',
-            status: inactive ? 'True' : 'False',
-            reason: inactive ? 'NotUsedRecently' : 'RecentlyUsed',
-            message: inactive
-                ? `Client has not been used for at least ${inactiveAfterDays} days`
-                : `Client was used within the last ${inactiveAfterDays} days`,
-            lastTransitionTime: previous?.status === (inactive ? 'True' : 'False')
-                ? previous.lastTransitionTime
-                : now.toISOString(),
-        }
-        this.#conditions = [...this.#conditions.filter(item => item.type !== 'Inactive'), condition]
+        this.#activityState.updateActivityCondition(now, inactiveAfterDays)
         return this
+    }
+
+    getReconcileFingerprint() {
+        return this.#activityState.getReconcileFingerprint()
     }
 
     // Build the secret-refresh Job from the user-supplied JobSpec. Using a Job

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -50,6 +50,10 @@ class OIDCClient {
     #secretRefreshJobSpec = null
     #displayOrder = 0
     #description = null
+    #disabled = false
+    #lastUsedAt = null
+    #creationTimestamp = null
+    #generation = null
 
     constructor() {
     }
@@ -58,7 +62,7 @@ class OIDCClient {
         return {
             client_id: this.getClientId(),
             client_name: this.#clientName,
-            client_namespace: this.#clientNamespace,
+            clientNamespace: this.#clientNamespace,
             client_secret: this.#clientSecret,
             grant_types: this.#grantTypes,
             token_endpoint_auth_method: this.#tokenEndpointAuthMethod,
@@ -76,6 +80,7 @@ class OIDCClient {
             allowedCORSOrigins: this.#allowedCORSOrigins,
             displayOrder: this.#displayOrder,
             description: this.#description,
+            kind: OIDCClientCrd,
         }
     }
 
@@ -104,6 +109,10 @@ class OIDCClient {
         this.#allowedCORSOrigins = incomingClient.spec?.allowedCORSOrigins
         this.#displayOrder = incomingClient.spec?.displayOrder ?? 0
         this.#description = incomingClient.metadata?.annotations?.['kubernetes.io/description'] ?? null
+        this.#disabled = incomingClient.spec?.disabled === true
+        this.#lastUsedAt = incomingClient.status?.lastUsedAt ?? null
+        this.#creationTimestamp = incomingClient.metadata?.creationTimestamp ?? null
+        this.#generation = incomingClient.metadata?.generation ?? null
         return this
     }
 
@@ -170,6 +179,10 @@ class OIDCClient {
         return OIDCClientId(this.#clientNamespace, this.#clientName)
     }
 
+    getKind() {
+        return OIDCClientCrd
+    }
+
     getInstance() {
         return this.#status.instance
     }
@@ -184,6 +197,52 @@ class OIDCClient {
 
     getResourceVersion() {
         return this.#resourceVersion
+    }
+
+    getGeneration() {
+        return this.#generation
+    }
+
+    isDisabled() {
+        return this.#disabled
+    }
+
+    getLastUsedAt() {
+        return this.#lastUsedAt
+    }
+
+    setLastUsedAt(lastUsedAt) {
+        this.#lastUsedAt = lastUsedAt
+        return this
+    }
+
+    getIntendedStatus() {
+        return {
+            ...this.#status,
+            instance: this.#status.instance,
+            lastUsedAt: this.#lastUsedAt,
+            conditions: this.#conditions,
+        }
+    }
+
+    updateActivityCondition(now, inactiveAfterDays) {
+        const reference = this.#lastUsedAt ?? this.#creationTimestamp
+        if (!reference) return this
+        const inactive = now.getTime() - new Date(reference).getTime() >= inactiveAfterDays * 86400000
+        const previous = this.#conditions.find(condition => condition.type === 'Inactive')
+        const condition = {
+            type: 'Inactive',
+            status: inactive ? 'True' : 'False',
+            reason: inactive ? 'NotUsedRecently' : 'RecentlyUsed',
+            message: inactive
+                ? `Client has not been used for at least ${inactiveAfterDays} days`
+                : `Client was used within the last ${inactiveAfterDays} days`,
+            lastTransitionTime: previous?.status === (inactive ? 'True' : 'False')
+                ? previous.lastTransitionTime
+                : now.toISOString(),
+        }
+        this.#conditions = [...this.#conditions.filter(item => item.type !== 'Inactive'), condition]
+        return this
     }
 
     // Build the secret-refresh Job from the user-supplied JobSpec. Using a Job

--- a/src/models/oidc-middleware-client.js
+++ b/src/models/oidc-middleware-client.js
@@ -25,6 +25,10 @@ export default class OIDCMiddlewareClient {
     #conditions = []
     #displayOrder = 0
     #description = null
+    #disabled = false
+    #lastUsedAt = null
+    #creationTimestamp = null
+    #generation = null
 
     fromIncomingClient(incomingClient) {
         this.#clientName = incomingClient.metadata.name
@@ -39,6 +43,10 @@ export default class OIDCMiddlewareClient {
         this.#conditions = incomingClient.status?.conditions ?? []
         this.#displayOrder = incomingClient.spec?.displayOrder ?? 0
         this.#description = incomingClient.metadata?.annotations?.['kubernetes.io/description'] ?? null
+        this.#disabled = incomingClient.spec?.disabled === true
+        this.#lastUsedAt = incomingClient.status?.lastUsedAt ?? null
+        this.#creationTimestamp = incomingClient.metadata?.creationTimestamp ?? null
+        this.#generation = incomingClient.metadata?.generation ?? null
         return this
     }
 
@@ -46,7 +54,7 @@ export default class OIDCMiddlewareClient {
         return {
             client_id: this.getClientId(),
             client_name: this.#clientName,
-            client_namespace: this.#clientNamespace,
+            clientNamespace: this.#clientNamespace,
             client_secret: randomUUID(),
             grant_types: [ grantType ],
             response_types: [ responseType ],
@@ -84,6 +92,10 @@ export default class OIDCMiddlewareClient {
         return OIDCMiddlewareClientId(this.#clientNamespace, this.#clientName)
     }
 
+    getKind() {
+        return OIDCMiddlewareClientCrd
+    }
+
     getClientName() {
         return this.#clientName
     }
@@ -94,6 +106,50 @@ export default class OIDCMiddlewareClient {
 
     getResourceVersion() {
         return this.#resourceVersion
+    }
+
+    getGeneration() {
+        return this.#generation
+    }
+
+    isDisabled() {
+        return this.#disabled
+    }
+
+    getLastUsedAt() {
+        return this.#lastUsedAt
+    }
+
+    setLastUsedAt(lastUsedAt) {
+        this.#lastUsedAt = lastUsedAt
+        return this
+    }
+
+    getIntendedStatus() {
+        return {
+            ...this.#status,
+            lastUsedAt: this.#lastUsedAt,
+            conditions: this.#conditions,
+        }
+    }
+
+    updateActivityCondition(now, inactiveAfterDays) {
+        const reference = this.#lastUsedAt ?? this.#creationTimestamp
+        if (!reference) return this
+        const inactive = now.getTime() - new Date(reference).getTime() >= inactiveAfterDays * 86400000
+        const previous = this.#conditions.find(condition => condition.type === 'Inactive')
+        const status = inactive ? 'True' : 'False'
+        const condition = {
+            type: 'Inactive',
+            status,
+            reason: inactive ? 'NotUsedRecently' : 'RecentlyUsed',
+            message: inactive
+                ? `Client has not been used for at least ${inactiveAfterDays} days`
+                : `Client was used within the last ${inactiveAfterDays} days`,
+            lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : now.toISOString(),
+        }
+        this.#conditions = [...this.#conditions.filter(item => item.type !== 'Inactive'), condition]
+        return this
     }
 
     getInstance() {

--- a/src/models/oidc-middleware-client.js
+++ b/src/models/oidc-middleware-client.js
@@ -5,6 +5,7 @@ import {
     TraefikMiddlewareForwardAuthAddress
 } from "../utils/kubernetes/kube-constants.js";
 import {randomUUID} from "crypto";
+import {ClientActivityState} from './client-activity-state.js';
 
 export const grantType = 'implicit'
 export const responseType = 'id_token'
@@ -18,17 +19,10 @@ export default class OIDCMiddlewareClient {
     #uri = null
     #displayName = null
     #resourceVersion = null
-    #status = {
-        instance: null
-    }
     #uid = null
-    #conditions = []
     #displayOrder = 0
-    #description = null
     #disabled = false
-    #lastUsedAt = null
-    #creationTimestamp = null
-    #generation = null
+    #activityState = null
 
     fromIncomingClient(incomingClient) {
         this.#clientName = incomingClient.metadata.name
@@ -38,15 +32,10 @@ export default class OIDCMiddlewareClient {
         this.#uri = incomingClient.spec.uri
         this.#displayName = incomingClient.spec.displayName
         this.#resourceVersion = incomingClient.metadata.resourceVersion
-        this.#status = {...this.#status, ...incomingClient.status}
         this.#uid = incomingClient.metadata.uid
-        this.#conditions = incomingClient.status?.conditions ?? []
         this.#displayOrder = incomingClient.spec?.displayOrder ?? 0
-        this.#description = incomingClient.metadata?.annotations?.['kubernetes.io/description'] ?? null
         this.#disabled = incomingClient.spec?.disabled === true
-        this.#lastUsedAt = incomingClient.status?.lastUsedAt ?? null
-        this.#creationTimestamp = incomingClient.metadata?.creationTimestamp ?? null
-        this.#generation = incomingClient.metadata?.generation ?? null
+        this.#activityState = new ClientActivityState(incomingClient)
         return this
     }
 
@@ -64,7 +53,7 @@ export default class OIDCMiddlewareClient {
             uri: this.#uri,
             displayName: this.#displayName,
             displayOrder: this.#displayOrder,
-            description: this.#description,
+            description: this.#activityState.description,
             kind: OIDCMiddlewareClientCrd
         }
     }
@@ -80,11 +69,11 @@ export default class OIDCMiddlewareClient {
     }
 
     getConditions() {
-        return this.#conditions
+        return this.#activityState.conditions
     }
 
     setConditions(conditions) {
-        this.#conditions = conditions
+        this.#activityState.conditions = conditions
         return this
     }
 
@@ -108,52 +97,34 @@ export default class OIDCMiddlewareClient {
         return this.#resourceVersion
     }
 
-    getGeneration() {
-        return this.#generation
-    }
-
     isDisabled() {
         return this.#disabled
     }
 
     getLastUsedAt() {
-        return this.#lastUsedAt
+        return this.#activityState.lastUsedAt
     }
 
     setLastUsedAt(lastUsedAt) {
-        this.#lastUsedAt = lastUsedAt
+        this.#activityState.lastUsedAt = lastUsedAt
         return this
     }
 
     getIntendedStatus() {
-        return {
-            ...this.#status,
-            lastUsedAt: this.#lastUsedAt,
-            conditions: this.#conditions,
-        }
+        return this.#activityState.getIntendedStatus()
     }
 
     updateActivityCondition(now, inactiveAfterDays) {
-        const reference = this.#lastUsedAt ?? this.#creationTimestamp
-        if (!reference) return this
-        const inactive = now.getTime() - new Date(reference).getTime() >= inactiveAfterDays * 86400000
-        const previous = this.#conditions.find(condition => condition.type === 'Inactive')
-        const status = inactive ? 'True' : 'False'
-        const condition = {
-            type: 'Inactive',
-            status,
-            reason: inactive ? 'NotUsedRecently' : 'RecentlyUsed',
-            message: inactive
-                ? `Client has not been used for at least ${inactiveAfterDays} days`
-                : `Client was used within the last ${inactiveAfterDays} days`,
-            lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : now.toISOString(),
-        }
-        this.#conditions = [...this.#conditions.filter(item => item.type !== 'Inactive'), condition]
+        this.#activityState.updateActivityCondition(now, inactiveAfterDays)
         return this
     }
 
+    getReconcileFingerprint() {
+        return this.#activityState.getReconcileFingerprint()
+    }
+
     getInstance() {
-        return this.#status.instance
+        return this.#activityState.status.instance
     }
 
     getMetadata() {

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -7,6 +7,7 @@ import RedisAdapter from "../adapters/redis.js";
 import {KubernetesAdapter} from "../adapters/kubernetes.js";
 import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 import {getActivityTracker} from "../services/activity-tracker.js";
+import {ClientReconcileState} from '../models/client-activity-state.js';
 
 export class KubeOIDCClientOperator {
     constructor(provider, adapter = new KubernetesAdapter()) {
@@ -14,8 +15,7 @@ export class KubeOIDCClientOperator {
         this.provider = provider
         this.adapter = adapter
         this.instance = this.adapter.instance
-        this.activityTracker = getActivityTracker()
-        this.reconciledGenerations = new Map()
+        this.reconcileState = new ClientReconcileState(getActivityTracker())
     }
 
     async watchClients() {
@@ -31,8 +31,7 @@ export class KubeOIDCClientOperator {
     }
 
     async #createOIDCClient (OIDCClient) {
-        this.activityTracker.registerClient(OIDCClient)
-        this.reconciledGenerations.set(OIDCClient.getClientId(), OIDCClient.getGeneration())
+        this.reconcileState.register(OIDCClient)
         if (OIDCClient.getInstance() === this.instance) {
             if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
                 let secret = await this.adapter.getSecret(
@@ -78,12 +77,7 @@ export class KubeOIDCClientOperator {
     }
 
     async #updateOIDCClient(OIDCClient) {
-        this.activityTracker.registerClient(OIDCClient)
-        const previousGeneration = this.reconciledGenerations.get(OIDCClient.getClientId())
-        if (OIDCClient.getGeneration() !== null && previousGeneration === OIDCClient.getGeneration()) {
-            return
-        }
-        this.reconciledGenerations.set(OIDCClient.getClientId(), OIDCClient.getGeneration())
+        if (!this.reconcileState.shouldReconcile(OIDCClient)) return
         if (OIDCClient.isDisabled()) {
             await this.redisAdapter.destroy(OIDCClient.getClientId())
             return
@@ -139,8 +133,7 @@ export class KubeOIDCClientOperator {
     }
 
     async #deleteOIDCClient (OIDCClient) {
-        this.activityTracker.unregisterClient(OIDCClient.getClientId())
-        this.reconciledGenerations.delete(OIDCClient.getClientId())
+        this.reconcileState.unregister(OIDCClient)
         if (OIDCClient.getInstance() === this.instance) {
             await this.redisAdapter.destroy(OIDCClient.getClientId())
         }

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -6,6 +6,7 @@ import {
 import RedisAdapter from "../adapters/redis.js";
 import {KubernetesAdapter} from "../adapters/kubernetes.js";
 import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
+import {getActivityTracker} from "../services/activity-tracker.js";
 
 export class KubeOIDCClientOperator {
     constructor(provider, adapter = new KubernetesAdapter()) {
@@ -13,6 +14,8 @@ export class KubeOIDCClientOperator {
         this.provider = provider
         this.adapter = adapter
         this.instance = this.adapter.instance
+        this.activityTracker = getActivityTracker()
+        this.reconciledGenerations = new Map()
     }
 
     async watchClients() {
@@ -28,6 +31,8 @@ export class KubeOIDCClientOperator {
     }
 
     async #createOIDCClient (OIDCClient) {
+        this.activityTracker.registerClient(OIDCClient)
+        this.reconciledGenerations.set(OIDCClient.getClientId(), OIDCClient.getGeneration())
         if (OIDCClient.getInstance() === this.instance) {
             if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
                 let secret = await this.adapter.getSecret(
@@ -53,15 +58,15 @@ export class KubeOIDCClientOperator {
                 await this.#createKubeSecret(OIDCClient)
             }
         }
-        if (OIDCClient.hasSecret()) {
+        if (OIDCClient.isDisabled()) {
+            await this.redisAdapter.destroy(OIDCClient.getClientId())
+        } else if (OIDCClient.hasSecret()) {
             await this.redisAdapter.upsert(OIDCClient.getClientId(), OIDCClient.toRedis())
         }
     }
 
     async #replaceClientStatus (OIDCClient) {
-        const status = {
-            instance: this.instance,
-        }
+        const status = {...OIDCClient.getIntendedStatus(), instance: this.instance}
         return await this.adapter.replaceNamespacedCustomObjectStatus(
             OIDCClientCrd,
             OIDCClient.getClientNamespace(),
@@ -73,6 +78,16 @@ export class KubeOIDCClientOperator {
     }
 
     async #updateOIDCClient(OIDCClient) {
+        this.activityTracker.registerClient(OIDCClient)
+        const previousGeneration = this.reconciledGenerations.get(OIDCClient.getClientId())
+        if (OIDCClient.getGeneration() !== null && previousGeneration === OIDCClient.getGeneration()) {
+            return
+        }
+        this.reconciledGenerations.set(OIDCClient.getClientId(), OIDCClient.getGeneration())
+        if (OIDCClient.isDisabled()) {
+            await this.redisAdapter.destroy(OIDCClient.getClientId())
+            return
+        }
         await new Promise(res => setTimeout(res, 1000));
         let secret = await this.adapter.getSecret(
             OIDCClient.getClientNamespace(),
@@ -124,6 +139,8 @@ export class KubeOIDCClientOperator {
     }
 
     async #deleteOIDCClient (OIDCClient) {
+        this.activityTracker.unregisterClient(OIDCClient.getClientId())
+        this.reconciledGenerations.delete(OIDCClient.getClientId())
         if (OIDCClient.getInstance() === this.instance) {
             await this.redisAdapter.destroy(OIDCClient.getClientId())
         }

--- a/src/operators/kube-oidc-middleware-client-operator.js
+++ b/src/operators/kube-oidc-middleware-client-operator.js
@@ -7,6 +7,7 @@ import {
 import OidcMiddlewareClient from "../models/oidc-middleware-client.js";
 import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 import {Claimed} from "../conditions/claimed.js";
+import {getActivityTracker} from '../services/activity-tracker.js';
 
 export class KubeOIDCMiddlewareClientOperator {
     constructor(provider, adapter = new KubernetesAdapter()) {
@@ -14,6 +15,8 @@ export class KubeOIDCMiddlewareClientOperator {
         this.provider = provider
         this.adapter = adapter
         this.instance = this.adapter.instance
+        this.activityTracker = getActivityTracker()
+        this.reconciledGenerations = new Map()
     }
 
     async watchClients() {
@@ -29,22 +32,33 @@ export class KubeOIDCMiddlewareClientOperator {
     }
 
     async #createOIDCClient (OIDCMiddlewareClient) {
+        this.activityTracker.registerClient(OIDCMiddlewareClient)
+        this.reconciledGenerations.set(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.getGeneration())
         if (OIDCMiddlewareClient.getInstance() === this.instance) {
             if (!await this.redisAdapter.find(OIDCMiddlewareClient.getClientId())) {
                 await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
-                await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
+                if (!OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
             }
         } else if (!OIDCMiddlewareClient.getInstance()) {
             // Claim that client
             const claimedClient = await this.#replaceClientStatus(OIDCMiddlewareClient)
             if (claimedClient?.getInstance() === this.instance) {
                 await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
-                await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
+                if (!OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
             }
         }
+        if (OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
     }
 
     async #updateOIDCClient(OIDCMiddlewareClient) {
+        this.activityTracker.registerClient(OIDCMiddlewareClient)
+        const previousGeneration = this.reconciledGenerations.get(OIDCMiddlewareClient.getClientId())
+        if (OIDCMiddlewareClient.getGeneration() !== null && previousGeneration === OIDCMiddlewareClient.getGeneration()) return
+        this.reconciledGenerations.set(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.getGeneration())
+        if (OIDCMiddlewareClient.isDisabled()) {
+            await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
+            return
+        }
         await new Promise(res => setTimeout(res, 1000)); // Wait second as the client is momentarily updated after creation, resulting 404.
         await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
         await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
@@ -52,6 +66,8 @@ export class KubeOIDCMiddlewareClientOperator {
     }
 
     async #deleteOIDCClient (OIDCMiddlewareClient) {
+        this.activityTracker.unregisterClient(OIDCMiddlewareClient.getClientId())
+        this.reconciledGenerations.delete(OIDCMiddlewareClient.getClientId())
         if (OIDCMiddlewareClient.getInstance() === this.instance) {
             await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
         }
@@ -96,10 +112,7 @@ export class KubeOIDCMiddlewareClientOperator {
 
     async #replaceClientStatus (OIDCMiddlewareClient) {
         OIDCMiddlewareClient = new Claimed().setStatus(true).set(OIDCMiddlewareClient)
-        const status = {
-            instance: this.instance,
-            conditions: OIDCMiddlewareClient.getConditions(),
-        }
+        const status = {...OIDCMiddlewareClient.getIntendedStatus(), instance: this.instance}
         return await this.adapter.replaceNamespacedCustomObjectStatus(
             OIDCMiddlewareClientCrd,
             OIDCMiddlewareClient.getClientNamespace(),

--- a/src/operators/kube-oidc-middleware-client-operator.js
+++ b/src/operators/kube-oidc-middleware-client-operator.js
@@ -8,6 +8,7 @@ import OidcMiddlewareClient from "../models/oidc-middleware-client.js";
 import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 import {Claimed} from "../conditions/claimed.js";
 import {getActivityTracker} from '../services/activity-tracker.js';
+import {ClientReconcileState} from '../models/client-activity-state.js';
 
 export class KubeOIDCMiddlewareClientOperator {
     constructor(provider, adapter = new KubernetesAdapter()) {
@@ -15,8 +16,7 @@ export class KubeOIDCMiddlewareClientOperator {
         this.provider = provider
         this.adapter = adapter
         this.instance = this.adapter.instance
-        this.activityTracker = getActivityTracker()
-        this.reconciledGenerations = new Map()
+        this.reconcileState = new ClientReconcileState(getActivityTracker())
     }
 
     async watchClients() {
@@ -32,8 +32,7 @@ export class KubeOIDCMiddlewareClientOperator {
     }
 
     async #createOIDCClient (OIDCMiddlewareClient) {
-        this.activityTracker.registerClient(OIDCMiddlewareClient)
-        this.reconciledGenerations.set(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.getGeneration())
+        this.reconcileState.register(OIDCMiddlewareClient)
         if (OIDCMiddlewareClient.getInstance() === this.instance) {
             if (!await this.redisAdapter.find(OIDCMiddlewareClient.getClientId())) {
                 await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
@@ -51,10 +50,7 @@ export class KubeOIDCMiddlewareClientOperator {
     }
 
     async #updateOIDCClient(OIDCMiddlewareClient) {
-        this.activityTracker.registerClient(OIDCMiddlewareClient)
-        const previousGeneration = this.reconciledGenerations.get(OIDCMiddlewareClient.getClientId())
-        if (OIDCMiddlewareClient.getGeneration() !== null && previousGeneration === OIDCMiddlewareClient.getGeneration()) return
-        this.reconciledGenerations.set(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.getGeneration())
+        if (!this.reconcileState.shouldReconcile(OIDCMiddlewareClient)) return
         if (OIDCMiddlewareClient.isDisabled()) {
             await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
             return
@@ -66,8 +62,7 @@ export class KubeOIDCMiddlewareClientOperator {
     }
 
     async #deleteOIDCClient (OIDCMiddlewareClient) {
-        this.activityTracker.unregisterClient(OIDCMiddlewareClient.getClientId())
-        this.reconciledGenerations.delete(OIDCMiddlewareClient.getClientId())
+        this.reconcileState.unregister(OIDCMiddlewareClient)
         if (OIDCMiddlewareClient.getInstance() === this.instance) {
             await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
         }

--- a/src/providers/setup-event-listeners.js
+++ b/src/providers/setup-event-listeners.js
@@ -5,11 +5,33 @@ import handleOidcFlowMetrics, {
     nonExistentClientError, tokenError,
     userinfoError
 } from "../utils/session/handle-oidc-flow-metrics.js";
+import AuditService from '../services/audit-service.js';
+import {getActivityTracker} from '../services/activity-tracker.js';
+
+function activityFromContext(ctx) {
+    const client = ctx?.oidc?.client
+    const entities = ctx?.oidc?.entities ?? {}
+    const accountId = ctx?.oidc?.account?.accountId
+        ?? ctx?.oidc?.session?.accountId
+        ?? entities.AuthorizationCode?.accountId
+        ?? entities.RefreshToken?.accountId
+        ?? entities.AccessToken?.accountId
+    if (!client?.clientId) return undefined
+    return {
+        accountId,
+        clientId: client.clientId,
+        clientNamespace: client.clientNamespace,
+        clientName: client.clientName,
+        clientKind: client.kind,
+    }
+}
 
 export default (provider) => {
     // https://github.com/panva/node-oidc-provider/blob/v8.x/docs/events.md
 
     const logger = globalThis.logger
+    const audit = new AuditService(logger)
+    const activityTracker = getActivityTracker()
 
     // Logging
     provider.on('access_token.destroyed', (token) => {
@@ -25,7 +47,7 @@ export default (provider) => {
     })
 
     provider.on('authorization_code.consumed', (code) => {
-        logger.info({code}, 'Client consumed authorization code')
+        logger.debug({clientId: code.clientId, accountId: code.accountId}, 'Client consumed authorization code')
     })
 
     provider.on('authorization_code.destroyed', (code) => {
@@ -47,6 +69,21 @@ export default (provider) => {
 
     provider.on('authorization.success', (ctx) => {
         logger.debug({ctx}, 'authorization.success')
+        const activity = activityFromContext(ctx)
+        if (activity) {
+            activityTracker.record(activity)
+            audit.write({
+                event: 'application.login.succeeded',
+                result: 'success',
+                subject: {id: activity.accountId},
+                client: {
+                    id: activity.clientId,
+                    namespace: activity.clientNamespace,
+                    name: activity.clientName,
+                    kind: activity.clientKind,
+                },
+            }, ctx)
+        }
     })
 
     provider.on('backchannel.error', (ctx, error, client, accountId, sid) => {
@@ -108,6 +145,22 @@ export default (provider) => {
 
     provider.on('grant.success', (ctx) => {
         logger.debug({ctx}, 'grant.success')
+        const activity = activityFromContext(ctx)
+        if (activity) {
+            activityTracker.record({...activity, userAuthenticated: false})
+            audit.write({
+                event: 'token.exchange.succeeded',
+                result: 'success',
+                grantType: ctx?.oidc?.params?.grant_type,
+                subject: {id: activity.accountId},
+                client: {
+                    id: activity.clientId,
+                    namespace: activity.clientNamespace,
+                    name: activity.clientName,
+                    kind: activity.clientKind,
+                },
+            }, ctx)
+        }
     })
 
     provider.on('initial_access_token.destroyed', (token) => {
@@ -163,7 +216,7 @@ export default (provider) => {
     })
 
     provider.on('refresh_token.consumed', (token) => {
-        logger.info({token}, 'Client consumed refresh token')
+        logger.debug({clientId: token.clientId, accountId: token.accountId}, 'Client consumed refresh token')
     })
 
     provider.on('refresh_token.destroyed', (token) => {

--- a/src/routes/metrics-server.js
+++ b/src/routes/metrics-server.js
@@ -1,4 +1,4 @@
-import {collectDefaultMetrics, register} from "prom-client";
+import {collectDefaultMetrics, Gauge, register} from "prom-client";
 import Koa from 'koa';
 import Router from "@koa/router";
 import { setupOidcMetrics } from "../utils/session/handle-oidc-flow-metrics.js";
@@ -27,6 +27,11 @@ export default async () => {
         deployment: process.env.DEPLOYMENT_NAME,
     })
     globalThis.metrics = {}
+    globalThis.metrics.oidcClientLastUsed = new Gauge({
+        name: 'passmower_oidc_client_last_used_timestamp_seconds',
+        help: 'Unix timestamp of the latest successful OIDC activity for a client, or zero if never used',
+        labelNames: ['kind', 'namespace', 'client'],
+    })
     setupOidcMetrics()
 
     const userService = new KubeOIDCUserService();

--- a/src/services/activity-tracker.js
+++ b/src/services/activity-tracker.js
@@ -18,6 +18,12 @@ function newer(a, b) {
     return new Date(a) >= new Date(b) ? a : b
 }
 
+function newestActivity(a, b) {
+    if (!a) return b
+    if (!b) return a
+    return newer(a.lastAuthenticatedAt, b.lastAuthenticatedAt) === a.lastAuthenticatedAt ? a : b
+}
+
 export class ActivityTracker {
     constructor({adapter = new KubernetesAdapter(), now = () => new Date()} = {}) {
         this.adapter = adapter
@@ -49,6 +55,14 @@ export class ActivityTracker {
     }
 
     unregisterClient(clientId) {
+        const client = this.knownClients.get(clientId)
+        if (client) {
+            globalThis.metrics?.oidcClientLastUsed?.remove({
+                kind: client.clientKind,
+                namespace: client.clientNamespace,
+                client: client.clientName,
+            })
+        }
         this.knownClients.delete(clientId)
     }
 
@@ -71,19 +85,32 @@ export class ActivityTracker {
         const clients = this.pendingClients
         this.pendingUsers = new Map()
         this.pendingClients = new Map()
-        try {
-            for (const [accountId, applications] of users) await this.#flushUser(accountId, applications)
-            const clientIds = new Set([...this.knownClients.keys(), ...clients.keys()])
-            for (const clientId of clientIds) await this.#flushClient(clientId, clients.get(clientId))
-        } catch (err) {
-            for (const [accountId, applications] of users) {
+        const errors = []
+        for (const [accountId, applications] of users) {
+            try {
+                await this.#flushUser(accountId, applications)
+            } catch (err) {
                 const pending = this.pendingUsers.get(accountId) ?? new Map()
-                for (const [clientId, app] of applications) pending.set(clientId, app)
+                for (const [clientId, app] of applications) {
+                    pending.set(clientId, newestActivity(pending.get(clientId), app))
+                }
                 this.pendingUsers.set(accountId, pending)
+                errors.push(err)
             }
-            for (const [clientId, client] of clients) this.pendingClients.set(clientId, client)
-            throw err
         }
+        const clientIds = new Set([...this.knownClients.keys(), ...clients.keys()])
+        for (const clientId of clientIds) {
+            try {
+                await this.#flushClient(clientId, clients.get(clientId))
+            } catch (err) {
+                const activity = clients.get(clientId)
+                if (activity) {
+                    this.pendingClients.set(clientId, newestActivity(this.pendingClients.get(clientId), activity))
+                }
+                errors.push(err)
+            }
+        }
+        if (errors.length) throw new AggregateError(errors, `Failed to flush ${errors.length} OIDC activity projection(s)`)
     }
 
     async #flushUser(accountId, applications) {

--- a/src/services/activity-tracker.js
+++ b/src/services/activity-tracker.js
@@ -1,0 +1,149 @@
+import {OIDCClientCrd, OIDCMiddlewareClientCrd, OIDCUserCrd} from '../utils/kubernetes/kube-constants.js';
+import Account from '../models/account.js';
+import OidcClient from '../models/oidc-client.js';
+import OidcMiddlewareClient from '../models/oidc-middleware-client.js';
+import {KubernetesAdapter} from '../adapters/kubernetes.js';
+
+const DEFAULT_FLUSH_INTERVAL_SECONDS = 900
+const DEFAULT_RECENT_APPLICATION_LIMIT = 20
+
+function intEnv(name, fallback) {
+    const value = Number.parseInt(process.env[name] ?? '', 10)
+    return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function newer(a, b) {
+    if (!a) return b
+    if (!b) return a
+    return new Date(a) >= new Date(b) ? a : b
+}
+
+export class ActivityTracker {
+    constructor({adapter = new KubernetesAdapter(), now = () => new Date()} = {}) {
+        this.adapter = adapter
+        this.now = now
+        this.pendingUsers = new Map()
+        this.pendingClients = new Map()
+        this.knownClients = new Map()
+        this.timer = null
+    }
+
+    record({accountId, clientId, clientNamespace, clientName, clientKind = OIDCClientCrd, userAuthenticated = true, timestamp = this.now().toISOString()}) {
+        if (!clientId || !clientNamespace || !clientName) return
+        const client = {clientId, clientNamespace, clientName, clientKind, lastAuthenticatedAt: timestamp}
+        this.pendingClients.set(clientId, {...client, lastAuthenticatedAt: newer(this.pendingClients.get(clientId)?.lastAuthenticatedAt, timestamp)})
+        if (accountId && userAuthenticated) {
+            const applications = this.pendingUsers.get(accountId) ?? new Map()
+            applications.set(clientId, {...client, lastAuthenticatedAt: newer(applications.get(clientId)?.lastAuthenticatedAt, timestamp)})
+            this.pendingUsers.set(accountId, applications)
+        }
+    }
+
+    registerClient(client) {
+        this.knownClients.set(client.getClientId(), {
+            clientId: client.getClientId(),
+            clientNamespace: client.getClientNamespace(),
+            clientName: client.getClientName(),
+            clientKind: client.getKind(),
+        })
+    }
+
+    unregisterClient(clientId) {
+        this.knownClients.delete(clientId)
+    }
+
+    start() {
+        if (process.env.ACTIVITY_TRACKING_ENABLED === 'false' || this.timer) return
+        this.timer = setInterval(() => this.flush().catch(err => {
+            globalThis.logger?.error({err}, 'Failed to flush OIDC activity')
+        }), intEnv('ACTIVITY_FLUSH_INTERVAL_SECONDS', DEFAULT_FLUSH_INTERVAL_SECONDS) * 1000)
+        this.timer.unref()
+    }
+
+    stop() {
+        clearInterval(this.timer)
+        this.timer = null
+    }
+
+    async flush() {
+        if (process.env.ACTIVITY_TRACKING_ENABLED === 'false') return
+        const users = this.pendingUsers
+        const clients = this.pendingClients
+        this.pendingUsers = new Map()
+        this.pendingClients = new Map()
+        try {
+            for (const [accountId, applications] of users) await this.#flushUser(accountId, applications)
+            const clientIds = new Set([...this.knownClients.keys(), ...clients.keys()])
+            for (const clientId of clientIds) await this.#flushClient(clientId, clients.get(clientId))
+        } catch (err) {
+            for (const [accountId, applications] of users) {
+                const pending = this.pendingUsers.get(accountId) ?? new Map()
+                for (const [clientId, app] of applications) pending.set(clientId, app)
+                this.pendingUsers.set(accountId, pending)
+            }
+            for (const [clientId, client] of clients) this.pendingClients.set(clientId, client)
+            throw err
+        }
+    }
+
+    async #flushUser(accountId, applications) {
+        const account = await this.adapter.getNamespacedCustomObject(
+            OIDCUserCrd, this.adapter.namespace, accountId,
+            raw => new Account().fromKubernetes(raw)
+        )
+        if (!account) return
+        const merged = new Map(account.getRecentApplications().map(app => [app.clientId, app]))
+        for (const [clientId, app] of applications) {
+            const previous = merged.get(clientId)
+            merged.set(clientId, {...app, lastAuthenticatedAt: newer(previous?.lastAuthenticatedAt, app.lastAuthenticatedAt)})
+        }
+        const recent = [...merged.values()]
+            .sort((a, b) => new Date(b.lastAuthenticatedAt) - new Date(a.lastAuthenticatedAt))
+            .slice(0, intEnv('ACTIVITY_RECENT_APPLICATION_LIMIT', DEFAULT_RECENT_APPLICATION_LIMIT))
+        account.setRecentApplications(recent)
+        const updated = await this.adapter.replaceNamespacedCustomObjectStatus(
+            OIDCUserCrd, this.adapter.namespace, accountId, account.resourceVersion,
+            account.getIntendedStatus(), raw => new Account().fromKubernetes(raw)
+        )
+        if (!updated) throw new Error(`Failed to update activity status for OIDCUser ${accountId}`)
+    }
+
+    async #flushClient(clientId, activity) {
+        const known = activity ?? this.knownClients.get(clientId)
+        if (!known) return
+        const kind = known.clientKind === OIDCMiddlewareClientCrd ? OIDCMiddlewareClientCrd : OIDCClientCrd
+        const Model = kind === OIDCMiddlewareClientCrd ? OidcMiddlewareClient : OidcClient
+        const client = await this.adapter.getNamespacedCustomObject(
+            kind, known.clientNamespace, known.clientName,
+            raw => new Model().fromIncomingClient(raw)
+        )
+        if (!client) return
+        const previousLastUsedAt = client.getLastUsedAt()
+        const previousConditions = JSON.stringify(client.getConditions())
+        if (activity) client.setLastUsedAt(newer(client.getLastUsedAt(), activity.lastAuthenticatedAt))
+        client.updateActivityCondition(this.now(), intEnv('CLIENT_INACTIVE_AFTER_DAYS', 90))
+        const value = client.getLastUsedAt() ? new Date(client.getLastUsedAt()).getTime() / 1000 : 0
+        globalThis.metrics?.oidcClientLastUsed?.set({kind, namespace: known.clientNamespace, client: known.clientName}, value)
+        const changed = previousLastUsedAt !== client.getLastUsedAt()
+            || previousConditions !== JSON.stringify(client.getConditions())
+        if (changed) {
+            const updated = await this.adapter.replaceNamespacedCustomObjectStatus(
+                kind, known.clientNamespace, known.clientName, client.getResourceVersion(),
+                client.getIntendedStatus(), raw => new Model().fromIncomingClient(raw)
+            )
+            if (!updated) throw new Error(`Failed to update activity status for OIDCClient ${clientId}`)
+        }
+    }
+}
+
+let tracker
+
+export function getActivityTracker(options) {
+    if (!tracker || options) tracker = new ActivityTracker(options)
+    return tracker
+}
+
+export function resetActivityTracker() {
+    tracker?.stop()
+    tracker = undefined
+}

--- a/src/services/audit-service.js
+++ b/src/services/audit-service.js
@@ -1,0 +1,35 @@
+import {randomUUID, createHash} from 'node:crypto';
+import {parseRequestMetadata} from '../utils/session/parse-request-headers.js';
+
+function hash(value) {
+    if (!value) return undefined
+    return createHash('sha256').update(String(value)).digest('hex')
+}
+
+export class AuditService {
+    constructor(logger = globalThis.logger, now = () => new Date()) {
+        this.logger = logger
+        this.now = now
+    }
+
+    write(event, ctx) {
+        if (process.env.AUDIT_ENABLED === 'false') return
+        const request = parseRequestMetadata(ctx?.headers ?? {}, undefined, undefined)
+        const record = {
+            schemaVersion: 1,
+            eventId: randomUUID(),
+            timestamp: this.now().toISOString(),
+            ...event,
+            request: {
+                id: ctx?.state?.requestId ?? ctx?.get?.('x-request-id') ?? undefined,
+                sourceAddress: process.env.AUDIT_INCLUDE_SOURCE_ADDRESS === 'true' ? request?.ip : undefined,
+                userAgent: process.env.AUDIT_INCLUDE_USER_AGENT === 'true' ? ctx?.get?.('user-agent') : undefined,
+            },
+            sessionHash: hash(ctx?.oidc?.session?.jti ?? ctx?.currentSession?.jti),
+        }
+        this.logger?.info({logType: 'audit', audit: record}, event.event)
+        return record
+    }
+}
+
+export default AuditService

--- a/src/services/audit-service.js
+++ b/src/services/audit-service.js
@@ -14,7 +14,11 @@ export class AuditService {
 
     write(event, ctx) {
         if (process.env.AUDIT_ENABLED === 'false') return
-        const request = parseRequestMetadata(ctx?.headers ?? {}, undefined, undefined)
+        const includeSourceAddress = process.env.AUDIT_INCLUDE_SOURCE_ADDRESS === 'true'
+        const includeUserAgent = process.env.AUDIT_INCLUDE_USER_AGENT === 'true'
+        const request = includeSourceAddress
+            ? parseRequestMetadata(ctx?.headers ?? {}, undefined, undefined)
+            : undefined
         const record = {
             schemaVersion: 1,
             eventId: randomUUID(),
@@ -22,8 +26,8 @@ export class AuditService {
             ...event,
             request: {
                 id: ctx?.state?.requestId ?? ctx?.get?.('x-request-id') ?? undefined,
-                sourceAddress: process.env.AUDIT_INCLUDE_SOURCE_ADDRESS === 'true' ? request?.ip : undefined,
-                userAgent: process.env.AUDIT_INCLUDE_USER_AGENT === 'true' ? ctx?.get?.('user-agent') : undefined,
+                sourceAddress: includeSourceAddress ? request?.ip : undefined,
+                userAgent: includeUserAgent ? ctx?.get?.('user-agent') : undefined,
             },
             sessionHash: hash(ctx?.oidc?.session?.jti ?? ctx?.currentSession?.jti),
         }

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -10,9 +10,12 @@ describe('KubeOIDCClientOperator reconciliation', () => {
     let provider, adapter, operator
     const clientRedis = () => new RedisAdapter('Client')
 
-    function rawClient(name, { secretRefreshJobSpec, disabled = false } = {}) {
+    function rawClient(name, { secretRefreshJobSpec, disabled = false, description } = {}) {
         return {
-            metadata: { name, namespace: 'apps', resourceVersion: '1', generation: disabled ? 2 : 1, uid: `uid-${name}`, annotations: {} },
+            metadata: {
+                name, namespace: 'apps', resourceVersion: '1', generation: disabled ? 2 : 1, uid: `uid-${name}`,
+                annotations: description ? {'kubernetes.io/description': description} : {},
+            },
             spec: {
                 grantTypes: ['authorization_code'],
                 responseTypes: ['code'],
@@ -99,6 +102,17 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         const jobs = adapter.jobs.length
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-status')
         expect(adapter.jobs).toHaveLength(jobs)
+    })
+
+    it('reconciles description annotation changes without a generation bump', async () => {
+        adapter.seed('OIDCClient', rawClient('app-description', {description: 'Old description'}))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-description')
+        expect((await clientRedis().find(idOf('app-description'))).description).toBe('Old description')
+
+        adapter.seed('OIDCClient', rawClient('app-description', {description: 'New description'}))
+        await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-description')
+
+        expect((await clientRedis().find(idOf('app-description'))).description).toBe('New description')
     })
 
     it('removes the client from Redis on delete', async () => {

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -10,15 +10,16 @@ describe('KubeOIDCClientOperator reconciliation', () => {
     let provider, adapter, operator
     const clientRedis = () => new RedisAdapter('Client')
 
-    function rawClient(name, { secretRefreshJobSpec } = {}) {
+    function rawClient(name, { secretRefreshJobSpec, disabled = false } = {}) {
         return {
-            metadata: { name, namespace: 'apps', resourceVersion: '1', uid: `uid-${name}`, annotations: {} },
+            metadata: { name, namespace: 'apps', resourceVersion: '1', generation: disabled ? 2 : 1, uid: `uid-${name}`, annotations: {} },
             spec: {
                 grantTypes: ['authorization_code'],
                 responseTypes: ['code'],
                 redirectUris: ['https://app.example.com/cb'],
                 availableScopes: ['openid'],
                 tokenEndpointAuthMethod: 'client_secret_basic',
+                disabled,
                 ...(secretRefreshJobSpec ? { secretRefreshJobSpec } : {}),
             },
             status: {}, // unclaimed
@@ -57,6 +58,10 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         const cached = await clientRedis().find(idOf('app-a'))
         expect(cached).toBeTruthy()
         expect(cached.client_secret).toBeTruthy()
+        const configured = await provider.Client.find(idOf('app-a'))
+        expect(configured.clientNamespace).toBe('apps')
+        expect(configured.clientName).toBe('app-a')
+        expect(configured.kind).toBe('OIDCClient')
     })
 
     it('creates the secretRefreshJob when configured (#69/#70)', async () => {
@@ -81,8 +86,19 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         adapter.seed('OIDCClient', rawClient('app-c', { secretRefreshJobSpec: refreshJobSpec }))
         await adapter.fireWatch('ADDED', 'OIDCClient', 'app-c')
         const afterCreate = adapter.jobs.length
+        const modified = rawClient('app-c', { secretRefreshJobSpec: refreshJobSpec })
+        modified.metadata.generation = 2
+        adapter.seed('OIDCClient', modified)
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-c')
         expect(adapter.jobs.length).toBe(afterCreate + 1)
+    })
+
+    it('does not refresh client material for a status-only update', async () => {
+        adapter.seed('OIDCClient', rawClient('app-status', {secretRefreshJobSpec: refreshJobSpec}))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-status')
+        const jobs = adapter.jobs.length
+        await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-status')
+        expect(adapter.jobs).toHaveLength(jobs)
     })
 
     it('removes the client from Redis on delete', async () => {
@@ -92,5 +108,18 @@ describe('KubeOIDCClientOperator reconciliation', () => {
 
         await adapter.fireWatch('DELETED', 'OIDCClient', 'app-d')
         expect(await clientRedis().find(idOf('app-d'))).toBeUndefined()
+    })
+
+    it('removes a disabled client from Redis without deleting its Secret', async () => {
+        adapter.seed('OIDCClient', rawClient('app-disabled'))
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-disabled')
+        const secret = adapter.secrets.get('apps/oidc-client-app-disabled-owner-secrets')
+        expect(await clientRedis().find(idOf('app-disabled'))).toBeTruthy()
+
+        adapter.seed('OIDCClient', rawClient('app-disabled', {disabled: true}))
+        await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-disabled')
+
+        expect(await clientRedis().find(idOf('app-disabled'))).toBeUndefined()
+        expect(adapter.secrets.get('apps/oidc-client-app-disabled-owner-secrets')).toEqual(secret)
     })
 })

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -69,6 +69,34 @@ describe('Account.getIntendedStatus', () => {
     })
 })
 
+describe('Account.getProfileResponse', () => {
+    const recentApplications = [{
+        clientId: 'apps.grafana',
+        clientNamespace: 'apps',
+        clientName: 'grafana',
+        clientKind: 'OIDCClient',
+        lastAuthenticatedAt: '2026-08-05T12:30:00.000Z',
+        ignoredRawField: 'not-for-the-api',
+    }]
+
+    it('exposes a refined recent-application projection to admins', () => {
+        const response = account({status: {recentApplications}}).getProfileResponse(true, 'admin')
+        expect(response.recentApplications).toEqual([{
+            clientId: 'apps.grafana',
+            namespace: 'apps',
+            name: 'grafana',
+            kind: 'OIDCClient',
+            lastAuthenticatedAt: '2026-08-05T12:30:00.000Z',
+        }])
+        expect(response.recentApplications[0].ignoredRawField).toBeUndefined()
+    })
+
+    it('does not expose recent application activity in the ordinary profile response', () => {
+        const response = account({status: {recentApplications}}).getProfileResponse()
+        expect(response.recentApplications).toBeUndefined()
+    })
+})
+
 describe('Account.claims', () => {
     it('returns sub/username/email for openid scope', async () => {
         const a = account({

--- a/test/unit/activity-tracker.test.js
+++ b/test/unit/activity-tracker.test.js
@@ -70,4 +70,92 @@ describe('ActivityTracker', () => {
         await tracker.flush()
         expect(adapter.list('OIDCClient')[0].status.conditions.find(c => c.type === 'Inactive').status).toBe('True')
     })
+
+    it('continues flushing clients when one user projection fails', async () => {
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCUser', rawUser())
+        adapter.seed('OIDCClient', rawClient())
+        const replace = adapter.replaceNamespacedCustomObjectStatus.bind(adapter)
+        adapter.replaceNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
+            if (kind === 'OIDCUser') return undefined
+            return replace(kind, ...args)
+        })
+        const tracker = new ActivityTracker({adapter, now: () => new Date('2026-08-05T12:00:00.000Z')})
+        tracker.registerClient(new OidcClient().fromIncomingClient(adapter.list('OIDCClient')[0]))
+        tracker.record({
+            accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            timestamp: '2026-08-05T11:30:00.000Z',
+        })
+
+        await expect(tracker.flush()).rejects.toThrow('Failed to flush 1 OIDC activity projection')
+        expect(adapter.list('OIDCClient')[0].status.lastUsedAt).toBe('2026-08-05T11:30:00.000Z')
+    })
+
+    it('preserves newer user activity recorded while a failed flush is in progress', async () => {
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCUser', rawUser())
+        adapter.seed('OIDCClient', rawClient())
+        const replace = adapter.replaceNamespacedCustomObjectStatus.bind(adapter)
+        const tracker = new ActivityTracker({adapter})
+        let fail = true
+        adapter.replaceNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
+            if (kind === 'OIDCUser' && fail) {
+                tracker.record({
+                    accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+                    timestamp: '2026-08-05T12:00:00.000Z',
+                })
+                return undefined
+            }
+            return replace(kind, ...args)
+        })
+        tracker.record({
+            accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            timestamp: '2026-08-05T11:00:00.000Z',
+        })
+        await expect(tracker.flush()).rejects.toBeInstanceOf(AggregateError)
+
+        fail = false
+        await tracker.flush()
+        expect(adapter.list('OIDCUser')[0].status.recentApplications[0].lastAuthenticatedAt)
+            .toBe('2026-08-05T12:00:00.000Z')
+    })
+
+    it('preserves newer client activity recorded while its status write fails', async () => {
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCClient', rawClient())
+        const replace = adapter.replaceNamespacedCustomObjectStatus.bind(adapter)
+        const tracker = new ActivityTracker({adapter})
+        let fail = true
+        adapter.replaceNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
+            if (kind === 'OIDCClient' && fail) {
+                tracker.record({
+                    clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+                    timestamp: '2026-08-05T12:00:00.000Z',
+                })
+                return undefined
+            }
+            return replace(kind, ...args)
+        })
+        tracker.record({
+            clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            timestamp: '2026-08-05T11:00:00.000Z',
+        })
+        await expect(tracker.flush()).rejects.toBeInstanceOf(AggregateError)
+
+        fail = false
+        await tracker.flush()
+        expect(adapter.list('OIDCClient')[0].status.lastUsedAt).toBe('2026-08-05T12:00:00.000Z')
+    })
+
+    it('removes the Prometheus series when a client is unregistered', () => {
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCClient', rawClient())
+        const remove = vi.fn()
+        globalThis.metrics = {oidcClientLastUsed: {remove}}
+        const tracker = new ActivityTracker({adapter})
+        const client = new OidcClient().fromIncomingClient(adapter.list('OIDCClient')[0])
+        tracker.registerClient(client)
+        tracker.unregisterClient(client.getClientId())
+        expect(remove).toHaveBeenCalledWith({kind: 'OIDCClient', namespace: 'apps', client: 'grafana'})
+    })
 })

--- a/test/unit/activity-tracker.test.js
+++ b/test/unit/activity-tracker.test.js
@@ -1,0 +1,73 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {ActivityTracker} from '../../src/services/activity-tracker.js';
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js';
+import OidcClient from '../../src/models/oidc-client.js';
+
+function rawClient() {
+    return {
+        metadata: {
+            name: 'grafana', namespace: 'apps', uid: 'client-1',
+            resourceVersion: '1', creationTimestamp: '2026-01-01T00:00:00.000Z',
+        },
+        spec: {
+            grantTypes: ['authorization_code'], responseTypes: ['code'],
+            redirectUris: ['https://grafana.example/callback'], availableScopes: ['openid'],
+        },
+        status: {instance: 'test-passmower'},
+    }
+}
+
+function rawUser() {
+    return {
+        metadata: {name: 'alice', namespace: 'apps', resourceVersion: '1'},
+        spec: {type: 'person'},
+        status: {recentApplications: [{
+            clientId: 'apps.old', clientNamespace: 'apps', clientName: 'old',
+            lastAuthenticatedAt: '2026-01-01T00:00:00.000Z',
+        }]},
+    }
+}
+
+describe('ActivityTracker', () => {
+    afterEach(() => vi.unstubAllEnvs())
+
+    it('deduplicates activity and projects bounded user and client summaries', async () => {
+        vi.stubEnv('ACTIVITY_RECENT_APPLICATION_LIMIT', '1')
+        vi.stubEnv('CLIENT_INACTIVE_AFTER_DAYS', '90')
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCUser', rawUser())
+        adapter.seed('OIDCClient', rawClient())
+        globalThis.metrics = {oidcClientLastUsed: {set: vi.fn()}}
+        const tracker = new ActivityTracker({adapter, now: () => new Date('2026-08-05T12:00:00.000Z')})
+        tracker.registerClient(new OidcClient().fromIncomingClient(adapter.list('OIDCClient')[0]))
+        tracker.record({
+            accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            timestamp: '2026-08-05T11:00:00.000Z',
+        })
+        tracker.record({
+            accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            timestamp: '2026-08-05T11:30:00.000Z',
+        })
+
+        await tracker.flush()
+
+        const user = adapter.list('OIDCUser')[0]
+        expect(user.status.recentApplications).toEqual([{
+            clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            clientKind: 'OIDCClient',
+            lastAuthenticatedAt: '2026-08-05T11:30:00.000Z',
+        }])
+        const client = adapter.list('OIDCClient')[0]
+        expect(client.status.lastUsedAt).toBe('2026-08-05T11:30:00.000Z')
+        expect(client.status.conditions.find(c => c.type === 'Inactive').status).toBe('False')
+    })
+
+    it('marks a never-used old client inactive', async () => {
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCClient', rawClient())
+        const tracker = new ActivityTracker({adapter, now: () => new Date('2026-08-05T12:00:00.000Z')})
+        tracker.registerClient(new OidcClient().fromIncomingClient(adapter.list('OIDCClient')[0]))
+        await tracker.flush()
+        expect(adapter.list('OIDCClient')[0].status.conditions.find(c => c.type === 'Inactive').status).toBe('True')
+    })
+})

--- a/test/unit/audit-service.test.js
+++ b/test/unit/audit-service.test.js
@@ -1,0 +1,41 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {AuditService} from '../../src/services/audit-service.js';
+
+describe('AuditService', () => {
+    afterEach(() => vi.unstubAllEnvs())
+
+    it('emits an allow-listed structured record without credentials', () => {
+        const info = vi.fn()
+        const service = new AuditService({info}, () => new Date('2026-08-05T12:30:00.000Z'))
+        const ctx = {
+            headers: {'x-forwarded-for': '192.0.2.1', cookie: 'secret'},
+            oidc: {session: {jti: 'raw-session-id'}},
+            get: () => 'browser',
+            state: {requestId: 'request-1'},
+        }
+        const record = service.write({
+            event: 'application.login.succeeded',
+            subject: {id: 'alice'},
+            client: {id: 'apps.grafana'},
+            result: 'success',
+        }, ctx)
+
+        expect(record.timestamp).toBe('2026-08-05T12:30:00.000Z')
+        expect(record.request).toEqual({id: 'request-1'})
+        expect(record.sessionHash).not.toBe('raw-session-id')
+        expect(JSON.stringify(record)).not.toContain('secret')
+        expect(info).toHaveBeenCalledWith({logType: 'audit', audit: record}, 'application.login.succeeded')
+    })
+
+    it('includes explicitly enabled personal request metadata', () => {
+        vi.stubEnv('AUDIT_INCLUDE_SOURCE_ADDRESS', 'true')
+        vi.stubEnv('AUDIT_INCLUDE_USER_AGENT', 'true')
+        const service = new AuditService({info() {}})
+        const record = service.write({event: 'test'}, {
+            headers: {'x-forwarded-for': '192.0.2.1'},
+            get: () => 'test-agent',
+        })
+        expect(record.request.sourceAddress).toBe('192.0.2.1')
+        expect(record.request.userAgent).toBe('test-agent')
+    })
+})

--- a/test/unit/client-activity-state.test.js
+++ b/test/unit/client-activity-state.test.js
@@ -1,0 +1,39 @@
+import {describe, expect, it, vi} from 'vitest';
+import OidcClient from '../../src/models/oidc-client.js';
+import OidcMiddlewareClient from '../../src/models/oidc-middleware-client.js';
+import {ClientReconcileState} from '../../src/models/client-activity-state.js';
+
+function resource(kind, {description = 'Initial', generation = 1, lastUsedAt} = {}) {
+    return {
+        metadata: {
+            name: 'grafana', namespace: 'apps', resourceVersion: '1', generation,
+            annotations: {'kubernetes.io/description': description},
+        },
+        spec: kind === 'OIDCClient' ? {
+            grantTypes: ['authorization_code'], responseTypes: ['code'],
+            redirectUris: ['https://grafana.example/callback'], availableScopes: ['openid'],
+        } : {
+            uri: 'https://grafana.example',
+        },
+        status: {instance: 'test', lastUsedAt},
+    }
+}
+
+describe.each([
+    ['OIDCClient', OidcClient],
+    ['OIDCMiddlewareClient', OidcMiddlewareClient],
+])('%s shared reconcile state', (kind, Model) => {
+    it('ignores status-only changes but reconciles description annotations', () => {
+        const tracker = {registerClient: vi.fn(), unregisterClient: vi.fn()}
+        const state = new ClientReconcileState(tracker)
+        state.register(new Model().fromIncomingClient(resource(kind)))
+
+        expect(state.shouldReconcile(new Model().fromIncomingClient(resource(kind, {
+            lastUsedAt: '2026-08-05T12:00:00.000Z',
+        })))).toBe(false)
+        expect(state.shouldReconcile(new Model().fromIncomingClient(resource(kind, {
+            description: 'Updated',
+            lastUsedAt: '2026-08-05T12:00:00.000Z',
+        })))).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary

- emit versioned, allow-listed audit events for successful application authorization and token exchange
- batch recent application activity into user and client CRD status and expose last-used metrics/inactivity conditions
- support reversible disabling for OIDC and middleware clients without rotating or deleting credentials
- document durable audit-log collection, privacy controls, retention, and Helm configuration
- avoid Secret refresh reconciliation for status-only client updates

Addresses #163.

## Verification

- npm test -- --run (107 passed)
- npm run test:integration -- --run (34 passed)
- helm template passmower charts/passmower
- git diff --check