### PR TITLE
Add authenticated privilege directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ To list users:
 kubectl get oidcusers --all-namespaces -o json | jq -r '.items[] | select(.spec.type=="person") | [.metadata.name, .spec.companyEmail // "-", .status.slackId // "-", .github.id // "-", .status.profile.name] | @tsv' | column -t
 ```
 
+An authenticated, explicitly allow-listed “who has access?” directory can help
+users find people responsible for selected roles. See
+[docs/privilege-directory.md](docs/privilege-directory.md).
+
 Passmower can also accept automated user and group provisioning over SCIM 2.0.
 See [docs/scim-provisioning.md](docs/scim-provisioning.md) for endpoint,
 authentication, Entra configuration, and lifecycle behavior.

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
             - name: REQUIRED_GROUP
               value: {{ . | quote }}
             {{- end }}
+            - name: PRIVILEGE_DIRECTORY_GROUPS
+              value: {{ .Values.passmower.privilegeDirectoryGroups | default list | toJson | quote }}
             {{- with .Values.passmower.githubOrganization }}
             - name: GITHUB_ORGANIZATION
               value: {{ . | quote }}

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -17,6 +17,10 @@ passmower:
   adminGroup: ""
   # If set, require all users to be member of the given local or remote group.
   requiredGroup: ""
+  # Authenticated, read-only directory of members of selected groups. Empty by
+  # default: no roles or user contact details are exposed until explicitly set.
+  # Entries use the full "prefix:name" group identifier.
+  privilegeDirectoryGroups: []
   # GitHub organization whose team memberships are mapped into groups (named "<org>:<team>") on GitHub login.
   # This enriches users with group memberships only — it does NOT restrict who may log in; users outside the
   # organization simply sign in with no GitHub groups. To actually gate access, pair this with requiredGroup.

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -131,7 +131,8 @@ passmower:
   #    groupsClaim: groups
   #    groupPrefix: entraid
   #    clientSecretRef: entraid-client
-  # Slack API client secret name. Secret must contain SLACK_TOKEN
+  # Slack API client secret name. Secret must contain SLACK_TOKEN and may contain
+  # SLACK_TEAM_ID to avoid resolving the workspace ID through auth.test.
   # slackClientSecretRef: "slack-client"
   # Different texts displayed and sent to the user
   texts:

--- a/docs/privilege-directory.md
+++ b/docs/privilege-directory.md
@@ -1,0 +1,28 @@
+# Privilege directory
+
+Passmower can publish an authenticated, read-only directory showing who belongs
+to selected groups. It gives users a stable page to reference when they need to
+request access or contact someone responsible for a role.
+
+The directory is disabled by default. Explicitly list the groups that may be
+shown in Helm values:
+
+```yaml
+passmower:
+  privilegeDirectoryGroups:
+    - example.com:kubernetes-admins
+    - github.com:example-org:billing
+```
+
+Authenticated users can then open `/privileges` for the complete configured
+directory. Each role heading links to `/privileges/<group>`, a shareable view
+containing only that role.
+
+Only person accounts are included. The API exposes a refined projection for
+each member: username, display name, and primary email. It does not expose the
+user CRD, other group memberships, conditions, identities, or audit activity.
+Groups not present in `privilegeDirectoryGroups` return `404`, even if they
+exist on an account.
+
+Treat the configured list as a privacy decision. The page requires a valid
+Passmower site session, but every authenticated user can view its contents.

--- a/docs/privilege-directory.md
+++ b/docs/privilege-directory.md
@@ -31,5 +31,12 @@ user CRD, other group memberships, conditions, identities, or audit activity.
 Groups not present in `privilegeDirectoryGroups` return `404`, even if they
 exist on an account.
 
+When Slack integration is enabled, members linked to Slack also receive a
+“Message on Slack” deep link. Passmower obtains the workspace ID once through
+Slack `auth.test`. To avoid that lookup, the secret selected by
+`slackClientSecretRef` may provide `SLACK_TEAM_ID` alongside `SLACK_TOKEN`.
+The Slack token is never returned; the workspace and user identifiers appear
+only inside the generated deep-link URL.
+
 Treat the configured list as a privacy decision. The page requires a valid
 Passmower site session, but every authenticated user can view its contents.

--- a/docs/privilege-directory.md
+++ b/docs/privilege-directory.md
@@ -14,6 +14,13 @@ passmower:
     - github.com:example-org:billing
 ```
 
