### PR TITLE
Prevent duplicate OIDC user identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ upstream provider) is controlled by `USERNAME_SOURCE`. See
 `USE_GITHUB_USERNAME` / `REQUIRE_CUSTOM_USERNAME` flags.
 
 If automatic enrollment is disabled users can be managed GitOps style.
+Passmower validates email ownership across those resources and blocks newer
+duplicates from authentication. See
+[docs/identity-integrity.md](docs/identity-integrity.md) for provider linking,
+normalization, conflict status, metrics, and remediation.
 
 ```
 apiVersion: codemowers.cloud/v1

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -572,6 +572,10 @@ spec:
         - name: Groups
           type: string
           jsonPath: .status.groups
+        - name: Email unique
+          type: string
+          description: Whether all claimed emails are uniquely owned by this user
+          jsonPath: .status.conditions[?(@.type=="EmailUnique")].status
     - name: v1beta1
       served: true
       storage: false

--- a/charts/passmower/templates/serviceaccount.yaml
+++ b/charts/passmower/templates/serviceaccount.yaml
@@ -45,6 +45,12 @@ rules:
   - verbs:
       - create
     apiGroups:
+      - ''
+    resources:
+      - events
+  - verbs:
+      - create
+    apiGroups:
       - batch
     resources:
       - jobs

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -37,7 +37,10 @@ passmower:
   namespaceSelector: "*"
   # Domain which will be preferred for determining primary emails.
   preferredEmailDomain: "gmail.com"
-  # Normalize incoming email addresses by removing aliases (e.g. username+alias@gmail.com) etc.
+  # Normalize all upstream and OIDCUser email claims before identity matching and
+  # duplicate detection, including provider-specific aliases such as Gmail +tags.
+  # Changing this on an existing installation may expose previously hidden conflicts;
+  # see docs/identity-integrity.md.
   normalizeEmailAddresses: true
   # Enable WebAuthn/Passkey authentication. Allows users to register passkeys for faster login.
   webauthnEnabled: true

--- a/docs/identity-integrity.md
+++ b/docs/identity-integrity.md
@@ -1,0 +1,76 @@
+# User identity integrity
+
+Passmower treats email addresses as account-linking claims, while retaining the
+upstream provider's immutable subject as the durable identity after the first
+login. This allows a user to add a new provider with an existing email and to
+keep the same account when an upstream email changes, without allowing a newer
+`OIDCUser` to take over an address already claimed by an older resource.
+
+## Duplicate email ownership
+
+Every email claimed in `spec.email`, `spec.companyEmail`, `passmower.email`,
+GitHub email data, or a generic OIDC identity is canonicalized and compared.
+Comparison is case-insensitive and trims whitespace. When
+`normalizeEmailAddresses` / `NORMALIZE_EMAIL_ADDRESSES` is enabled, Passmower
+also applies provider-specific normalization such as removing Gmail `+tag`
+aliases.
+
+If multiple `OIDCUser` resources claim the same canonical address, ownership is
+deterministic: the resource with the oldest `metadata.creationTimestamp` wins,
+with the resource name as a tie-breaker. A losing resource receives:
+
+```yaml
+status:
+  conditions:
+    - type: EmailUnique
+      status: "False"
+      reason: DuplicateEmail
+      message: person@example.com is owned by OIDCUser original-user
+```
+
+The conflicted resource is excluded from email and upstream-subject login. The
+original owner remains usable. Passmower also emits a Kubernetes warning Event,
+sets `passmower_oidc_user_email_conflicts` to the number of conflicted users,
+shows the refined conflict reason in the admin UI, and exposes the condition in
+the `kubectl get oidcusers` table. Once the duplicate claim is removed, the
+condition returns to `True` automatically.
+
+To remediate, inspect all claims on the named resources, remove or correct the
+duplicate claim in Git, and let the operator reconcile. Do not delete the older
+resource merely to transfer ownership unless that transfer is intentional: once
+it is gone, the next-oldest claimant becomes the owner.
+
+## Login and account linking
+
+On generic OIDC login, Passmower first looks for the configured provider key and
+the provider's `sub`. GitHub uses its numeric user ID in the same way. If that
+stable identity is already attached, it selects the existing `OIDCUser` even if
+the upstream email changed. Otherwise, verified upstream email addresses are
+used to find an existing account, so signing in through a new provider with the
+same email links that provider to the existing user.
+
+Authentication is stopped when multiple incoming emails resolve to different
+users, when a stable subject and its current email resolve to different users,
+or when a stable subject is attached to more than one resource. These cases
+require an administrator to resolve the CRDs; Passmower will not guess or merge
+them automatically.
+
+GitHub contributes only email addresses reported as verified. Generic OIDC
+rejects an explicitly unverified email (`email_verified: false`); providers that
+omit the claim retain the existing compatibility behavior. Email magic links
+prove control of the destination address directly.
+
+## Related configuration
+
+- `ENROLL_USERS=false` prevents creation of an unknown account. It does not
+  disable linking a new upstream identity to an existing email owner.
+- `USERNAME_SOURCE` affects only the name chosen for a newly enrolled
+  `OIDCUser`; it does not participate in matching existing identities.
+- `NORMALIZE_EMAIL_ADDRESSES` controls canonicalization for both CRD claims and
+  login claims. Review conflicts before changing it on an existing deployment.
+- `PREFERRED_EMAIL_DOMAIN` chooses the primary address among an account's
+  claims. It does not change ownership or linking decisions.
+
+Kubernetes RBAC is still the security boundary for declarative user changes.
+Deploy Passmower in its dedicated namespace and restrict `OIDCUser` writes to
+trusted administrators and CI controllers.

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -23,6 +23,9 @@
                 <p>Name: {{ account.name }}</p>
                 <p>Primary email: {{ account.email }}</p>
                 <p>Conditions: {{ account.conditions.filter(c => c.status === 'True').map(c => c.type).join(', ') }}</p>
+                <p v-if="emailConflict(account)" class="notice">
+                    Email conflict: {{ emailConflict(account).message }}
+                </p>
                 <p v-if="account.groups.length">Groups: {{ account.groups.map(g => g.displayName).join(', ') }}</p>
                 <div class="recent-applications" v-if="account.recentApplications?.length">
                     <p>Recent applications:</p>
@@ -83,6 +86,11 @@ export default {
                 dateStyle: 'medium',
                 timeStyle: 'short',
             }).format(new Date(value))
+        },
+        emailConflict(account) {
+            return account.conditions.find(condition =>
+                condition.type === 'EmailUnique' && condition.status === 'False'
+            )
         },
         async editProfile(account) {
             this.setAccount(account)

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -273,6 +273,36 @@ export class KubernetesAdapter {
         })
     }
 
+    async createEvent(namespace, involvedObject, reason, message, type = 'Warning') {
+        const now = new Date()
+        return await this.coreV1Api.createNamespacedEvent({
+            namespace,
+            body: {
+                metadata: {
+                    generateName: `${involvedObject.name}-`,
+                    namespace,
+                },
+                involvedObject: {
+                    apiVersion: involvedObject.apiVersion ?? `${defaultApiGroup}/${defaultApiGroupVersion}`,
+                    kind: 'OIDCUser',
+                    name: involvedObject.name,
+                    namespace,
+                    uid: involvedObject.uid,
+                },
+                reason,
+                message,
+                type,
+                source: {component: this.instance},
+                firstTimestamp: now,
+                lastTimestamp: now,
+                count: 1,
+            },
+        }, this.defaultOptions).catch(error => {
+            globalThis.logger.error({error, reason, involvedObject: involvedObject.name}, 'Failed to create Kubernetes Event')
+            return null
+        })
+    }
+
     setWatchParameters (kind, mapperFunction, addedCallback, modifiedCallback, deletedCallback, namespaceFilter, apiGroup = defaultApiGroup, apiGroupVersion = defaultApiGroupVersion) {
         this.watchParameters = {
             kind,

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -284,7 +284,7 @@ export class KubernetesAdapter {
                 },
                 involvedObject: {
                     apiVersion: involvedObject.apiVersion ?? `${defaultApiGroup}/${defaultApiGroupVersion}`,
-                    kind: 'OIDCUser',
+                    kind: involvedObject.kind ?? 'OIDCUser',
                     name: involvedObject.name,
                     namespace,
                     uid: involvedObject.uid,

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -351,12 +351,13 @@ class Account {
         auditLog(ctx, {emails, email, githubEmails, username}, 'Finding user by emails')
         let user
         try {
+            const users = await ctx.kubeOIDCUserService.listUsers()
             if (identity.providerKey && identity.subject) {
-                user = await ctx.kubeOIDCUserService.findUserByIdentity(identity.providerKey, identity.subject)
+                user = await ctx.kubeOIDCUserService.findUserByIdentity(identity.providerKey, identity.subject, users)
             } else if (identity.githubId !== undefined) {
-                user = await ctx.kubeOIDCUserService.findUserByGithubId(identity.githubId)
+                user = await ctx.kubeOIDCUserService.findUserByGithubId(identity.githubId, users)
             }
-            const emailUser = await ctx.kubeOIDCUserService.findUserByEmails(emails)
+            const emailUser = await ctx.kubeOIDCUserService.findUserByEmails(emails, users)
             if (user && emailUser && user.accountId !== emailUser.accountId) {
                 throw new IdentityIntegrityError('Stable upstream identity and email resolve to different OIDC users', {
                     identityAccountId: user.accountId,

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -2,11 +2,11 @@ import ShortUniqueId from "short-unique-id";
 import {Approved} from "../conditions/approved.js";
 import {getSlackId} from "../utils/user/get-slack-id.js";
 import {auditLog} from "../utils/session/audit-log.js";
-import validator from "validator";
 import {listMyApps} from "../utils/apps/list-apps.js";
 import {getUsernameSource} from "../utils/username-source.js";
 import {sanitizeUsername, isUsernameValid, isUsernameAvailable} from "../utils/user/username.js";
 import {fetchExtraClaims} from "../utils/fetch-extra-claims.js";
+import {canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
 
 export const AdminGroup = process.env.ADMIN_GROUP;
 export const GroupPrefix = process.env.GROUP_PREFIX;
@@ -144,7 +144,7 @@ class Account {
             this.#passmower?.email,
             ...(this.#github?.emails ?? []).map(ghEmail => ghEmail.email),
             ...identityEmails.map(e => e.email),
-        ].filter(e => e))]
+        ].map(canonicalizeEmail).filter(Boolean))]
         let primaryEmail
         const preferredDomain = process.env.PREFERRED_EMAIL_DOMAIN
         if (preferredDomain) {
@@ -154,11 +154,11 @@ class Account {
                     domain: e.split('@')[1]
                 }
             })
-            primaryEmail = emailsWithDomains.find(e => e.domain === preferredDomain)
+            primaryEmail = emailsWithDomains.find(e => e.domain === preferredDomain.toLowerCase())
             primaryEmail = primaryEmail?.email
         }
         if (!primaryEmail) {
-            primaryEmail = this.#spec?.email || this.#spec?.companyEmail || this.#passmower?.email || this.#github?.emails?.find(ghEmail => ghEmail.primary)?.email || this.#github?.emails?.find(ghEmail => ghEmail.email)?.email || identityEmails.find(e => e.primary)?.email || identityEmails.find(e => e.email)?.email
+            primaryEmail = canonicalizeEmail(this.#spec?.email || this.#spec?.companyEmail || this.#passmower?.email || this.#github?.emails?.find(ghEmail => ghEmail.primary)?.email || this.#github?.emails?.find(ghEmail => ghEmail.email)?.email || identityEmails.find(e => e.primary)?.email || identityEmails.find(e => e.email)?.email)
         }
         const groups = [...(this.#spec?.groups ?? []), ...(this.#passmower?.groups ?? []), ...(this.#github?.groups ?? []), ...activeIdentities.flatMap(i => i.groups ?? [])]
         return {
@@ -277,6 +277,25 @@ class Account {
         return this.#metadata
     }
 
+    getClaimedEmails() {
+        const identities = Object.values(this.#identities ?? {})
+        return [...new Set([
+            this.#spec?.email,
+            this.#spec?.companyEmail,
+            this.#passmower?.email,
+            ...(this.#github?.emails ?? []).map(item => item.email),
+            ...identities.flatMap(identity => (identity.emails ?? []).map(item => item.email)),
+        ].map(canonicalizeEmail).filter(Boolean))]
+    }
+
+    getIdentity(providerKey) {
+        return this.#identities?.[providerKey]
+    }
+
+    getGithubId() {
+        return this.#github?.id
+    }
+
     pushCustomGroup(name) {
         const group = {
             prefix: GroupPrefix,
@@ -314,10 +333,10 @@ class Account {
         return 'u' + uid.rnd(10);
     }
 
-    static async createOrUpdateByEmails(ctx, provider, email, githubEmails, username, preferredUsername) {
+    static async createOrUpdateByEmails(ctx, provider, email, githubEmails, username, preferredUsername, identity = {}) {
         if (Array.isArray(githubEmails)) {
             githubEmails = githubEmails.map((e) => {
-                let ghEmail = e.email && process.env.NORMALIZE_EMAIL_ADDRESSES === 'true' ? validator.normalizeEmail(e.email) : e.email
+                const ghEmail = canonicalizeEmail(e.email)
                 return {
                     email: ghEmail,
                     primary: e.primary
@@ -326,11 +345,30 @@ class Account {
             githubEmails = [...new Map(githubEmails.map(v => [v.email, v])).values()]
         }
         const emails = [
-            email && process.env.NORMALIZE_EMAIL_ADDRESSES === 'true' ? validator.normalizeEmail(email) : email,
+            canonicalizeEmail(email),
             ...(githubEmails ?? []).map(ghEmail => ghEmail.email)
         ].filter(e => e)
         auditLog(ctx, {emails, email, githubEmails, username}, 'Finding user by emails')
-        let user = await ctx.kubeOIDCUserService.findUserByEmails(emails)
+        let user
+        try {
+            if (identity.providerKey && identity.subject) {
+                user = await ctx.kubeOIDCUserService.findUserByIdentity(identity.providerKey, identity.subject)
+            } else if (identity.githubId !== undefined) {
+                user = await ctx.kubeOIDCUserService.findUserByGithubId(identity.githubId)
+            }
+            const emailUser = await ctx.kubeOIDCUserService.findUserByEmails(emails)
+            if (user && emailUser && user.accountId !== emailUser.accountId) {
+                throw new IdentityIntegrityError('Stable upstream identity and email resolve to different OIDC users', {
+                    identityAccountId: user.accountId,
+                    emailAccountId: emailUser.accountId,
+                })
+            }
+            user ??= emailUser
+        } catch (error) {
+            if (!(error instanceof IdentityIntegrityError)) throw error
+            auditLog(ctx, {emails, identity, error: error.message}, 'Identity resolution blocked by integrity conflict')
+            return undefined
+        }
         if (!user) {
             auditLog(ctx, {emails, email, githubEmails, username}, 'User not found')
             // `username` is set explicitly only by the admin invite path; otherwise
@@ -380,7 +418,7 @@ class Account {
     }
 
     static async findByEmail(ctx, email) {
-        email = email && process.env.NORMALIZE_EMAIL_ADDRESSES === 'true' ? validator.normalizeEmail(email) : email
+        email = canonicalizeEmail(email)
         return await ctx.kubeOIDCUserService.findUserByEmails([email])
     }
 

--- a/src/operators/kube-oidc-user-operator.js
+++ b/src/operators/kube-oidc-user-operator.js
@@ -62,6 +62,9 @@ export class KubeOIDCUserOperator {
             } while (this.reconcileEmailPending)
         })().finally(() => {
             this.reconcileEmailPromise = null
+            if (this.reconcileEmailPending) {
+                return this.#scheduleEmailReconcile()
+            }
         })
         return this.reconcileEmailPromise
     }

--- a/src/operators/kube-oidc-user-operator.js
+++ b/src/operators/kube-oidc-user-operator.js
@@ -14,6 +14,7 @@ export class KubeOIDCUserOperator {
         this.adapter = adapter
         this.instance = this.adapter.instance
         this.userService = new KubeOIDCUserService(this.adapter);
+        this.reconcileEmailPromise = Promise.resolve()
     }
 
     async watchUsers() {
@@ -22,7 +23,7 @@ export class KubeOIDCUserOperator {
             (OIDCUser) => (new Account()).fromKubernetes(OIDCUser),
             (OIDCUser) => this.#claimOIDCUser(OIDCUser),
             (OIDCUser) => this.#updateOIDCUser(OIDCUser),
-            (OIDCUser) => (OIDCUser),
+            () => this.#scheduleEmailReconcile(),
             new NamespaceFilter(this.adapter.namespace)
         )
         await this.adapter.watchObjects()
@@ -34,12 +35,24 @@ export class KubeOIDCUserOperator {
         OIDCUser.setLabels(condition.toLabels())
         await this.userService.replaceUserLabels(OIDCUser)
         await this.userService.updateUserStatus(OIDCUser)
+        await this.#scheduleEmailReconcile()
     }
 
     async #updateOIDCUser(OIDCUser) {
-        if (OIDCUser.getMetadata()?.managedFields.pop()?.manager !== this.instance) {
+        if (OIDCUser.getMetadata()?.managedFields?.at(-1)?.manager !== this.instance) {
             await this.userService.updateUserStatus(OIDCUser)
+            await this.#scheduleEmailReconcile()
         }
+    }
+
+    async #scheduleEmailReconcile() {
+        this.reconcileEmailPromise = this.reconcileEmailPromise
+            .catch(() => undefined)
+            .then(() => this.userService.reconcileEmailUniqueness())
+            .catch(error => {
+                globalThis.logger?.error(error, 'Failed to reconcile OIDCUser email uniqueness')
+            })
+        return this.reconcileEmailPromise
     }
 }
 

--- a/src/operators/kube-oidc-user-operator.js
+++ b/src/operators/kube-oidc-user-operator.js
@@ -14,7 +14,8 @@ export class KubeOIDCUserOperator {
         this.adapter = adapter
         this.instance = this.adapter.instance
         this.userService = new KubeOIDCUserService(this.adapter);
-        this.reconcileEmailPromise = Promise.resolve()
+        this.reconcileEmailPromise = null
+        this.reconcileEmailPending = false
     }
 
     async watchUsers() {
@@ -46,12 +47,22 @@ export class KubeOIDCUserOperator {
     }
 
     async #scheduleEmailReconcile() {
-        this.reconcileEmailPromise = this.reconcileEmailPromise
-            .catch(() => undefined)
-            .then(() => this.userService.reconcileEmailUniqueness())
-            .catch(error => {
-                globalThis.logger?.error(error, 'Failed to reconcile OIDCUser email uniqueness')
-            })
+        if (this.reconcileEmailPromise) {
+            this.reconcileEmailPending = true
+            return this.reconcileEmailPromise
+        }
+        this.reconcileEmailPromise = (async () => {
+            do {
+                this.reconcileEmailPending = false
+                try {
+                    await this.userService.reconcileEmailUniqueness()
+                } catch (error) {
+                    globalThis.logger?.error(error, 'Failed to reconcile OIDCUser email uniqueness')
+                }
+            } while (this.reconcileEmailPending)
+        })().finally(() => {
+            this.reconcileEmailPromise = null
+        })
         return this.reconcileEmailPromise
     }
 }

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -144,6 +144,11 @@ export default (provider) => {
         }
 
         const account = await Account.createOrUpdateByEmails(ctx, provider, email, undefined, username);
+        if (!account) {
+            ctx.status = 409
+            ctx.body = {errors: [{param: 'email', msg: 'Email is already taken'}]}
+            return
+        }
         let condition = new UsernameCommitted()
         condition = condition.setStatus(true)
         account.addCondition(condition)

--- a/src/routes/metrics-server.js
+++ b/src/routes/metrics-server.js
@@ -32,6 +32,10 @@ export default async () => {
         help: 'Unix timestamp of the latest successful OIDC activity for a client, or zero if never used',
         labelNames: ['kind', 'namespace', 'client'],
     })
+    globalThis.metrics.oidcUserEmailConflicts = new Gauge({
+        name: 'passmower_oidc_user_email_conflicts',
+        help: 'Number of OIDCUser resources rejected because an older user owns one or more claimed emails',
+    })
     setupOidcMetrics()
 
     const userService = new KubeOIDCUserService();

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -5,6 +5,7 @@ import {ClaimedBy} from "../conditions/claimed-by.js";
 import mergeWith from "lodash/mergeWith.js";
 import cloneDeep from "lodash/cloneDeep.js";
 import isArray from "lodash/isArray.js";
+import {assessEmailOwnership, canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
 
 // Custom merge that replaces arrays instead of merging by index
 function mergeReplacingArrays(objValue, srcValue) {
@@ -36,20 +37,105 @@ export class KubeOIDCUserService {
     }
 
     async findUserByEmails(emails) {
-        const emailsInKube = []
         const allUsers = await this.listUsers()
-        allUsers.map(user => {
-            user.emails.map((email) => {
-                emailsInKube.push({
-                    email: email,
-                    user: user
-                })
+        const ownership = assessEmailOwnership(allUsers)
+        const candidates = [...new Set(emails.map(canonicalizeEmail).filter(Boolean)
+            .map(email => ownership.owners.get(email)).filter(Boolean))]
+        if (candidates.length > 1) {
+            throw new IdentityIntegrityError('Incoming emails belong to different OIDC users', {
+                accountIds: candidates.map(account => account.accountId),
             })
-        })
-        const foundUser = emailsInKube.find((element) => {
-            return emails.includes(element.email)
-        })
-        return foundUser?.user
+        }
+        const account = candidates[0]
+        if (account && !ownership.isEligible(account)) {
+            throw new IdentityIntegrityError(`OIDCUser ${account.accountId} has conflicting email claims`, {
+                accountId: account.accountId,
+                conflicts: ownership.conflicts.get(account.accountId),
+            })
+        }
+        return account
+    }
+
+    async findUserByIdentity(providerKey, subject) {
+        return this.#findUniqueStableIdentity(
+            account => account.getIdentity(providerKey)?.sub === subject,
+            `${providerKey} subject ${subject}`
+        )
+    }
+
+    async findUserByGithubId(githubId) {
+        return this.#findUniqueStableIdentity(
+            account => String(account.getGithubId()) === String(githubId),
+            `GitHub id ${githubId}`
+        )
+    }
+
+    async #findUniqueStableIdentity(predicate, description) {
+        const allUsers = await this.listUsers()
+        const matches = allUsers.filter(predicate)
+        if (matches.length > 1) {
+            throw new IdentityIntegrityError(`${description} is attached to multiple OIDC users`, {
+                accountIds: matches.map(account => account.accountId),
+            })
+        }
+        const account = matches[0]
+        if (!account) return undefined
+        const ownership = assessEmailOwnership(allUsers)
+        if (!ownership.isEligible(account)) {
+            throw new IdentityIntegrityError(`OIDCUser ${account.accountId} has conflicting email claims`, {
+                accountId: account.accountId,
+                conflicts: ownership.conflicts.get(account.accountId),
+            })
+        }
+        return account
+    }
+
+    async reconcileEmailUniqueness() {
+        const accounts = await this.listUsers()
+        const ownership = assessEmailOwnership(accounts)
+        let conflictedUsers = 0
+        const errors = []
+        for (const account of accounts) {
+            const conflicts = ownership.conflicts.get(account.accountId) ?? []
+            if (conflicts.length) conflictedUsers++
+            const previous = account.getConditions().find(condition => condition.type === 'EmailUnique')
+            const status = conflicts.length ? 'False' : 'True'
+            const reason = conflicts.length ? 'DuplicateEmail' : 'Unique'
+            const message = conflicts.length
+                ? conflicts.map(conflict => `${conflict.email} is owned by OIDCUser ${conflict.ownerAccountId}`).join('; ')
+                : 'All claimed email addresses are unique'
+            if (previous?.status === status && previous?.reason === reason && previous?.message === message) continue
+            const condition = {
+                apiVersion: 'v1',
+                kind: 'Condition',
+                type: 'EmailUnique',
+                status,
+                reason,
+                message,
+                lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : new Date(),
+            }
+            account.setConditions([
+                ...account.getConditions().filter(item => item.type !== 'EmailUnique'),
+                condition,
+            ])
+            try {
+                const updated = await this.updateUserStatus(account)
+                if (!updated) throw new Error(`Status update returned no OIDCUser for ${account.accountId}`)
+                if (status === 'False' && previous?.status !== 'False') {
+                    await this.adapter.createEvent?.(
+                        this.adapter.namespace,
+                        account.getMetadata(),
+                        'DuplicateEmail',
+                        message,
+                    )
+                }
+            } catch (error) {
+                errors.push(error)
+            }
+        }
+        globalThis.metrics?.oidcUserEmailConflicts?.set(conflictedUsers)
+        if (errors.length) throw new AggregateError(errors, `Failed to reconcile ${errors.length} OIDCUser email condition(s)`)
+        return {accounts, ownership, conflictedUsers}
     }
 
     async createUser(id, email, githubEmails) {

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -36,8 +36,8 @@ export class KubeOIDCUserService {
         )
     }
 
-    async findUserByEmails(emails) {
-        const allUsers = await this.listUsers()
+    async findUserByEmails(emails, users) {
+        const allUsers = users ?? await this.listUsers()
         const ownership = assessEmailOwnership(allUsers)
         const candidates = [...new Set(emails.map(canonicalizeEmail).filter(Boolean)
             .map(email => ownership.owners.get(email)).filter(Boolean))]
@@ -56,22 +56,24 @@ export class KubeOIDCUserService {
         return account
     }
 
-    async findUserByIdentity(providerKey, subject) {
+    async findUserByIdentity(providerKey, subject, users) {
         return this.#findUniqueStableIdentity(
             account => account.getIdentity(providerKey)?.sub === subject,
-            `${providerKey} subject ${subject}`
+            `${providerKey} subject ${subject}`,
+            users,
         )
     }
 
-    async findUserByGithubId(githubId) {
+    async findUserByGithubId(githubId, users) {
         return this.#findUniqueStableIdentity(
             account => String(account.getGithubId()) === String(githubId),
-            `GitHub id ${githubId}`
+            `GitHub id ${githubId}`,
+            users,
         )
     }
 
-    async #findUniqueStableIdentity(predicate, description) {
-        const allUsers = await this.listUsers()
+    async #findUniqueStableIdentity(predicate, description, users) {
+        const allUsers = users ?? await this.listUsers()
         const matches = allUsers.filter(predicate)
         if (matches.length > 1) {
             throw new IdentityIntegrityError(`${description} is attached to multiple OIDC users`, {

--- a/src/services/login/email-login.js
+++ b/src/services/login/email-login.js
@@ -8,6 +8,7 @@ import {getEmailContent, getEmailSubject} from "../../utils/get-email-content.js
 import {SlackAdapter} from "../../adapters/slack.js";
 import {parseRequestMetadata} from "../../utils/session/parse-request-headers.js";
 import {auditLog} from "../../utils/session/audit-log.js";
+import {IdentityIntegrityError} from "../../utils/user/identity-integrity.js";
 
 export class EmailLogin {
     constructor() {
@@ -20,7 +21,14 @@ export class EmailLogin {
         const {uid, params} = await provider.interactionDetails(ctx.req, ctx.res);
         const client = await provider.Client.find(params.client_id);
         const email = ctx.request.body.email.toLowerCase()
-        const account = await Account.findByEmail(ctx, email)
+        let account
+        try {
+            account = await Account.findByEmail(ctx, email)
+        } catch (error) {
+            if (!(error instanceof IdentityIntegrityError)) throw error
+            auditLog(ctx, {email, error: error.message}, 'Email login blocked by identity conflict')
+            return accessDenied(ctx, provider, 'This email is attached to a conflicted account. Contact an administrator.')
+        }
         if (process.env.ENROLL_USERS === 'false' && !account) {
             auditLog(ctx, {email}, 'Account doesn\'t exist')
             return accessDenied(ctx, provider, 'Account doesn\'t exist')

--- a/src/services/login/github-login.js
+++ b/src/services/login/github-login.js
@@ -86,7 +86,9 @@ export default async (ctx, provider) => {
         return accessDenied(ctx, provider, 'Error getting profile from GitHub')
     }
 
-    const account = await Account.createOrUpdateByEmails(ctx, provider, undefined, emails, undefined, user.login);
+    const account = await Account.createOrUpdateByEmails(
+        ctx, provider, undefined, emails, undefined, user.login, {githubId: user.id}
+    );
 
     if (!account?.accountId) {
         auditLog(ctx,{account, interactionDetails}, 'Unable to determine account from GitHub')

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -135,7 +135,10 @@ export default async (ctx, provider, providerConfig) => {
     }
 
     // Phase 3 — link/create the account, persist the identity, finish.
-    const account = await Account.createOrUpdateByEmails(ctx, provider, identity.primaryEmail, identity.emails, undefined, identity.preferredUsername);
+    const account = await Account.createOrUpdateByEmails(
+        ctx, provider, identity.primaryEmail, identity.emails, undefined, identity.preferredUsername,
+        {providerKey: key, subject: identity.sub}
+    );
 
     if (!account?.accountId) {
         auditLog(ctx, { account, interactionDetails }, `Unable to determine account from ${displayName}`);

--- a/src/utils/session/validator.js
+++ b/src/utils/session/validator.js
@@ -3,6 +3,7 @@ import Account from "../../models/account.js";
 import validatorLib from "validator";
 import {getText} from "../get-text.js";
 import {USERNAME_RULES} from "../user/username.js";
+import {IdentityIntegrityError} from "../user/identity-integrity.js";
 
 // Display-name / company validation (#64). Upstream IdPs (GitHub, OIDC) legitimately
 // supply names with unicode letters, accents, apostrophes, hyphens, "&", etc. — an
@@ -40,7 +41,13 @@ const customValidators = {
         } else {
             Account.findByEmail(ctx, value).then(user => {
                 resolve(!user)
-            }).catch(reject);
+            }).catch(error => {
+                if (error instanceof IdentityIntegrityError) {
+                    resolve(false)
+                } else {
+                    reject(error)
+                }
+            });
         }
     }),
     isValidName: (value) => isSafeDisplayName(value),

--- a/src/utils/user/identity-integrity.js
+++ b/src/utils/user/identity-integrity.js
@@ -1,0 +1,55 @@
+import validator from 'validator';
+
+export class IdentityIntegrityError extends Error {
+    constructor(message, details = {}) {
+        super(message)
+        this.name = 'IdentityIntegrityError'
+        this.details = details
+    }
+}
+
+export function canonicalizeEmail(email, env = process.env) {
+    if (typeof email !== 'string') return undefined
+    const trimmed = email.trim().toLowerCase()
+    if (!trimmed) return undefined
+    if (env.NORMALIZE_EMAIL_ADDRESSES === 'true') {
+        return validator.normalizeEmail(trimmed) || undefined
+    }
+    return trimmed
+}
+
+function accountOrder(a, b) {
+    const aCreated = Date.parse(a.getMetadata()?.creationTimestamp ?? '')
+    const bCreated = Date.parse(b.getMetadata()?.creationTimestamp ?? '')
+    const byCreation = (Number.isFinite(aCreated) ? aCreated : Number.MAX_SAFE_INTEGER)
+        - (Number.isFinite(bCreated) ? bCreated : Number.MAX_SAFE_INTEGER)
+    return byCreation || a.accountId.localeCompare(b.accountId)
+}
+
+export function assessEmailOwnership(accounts) {
+    const ordered = [...accounts].sort(accountOrder)
+    const claims = new Map()
+    for (const account of ordered) {
+        for (const email of account.getClaimedEmails()) {
+            const claimants = claims.get(email) ?? []
+            claimants.push(account)
+            claims.set(email, claimants)
+        }
+    }
+    const owners = new Map()
+    const conflicts = new Map()
+    for (const [email, claimants] of claims) {
+        const owner = claimants[0]
+        owners.set(email, owner)
+        for (const duplicate of claimants.slice(1)) {
+            const entries = conflicts.get(duplicate.accountId) ?? []
+            entries.push({email, ownerAccountId: owner.accountId})
+            conflicts.set(duplicate.accountId, entries)
+        }
+    }
+    return {
+        owners,
+        conflicts,
+        isEligible: account => !conflicts.has(account.accountId),
+    }
+}

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -16,6 +16,7 @@ export class FakeKubernetesAdapter {
         this.store = new Map()       // `${kind}/${name}` -> stored CR object
         this.secrets = new Map()     // `${namespace}/${name}` -> { data, metadata }
         this.jobs = []               // jobs created via createJob (e.g. secret-refresh)
+        this.events = []             // Kubernetes Events emitted by reconcilers
         this.watchHandlers = []      // for operator tests
         this.watchParameters = null  // set by setWatchParameters()
         this._rv = 0
@@ -45,7 +46,7 @@ export class FakeKubernetesAdapter {
         const obj = {
             apiVersion: 'codemowers.cloud/v1',
             kind,
-            metadata: { name, labels, resourceVersion: this.#nextRv() },
+            metadata: { name, labels, resourceVersion: this.#nextRv(), creationTimestamp: new Date().toISOString() },
             status: {},
             ...structuredClone(spec),
         }
@@ -85,6 +86,11 @@ export class FakeKubernetesAdapter {
     async patchSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
     async deleteSecret(namespace, id) { this.secrets.delete(`${namespace}/${id}`) }
     async createJob(namespace, jobManifest) { this.jobs.push({ namespace, jobManifest: structuredClone(jobManifest) }); return { active: 1 } }
+    async createEvent(namespace, involvedObject, reason, message, type = 'Warning') {
+        const event = {namespace, involvedObject: structuredClone(involvedObject), reason, message, type}
+        this.events.push(event)
+        return event
+    }
 
     // --- Watch (used by operators) ------------------------------------------
 
@@ -134,6 +140,10 @@ export class FakeKubernetesAdapter {
     /** All stored resources of a kind, as raw objects. */
     list(kind) {
         return [...this.store.entries()].filter(([k]) => k.startsWith(`${kind}/`)).map(([, v]) => v)
+    }
+
+    delete(kind, name) {
+        this.store.delete(this.#key(kind, name))
     }
 }
 

--- a/test/integration/kube-user-service.test.js
+++ b/test/integration/kube-user-service.test.js
@@ -1,6 +1,16 @@
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
 import { KubeOIDCUserService } from '../../src/services/kube-oidc-user-service.js'
 import { FakeKubernetesAdapter } from '../fakes/fake-kubernetes-adapter.js'
+import {IdentityIntegrityError} from '../../src/utils/user/identity-integrity.js';
+
+function rawUser(name, created, email, overrides = {}) {
+    return {
+        metadata: {name, namespace: 'test', creationTimestamp: created, uid: `uid-${name}`},
+        spec: {type: 'person', email},
+        status: {},
+        ...overrides,
+    }
+}
 
 // Exercises the real user-service + Account model against the in-memory fake
 // adapter — i.e. the exact code path that reads/writes OIDCUser custom resources.
@@ -62,6 +72,65 @@ describe('KubeOIDCUserService over the fake Kubernetes adapter', () => {
         expect(stored.identities.google.sub).toBe('g-1')
         expect(stored.status.emails).toContain('dave@corp.example.com')
         expect(stored.status.groups.map(g => `${g.prefix}:${g.name}`)).toContain('google.com:eng')
+    })
+
+    it('deterministically rejects a newer GitOps user with a duplicate email', async () => {
+        adapter.seed('OIDCUser', rawUser('original', '2026-01-01T00:00:00Z', 'person@example.com'))
+        adapter.seed('OIDCUser', rawUser('duplicate', '2026-02-01T00:00:00Z', 'PERSON@example.com'))
+        globalThis.metrics = {oidcUserEmailConflicts: {set: vi.fn()}}
+
+        const result = await service.reconcileEmailUniqueness()
+
+        expect(result.conflictedUsers).toBe(1)
+        const byName = Object.fromEntries(adapter.list('OIDCUser').map(user => [user.metadata.name, user]))
+        expect(byName.original.status.conditions.find(c => c.type === 'EmailUnique').status).toBe('True')
+        expect(byName.duplicate.status.conditions.find(c => c.type === 'EmailUnique')).toMatchObject({
+            status: 'False',
+            reason: 'DuplicateEmail',
+            message: 'person@example.com is owned by OIDCUser original',
+        })
+        expect((await service.findUserByEmails(['person@example.com'])).accountId).toBe('original')
+        expect(adapter.events).toHaveLength(1)
+        expect(adapter.events[0]).toMatchObject({reason: 'DuplicateEmail', type: 'Warning'})
+        expect(globalThis.metrics.oidcUserEmailConflicts.set).toHaveBeenCalledWith(1)
+    })
+
+    it('restores uniqueness after the original duplicate claim is removed', async () => {
+        adapter.seed('OIDCUser', rawUser('original', '2026-01-01T00:00:00Z', 'person@example.com'))
+        adapter.seed('OIDCUser', rawUser('duplicate', '2026-02-01T00:00:00Z', 'person@example.com'))
+        await service.reconcileEmailUniqueness()
+        adapter.delete('OIDCUser', 'original')
+
+        await service.reconcileEmailUniqueness()
+
+        const duplicate = adapter.list('OIDCUser')[0]
+        expect(duplicate.status.conditions.find(c => c.type === 'EmailUnique')).toMatchObject({
+            status: 'True', reason: 'Unique',
+        })
+        expect((await service.findUserByEmails(['person@example.com'])).accountId).toBe('duplicate')
+    })
+
+    it('rejects an upstream identity whose verified emails span multiple owners', async () => {
+        adapter.seed('OIDCUser', rawUser('alice', '2026-01-01T00:00:00Z', 'alice@example.com'))
+        adapter.seed('OIDCUser', rawUser('bob', '2026-01-02T00:00:00Z', 'bob@example.com'))
+        await expect(service.findUserByEmails(['alice@example.com', 'bob@example.com']))
+            .rejects.toBeInstanceOf(IdentityIntegrityError)
+    })
+
+    it('resolves an existing provider subject before an upstream email change', async () => {
+        adapter.seed('OIDCUser', rawUser('alice', '2026-01-01T00:00:00Z', 'old@example.com', {
+            identities: {google: {sub: 'google-123', emails: [{email: 'old@example.com', primary: true}]}},
+        }))
+        const found = await service.findUserByIdentity('google', 'google-123')
+        expect(found.accountId).toBe('alice')
+        expect(await service.findUserByEmails(['new@example.com'])).toBeUndefined()
+    })
+
+    it('resolves an existing GitHub numeric id independently of email', async () => {
+        adapter.seed('OIDCUser', rawUser('alice', '2026-01-01T00:00:00Z', 'old@example.com', {
+            github: {id: 12345, emails: [{email: 'old@example.com', primary: true}]},
+        }))
+        expect((await service.findUserByGithubId(12345)).accountId).toBe('alice')
     })
 
     it('adds, renames and removes a passkey', async () => {

--- a/test/unit/identity-integrity-boundaries.test.js
+++ b/test/unit/identity-integrity-boundaries.test.js
@@ -1,0 +1,47 @@
+import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+import Account from '../../src/models/account.js';
+import {EmailLogin} from '../../src/services/login/email-login.js';
+import koaValidator, {checkIfEmailIsTaken} from '../../src/utils/session/validator.js';
+import {IdentityIntegrityError} from '../../src/utils/user/identity-integrity.js';
+
+beforeAll(() => {
+    globalThis.logger ??= {info() {}, warn() {}, error() {}, debug() {}}
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('identity-integrity error boundaries', () => {
+    it('renders access denied when magic-link lookup encounters a conflict', async () => {
+        vi.spyOn(Account, 'findByEmail').mockRejectedValue(new IdentityIntegrityError('duplicate'))
+        const login = Object.create(EmailLogin.prototype)
+        const ctx = {req: {}, res: {}, headers: {}, request: {body: {email: 'duplicate@example.com'}}}
+        const provider = {
+            interactionDetails: vi.fn().mockResolvedValue({uid: 'interaction', params: {client_id: 'client'}}),
+            Client: {find: vi.fn().mockResolvedValue({clientId: 'client'})},
+            interactionFinished: vi.fn().mockResolvedValue('denied'),
+        }
+
+        await expect(login.sendLink(ctx, provider)).resolves.toBe('denied')
+        expect(provider.interactionFinished).toHaveBeenCalledWith(ctx.req, ctx.res, {
+            error: 'access_denied',
+            error_description: 'This email is attached to a conflicted account. Contact an administrator.',
+        }, {mergeWithLastSubmission: false})
+    })
+
+    it('reports a conflicted email as already taken during form validation', async () => {
+        vi.spyOn(Account, 'findByEmail').mockRejectedValue(new IdentityIntegrityError('duplicate'))
+        const ctx = {request: {body: {email: 'duplicate@example.com'}}}
+        let errors
+
+        await koaValidator()(ctx, async () => {
+            checkIfEmailIsTaken(ctx)
+            errors = await ctx.validationErrors()
+        })
+
+        expect(errors).toEqual([{
+            param: 'email',
+            msg: 'Email is already taken',
+            value: 'duplicate@example.com',
+        }])
+    })
+})

--- a/test/unit/identity-integrity.test.js
+++ b/test/unit/identity-integrity.test.js
@@ -1,0 +1,35 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import Account from '../../src/models/account.js';
+import {assessEmailOwnership, canonicalizeEmail} from '../../src/utils/user/identity-integrity.js';
+
+function account(name, created, email) {
+    return new Account().fromKubernetes({
+        metadata: {name, creationTimestamp: created},
+        spec: {email, type: 'person'},
+        status: {},
+    })
+}
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('email identity integrity', () => {
+    it('always trims and lowercases email addresses', () => {
+        expect(canonicalizeEmail(' Alice@Example.COM ')).toBe('alice@example.com')
+    })
+
+    it('applies configured provider-specific normalization consistently', () => {
+        vi.stubEnv('NORMALIZE_EMAIL_ADDRESSES', 'true')
+        expect(canonicalizeEmail('alice+alias@gmail.com')).toBe('alice@gmail.com')
+    })
+
+    it('selects the earliest resource as owner independent of list order', () => {
+        const original = account('original', '2026-01-01T00:00:00Z', 'same@example.com')
+        const duplicate = account('duplicate', '2026-02-01T00:00:00Z', 'SAME@example.com')
+        const ownership = assessEmailOwnership([duplicate, original])
+
+        expect(ownership.owners.get('same@example.com').accountId).toBe('original')
+        expect(ownership.conflicts.get('duplicate')).toEqual([{
+            email: 'same@example.com', ownerAccountId: 'original',
+        }])
+    })
+})

--- a/test/unit/oidc-user-operator.test.js
+++ b/test/unit/oidc-user-operator.test.js
@@ -1,0 +1,32 @@
+import {beforeAll, describe, expect, it, vi} from 'vitest';
+import KubeOIDCUserOperator from '../../src/operators/kube-oidc-user-operator.js';
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js';
+
+beforeAll(() => {
+    globalThis.logger ??= {info() {}, warn() {}, error() {}, debug() {}}
+})
+
+describe('KubeOIDCUserOperator email reconciliation', () => {
+    it('coalesces a burst of user events into at most one follow-up pass', async () => {
+        const adapter = new FakeKubernetesAdapter()
+        const operator = new KubeOIDCUserOperator({}, adapter)
+        await operator.watchUsers()
+        for (const name of ['one', 'two', 'three']) {
+            adapter.seed('OIDCUser', {
+                metadata: {name, creationTimestamp: '2026-01-01T00:00:00Z'},
+                spec: {email: `${name}@example.com`},
+            })
+        }
+        let releaseFirst
+        const reconcile = vi.spyOn(operator.userService, 'reconcileEmailUniqueness')
+            .mockImplementationOnce(() => new Promise(resolve => { releaseFirst = resolve }))
+            .mockResolvedValue({})
+
+        const events = ['one', 'two', 'three'].map(name => adapter.fireWatch('ADDED', 'OIDCUser', name))
+        await vi.waitFor(() => expect(reconcile).toHaveBeenCalledTimes(1))
+        releaseFirst({})
+        await Promise.all(events)
+
+        expect(reconcile).toHaveBeenCalledTimes(2)
+    })
+})


### PR DESCRIPTION
## Summary
- deterministically assign canonical email ownership and mark newer duplicate OIDCUsers conflicted
- resolve returning users by stable upstream subject before email linking, rejecting ambiguous identity claims
- expose conflict conditions through kubectl/admin UI, Kubernetes Events, and Prometheus metrics
- document configuration behavior and remediation

## Verification
- npm test (118 passed)
- npx vitest run --project integration test/integration/kube-user-service.test.js (10 passed)
- npm run lint --prefix frontend
- helm template passmower charts/passmower
- git diff --check

The full integration project requires its Redis fixture; without it, Redis-dependent suites timed out/skipped, so focused fake-Kubernetes integration coverage was run successfully.