+Without the Helm chart, set `PRIVILEGE_DIRECTORY_GROUPS` to the equivalent JSON
+array string, for example:
+
+```shell
+PRIVILEGE_DIRECTORY_GROUPS='["example.com:kubernetes-admins","github.com:example-org:billing"]'
+```
+
 Authenticated users can then open `/privileges` for the complete configured
 directory. Each role heading links to `/privileges/<group>`, a shareable view
 containing only that role.

--- a/frontend/src/Apps.vue
+++ b/frontend/src/Apps.vue
@@ -1,6 +1,7 @@
 <template>
   <header>
       <a href="/profile">Profile</a>
+      <a v-if="account.privilegeDirectoryEnabled" href="/privileges">Who has access?</a>
       <a v-if="account.isAdmin" href="/admin">Admin panel</a>
   </header>
 

--- a/frontend/src/Privileges.vue
+++ b/frontend/src/Privileges.vue
@@ -2,6 +2,7 @@
   <header>
     <a href="/">Apps</a>
     <a href="/profile">Profile</a>
+    <a v-if="account.isAdmin" href="/admin">Admin panel</a>
   </header>
 
   <main>
@@ -9,6 +10,7 @@
       <h1>Who has access?</h1>
       <p>Contact one of the people listed below when you need help with a role or its resources.</p>
       <p v-if="loading">Loading roles…</p>
+      <p v-else-if="error">{{ error }}</p>
       <p v-else-if="notFound">This role is not listed.</p>
       <p v-else-if="!roles.length">No roles are published.</p>
       <section class="profile-section" v-for="role in roles" :key="role.group">
@@ -29,12 +31,19 @@
 </template>
 
 <script>
+import {mapActions, mapState} from 'pinia'
+import {useAccountStore} from './stores/account'
+
 export default {
   name: 'Privileges',
   data() {
-    return {roles: [], loading: true, notFound: false}
+    return {roles: [], loading: true, notFound: false, error: null}
+  },
+  computed: {
+    ...mapState(useAccountStore, ['account']),
   },
   created() {
+    fetch('/api/me').then(response => response.json()).then(account => this.setAccount(account)).catch(() => {})
     const group = this.$route.params.group
     const query = group ? `?group=${encodeURIComponent(group)}` : ''
     fetch(`/api/privileges${query}`).then(response => {
@@ -46,11 +55,14 @@ export default {
       return response.json()
     }).then(result => {
       this.roles = result.roles
+    }).catch(() => {
+      this.error = 'Unable to load the privilege directory. Please try again.'
     }).finally(() => {
       this.loading = false
     })
   },
   methods: {
+    ...mapActions(useAccountStore, ['setAccount']),
     roleUrl(group) {
       return `/privileges/${encodeURIComponent(group)}`
     },

--- a/frontend/src/Privileges.vue
+++ b/frontend/src/Privileges.vue
@@ -23,6 +23,7 @@
             <h3>{{ member.name || member.username }}</h3>
             <p v-if="member.name && member.name !== member.username">Username: {{ member.username }}</p>
             <p v-if="member.email"><a :href="`mailto:${member.email}`">{{ member.email }}</a></p>
+            <p v-if="member.slackUrl"><a :href="member.slackUrl">Message on Slack</a></p>
           </div>
         </div>
       </section>

--- a/frontend/src/Privileges.vue
+++ b/frontend/src/Privileges.vue
@@ -1,0 +1,59 @@
+<template>
+  <header>
+    <a href="/">Apps</a>
+    <a href="/profile">Profile</a>
+  </header>
+
+  <main>
+    <div class="card card-wide">
+      <h1>Who has access?</h1>
+      <p>Contact one of the people listed below when you need help with a role or its resources.</p>
+      <p v-if="loading">Loading roles…</p>
+      <p v-else-if="notFound">This role is not listed.</p>
+      <p v-else-if="!roles.length">No roles are published.</p>
+      <section class="profile-section" v-for="role in roles" :key="role.group">
+        <div class="profile-section-header">
+          <h2><a :href="roleUrl(role.group)">{{ role.group }}</a></h2>
+        </div>
+        <p v-if="!role.members.length">No current members.</p>
+        <div class="item" v-for="member in role.members" :key="member.username">
+          <div class="item-details">
+            <h3>{{ member.name || member.username }}</h3>
+            <p v-if="member.name && member.name !== member.username">Username: {{ member.username }}</p>
+            <p v-if="member.email"><a :href="`mailto:${member.email}`">{{ member.email }}</a></p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+</template>
+
+<script>
+export default {
+  name: 'Privileges',
+  data() {
+    return {roles: [], loading: true, notFound: false}
+  },
+  created() {
+    const group = this.$route.params.group
+    const query = group ? `?group=${encodeURIComponent(group)}` : ''
+    fetch(`/api/privileges${query}`).then(response => {
+      if (response.status === 404) {
+        this.notFound = true
+        return {roles: []}
+      }
+      if (!response.ok) throw new Error('Unable to load privilege directory')
+      return response.json()
+    }).then(result => {
+      this.roles = result.roles
+    }).finally(() => {
+      this.loading = false
+    })
+  },
+  methods: {
+    roleUrl(group) {
+      return `/privileges/${encodeURIComponent(group)}`
+    },
+  },
+}
+</script>

--- a/frontend/src/Profile.vue
+++ b/frontend/src/Profile.vue
@@ -1,6 +1,7 @@
 <template>
   <header>
     <a href="/">Apps</a>
+    <a v-if="account.privilegeDirectoryEnabled" href="/privileges">Who has access?</a>
     <a v-if="account.isAdmin" href="/admin">Admin panel</a>
   </header>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,12 +7,14 @@ import {createRouter, createWebHistory} from 'vue-router'
 import App from "./App.vue";
 import Apps from "./Apps.vue";
 import Profile from "./Profile.vue";
+import Privileges from "./Privileges.vue";
 
 const app = createApp(App)
 
 const routes = [
     { path: '/', component: Apps },
     { path: '/profile', component: Profile },
+    { path: '/privileges/:group?', component: Privileges },
     { path: '/admin', component: Admin },
 ]
 const router = createRouter({

--- a/src/adapters/slack.js
+++ b/src/adapters/slack.js
@@ -29,7 +29,8 @@ export class SlackAdapter {
         teamIdPromise ??= this.client.auth.test()
             .then(response => response.team_id)
             .catch(error => {
-                globalThis.logger.error({error}, 'getting workspace ID from Slack failed')
+                teamIdPromise = undefined
+                globalThis.logger?.error({error}, 'getting workspace ID from Slack failed')
                 return undefined
             })
         return teamIdPromise

--- a/src/adapters/slack.js
+++ b/src/adapters/slack.js
@@ -1,5 +1,7 @@
 import {WebClient} from "@slack/web-api";
 
+let teamIdPromise
+
 export class SlackAdapter {
     constructor() {
         const token = process.env.SLACK_TOKEN;
@@ -19,6 +21,18 @@ export class SlackAdapter {
                 }, 'getting user by email from Slack failed')
             }
         })
+    }
+
+    async getTeamId() {
+        if (!this.client) return undefined
+        if (process.env.SLACK_TEAM_ID) return process.env.SLACK_TEAM_ID
+        teamIdPromise ??= this.client.auth.test()
+            .then(response => response.team_id)
+            .catch(error => {
+                globalThis.logger.error({error}, 'getting workspace ID from Slack failed')
+                return undefined
+            })
+        return teamIdPromise
     }
 
     async sendMessage(userId, text) {

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -14,6 +14,7 @@ import validator, {
 } from "../utils/session/validator.js";
 import {getText} from "../utils/get-text.js";
 import {WebAuthnService} from "../services/webauthn/index.js";
+import {buildPrivilegeDirectory, getListedPrivilegeGroups} from "../utils/user/privilege-directory.js";
 
 export default (provider) => {
     const router = new Router();
@@ -86,6 +87,20 @@ export default (provider) => {
         ctx.body = {
             ...account.getProfileResponse(),
             disableEditing: process.env.DISABLE_FRONTEND_EDIT === 'true',
+            privilegeDirectoryEnabled: getListedPrivilegeGroups().length > 0,
+        }
+    })
+
+    router.get('/api/privileges', async (ctx) => {
+        const configuredGroups = getListedPrivilegeGroups()
+        const requestedGroup = ctx.query.group
+        if (requestedGroup && !configuredGroups.includes(requestedGroup)) {
+            ctx.status = 404
+            return
+        }
+        const groups = requestedGroup ? [requestedGroup] : configuredGroups
+        ctx.body = {
+            roles: buildPrivilegeDirectory(await ctx.kubeOIDCUserService.listUsers(), groups),
         }
     })
 

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -15,6 +15,7 @@ import validator, {
 import {getText} from "../utils/get-text.js";
 import {WebAuthnService} from "../services/webauthn/index.js";
 import {buildPrivilegeDirectory, getListedPrivilegeGroups} from "../utils/user/privilege-directory.js";
+import {SlackAdapter} from "../adapters/slack.js";
 
 export default (provider) => {
     const router = new Router();
@@ -99,8 +100,9 @@ export default (provider) => {
             return
         }
         const groups = requestedGroup ? [requestedGroup] : configuredGroups
+        const slackTeamId = await new SlackAdapter().getTeamId()
         ctx.body = {
-            roles: buildPrivilegeDirectory(await ctx.kubeOIDCUserService.listUsers(), groups),
+            roles: buildPrivilegeDirectory(await ctx.kubeOIDCUserService.listUsers(), groups, slackTeamId),
         }
     })
 

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -120,7 +120,7 @@ export default (provider) => {
     }))
     router.use(validator())
 
-    router.get(['/', '/profile', '/terms-of-service'], async (ctx, next) => {
+    router.get(['/', '/profile', '/privileges', '/privileges/:group', '/terms-of-service'], async (ctx, next) => {
         if (await signedInToSelf(ctx, provider)) {
             if (ctx.path === '/terms-of-service') {
                 // TODO: proper implementation

--- a/src/utils/user/privilege-directory.js
+++ b/src/utils/user/privilege-directory.js
@@ -10,7 +10,7 @@ export function getListedPrivilegeGroups(value = process.env.PRIVILEGE_DIRECTORY
     }
 }
 
-export function buildPrivilegeDirectory(accounts, groups = getListedPrivilegeGroups()) {
+export function buildPrivilegeDirectory(accounts, groups = getListedPrivilegeGroups(), slackTeamId) {
     return groups.map(group => ({
         group,
         members: accounts
@@ -20,6 +20,9 @@ export function buildPrivilegeDirectory(accounts, groups = getListedPrivilegeGro
                 username: account.accountId,
                 name: account.profile.name,
                 email: account.primaryEmail,
+                slackUrl: slackTeamId && account.slackId
+                    ? `slack://user?team=${encodeURIComponent(slackTeamId)}&id=${encodeURIComponent(account.slackId)}`
+                    : undefined,
             }))
             .sort((a, b) => (a.name ?? a.username).localeCompare(b.name ?? b.username)),
     }))

--- a/src/utils/user/privilege-directory.js
+++ b/src/utils/user/privilege-directory.js
@@ -1,0 +1,26 @@
+export function getListedPrivilegeGroups(value = process.env.PRIVILEGE_DIRECTORY_GROUPS) {
+    if (!value) return []
+    try {
+        const groups = JSON.parse(value)
+        if (!Array.isArray(groups)) throw new TypeError('expected a JSON array')
+        return [...new Set(groups.map(group => String(group).trim()).filter(Boolean))]
+    } catch (error) {
+        globalThis.logger?.warn({error}, 'Ignoring invalid PRIVILEGE_DIRECTORY_GROUPS; expected a JSON array')
+        return []
+    }
+}
+
+export function buildPrivilegeDirectory(accounts, groups = getListedPrivilegeGroups()) {
+    return groups.map(group => ({
+        group,
+        members: accounts
+            .filter(account => account.type === null || account.type === 'person')
+            .filter(account => account.groups.some(item => `${item.prefix}:${item.name}` === group))
+            .map(account => ({
+                username: account.accountId,
+                name: account.profile.name,
+                email: account.primaryEmail,
+            }))
+            .sort((a, b) => (a.name ?? a.username).localeCompare(b.name ?? b.username)),
+    }))
+}

--- a/test/unit/privilege-directory.test.js
+++ b/test/unit/privilege-directory.test.js
@@ -38,4 +38,12 @@ describe('privilege directory', () => {
             members: [{username: 'alice', name: 'Alice', email: 'alice@example.com'}],
         }])
     })
+
+    it('adds Slack links only for linked users when a workspace is configured', () => {
+        const alice = account('alice', 'person', 'Alice', 'alice@example.com', ['local:admin'])
+        alice.slackId = 'U123'
+        expect(buildPrivilegeDirectory([alice], ['local:admin'], 'T456')[0].members[0].slackUrl)
+            .toBe('slack://user?team=T456&id=U123')
+        expect(buildPrivilegeDirectory([alice], ['local:admin'])[0].members[0].slackUrl).toBeUndefined()
+    })
 })

--- a/test/unit/privilege-directory.test.js
+++ b/test/unit/privilege-directory.test.js
@@ -1,0 +1,41 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import Account from '../../src/models/account.js';
+import {buildPrivilegeDirectory, getListedPrivilegeGroups} from '../../src/utils/user/privilege-directory.js';
+
+function account(name, type, displayName, email, groups) {
+    return new Account().fromKubernetes({
+        metadata: {name},
+        spec: {type},
+        status: {
+            primaryEmail: email,
+            profile: {name: displayName},
+            groups: groups.map(group => {
+                const separator = group.indexOf(':')
+                return {prefix: group.slice(0, separator), name: group.slice(separator + 1)}
+            }),
+        },
+    })
+}
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('privilege directory', () => {
+    it('is private by default and de-duplicates configured groups', () => {
+        expect(getListedPrivilegeGroups()).toEqual([])
+        vi.stubEnv('PRIVILEGE_DIRECTORY_GROUPS', '["local:admin", "local:admin", "local:billing"]')
+        expect(getListedPrivilegeGroups()).toEqual(['local:admin', 'local:billing'])
+    })
+
+    it('returns only people and only a refined member projection', () => {
+        const users = [
+            account('alice', 'person', 'Alice', 'alice@example.com', ['local:admin', 'private:group']),
+            account('robot', 'service', 'Robot', 'robot@example.com', ['local:admin']),
+            account('bob', 'person', 'Bob', 'bob@example.com', ['local:billing']),
+        ]
+
+        expect(buildPrivilegeDirectory(users, ['local:admin'])).toEqual([{
+            group: 'local:admin',
+            members: [{username: 'alice', name: 'Alice', email: 'alice@example.com'}],
+        }])
+    })
+})

--- a/test/unit/slack-adapter.test.js
+++ b/test/unit/slack-adapter.test.js
@@ -1,0 +1,28 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {SlackAdapter} from '../../src/adapters/slack.js';
+
+const originalLogger = globalThis.logger
+
+afterEach(() => {
+    globalThis.logger = originalLogger
+    vi.unstubAllEnvs()
+})
+
+describe('SlackAdapter.getTeamId', () => {
+    it('retries workspace discovery after a transient failure without requiring a logger', async () => {
+        vi.stubEnv('SLACK_TEAM_ID', '')
+        globalThis.logger = undefined
+        const adapter = new SlackAdapter()
+        adapter.client = {
+            auth: {
+                test: vi.fn()
+                    .mockRejectedValueOnce(new Error('temporary Slack outage'))
+                    .mockResolvedValueOnce({team_id: 'T123'}),
+            },
+        }
+
+        await expect(adapter.getTeamId()).resolves.toBeUndefined()
+        await expect(adapter.getTeamId()).resolves.toBe('T123')
+        expect(adapter.client.auth.test).toHaveBeenCalledTimes(2)
+    })
+})


### PR DESCRIPTION
## Summary
- add an opt-in authenticated directory for explicitly allow-listed privilege groups
- provide overview and linkable per-role views with a refined member projection
- keep the feature private by default and return 404 for unlisted groups
- document Helm configuration and privacy boundaries

Refs #81 (the issue must be closed manually after merge because this PR targets develop).

## Verification
- npm test (123 passed)
- npm run lint:check --prefix frontend
- npm run build --prefix frontend
- helm template passmower charts/passmower
- git diff --check