### PR TITLE
Scope dashboard session cookie to issuer host

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ authentication, Entra configuration, and lifecycle behavior.
 
 For legacy applications `forwardAuth` based middleware option is supported.
 
+Forward-auth applications must use hostnames under the same registrable base
+domain as Passmower. Their per-client session cookie is scoped to that base
+domain so the browser includes it in Traefik's authentication request. The
+Passmower dashboard itself uses a host-only session cookie.
+
 ```
 ---
 apiVersion: codemowers.cloud/v1

--- a/src/utils/session/site-session.js
+++ b/src/utils/session/site-session.js
@@ -5,6 +5,8 @@ import {providerBaseDomain} from "./base-domain.js";
 import configuration from "../../configuration.js";
 import {clientId as selfClientId} from "./self-oidc-client.js";
 
+const providerHostname = new URL(process.env.ISSUER_URL).hostname
+
 const getFullSiteSessionCookieName = (clientId) => {
     return configuration.cookies.names['site_session'] + '.' + clientId
 }
@@ -13,8 +15,14 @@ export const getSiteSessionCookieDomain = (clientId) => {
     return clientId === selfClientId ? undefined : providerBaseDomain
 }
 
+export const getLegacySiteSessionCookieDomain = (clientId) => {
+    return clientId === selfClientId && providerBaseDomain !== providerHostname ? providerBaseDomain : undefined
+}
+
+// Redis records carry the scope where their cookie is valid: the exact issuer
+// host for the dashboard and the shared base domain for forward-auth clients.
 const getSiteSessionScope = (clientId) => {
-    return getSiteSessionCookieDomain(clientId) ?? new URL(process.env.ISSUER_URL).hostname
+    return getSiteSessionCookieDomain(clientId) ?? providerHostname
 }
 
 export const addSiteSession = async (ctx, provider, sessionId, accountId, client) => {
@@ -25,11 +33,19 @@ export const addSiteSession = async (ctx, provider, sessionId, accountId, client
         ...instance(provider).configuration.cookies.long,
         maxAge: instance(provider).configuration.ttl.SiteSession * 1000,
     }
+    const cookieName = getFullSiteSessionCookieName(client.clientId)
+    const legacyDomain = getLegacySiteSessionCookieDomain(client.clientId)
+    if (legacyDomain) {
+        ctx.cookies.set(cookieName, null, {
+            ...instance(provider).configuration.cookies.long,
+            domain: legacyDomain,
+        })
+    }
     if (domain) {
         cookieOptions.domain = domain
     }
     ctx.cookies.set(
-        getFullSiteSessionCookieName(client.clientId),
+        cookieName,
         siteWideCookie,
         cookieOptions
     )

--- a/src/utils/session/site-session.js
+++ b/src/utils/session/site-session.js
@@ -3,29 +3,41 @@ import instance from "oidc-provider/lib/helpers/weak_cache.js";
 import nanoid from "oidc-provider/lib/helpers/nanoid.js";
 import {providerBaseDomain} from "./base-domain.js";
 import configuration from "../../configuration.js";
+import {clientId as selfClientId} from "./self-oidc-client.js";
 
 const getFullSiteSessionCookieName = (clientId) => {
     return configuration.cookies.names['site_session'] + '.' + clientId
 }
 
+export const getSiteSessionCookieDomain = (clientId) => {
+    return clientId === selfClientId ? undefined : providerBaseDomain
+}
+
+const getSiteSessionScope = (clientId) => {
+    return getSiteSessionCookieDomain(clientId) ?? new URL(process.env.ISSUER_URL).hostname
+}
+
 export const addSiteSession = async (ctx, provider, sessionId, accountId, client) => {
     const redis = new RedisAdapter('SiteSession')
     let siteWideCookie = nanoid()
-    const domain = providerBaseDomain
+    const domain = getSiteSessionCookieDomain(client.clientId)
+    const cookieOptions = {
+        ...instance(provider).configuration.cookies.long,
+        maxAge: instance(provider).configuration.ttl.SiteSession * 1000,
+    }
+    if (domain) {
+        cookieOptions.domain = domain
+    }
     ctx.cookies.set(
         getFullSiteSessionCookieName(client.clientId),
         siteWideCookie,
-        {
-            ...instance(provider).configuration.cookies.long,
-            domain,
-            maxAge: instance(provider).configuration.ttl.SiteSession * 1000,
-        }
+        cookieOptions
     )
     siteWideCookie = {
         jti: siteWideCookie,
         sessionId,
         accountId,
-        domain,
+        domain: getSiteSessionScope(client.clientId),
     }
     await redis.upsert(siteWideCookie.jti, siteWideCookie, instance(provider).configuration.ttl.SiteSession);
     return siteWideCookie
@@ -45,7 +57,7 @@ export const validateSiteSession = async (ctx, clientId) => {
     if (baseSession?.authorizations) {
         baseSession = baseSession?.authorizations?.[clientId]
     }
-    return (baseSession && siteSession?.domain === providerBaseDomain) ? siteSession : undefined
+    return (baseSession && siteSession?.domain === getSiteSessionScope(clientId)) ? siteSession : undefined
 }
 
 export const updateSessionReference = async (sessionId, oldSessionId, accountId) => {

--- a/test/unit/site-session.test.js
+++ b/test/unit/site-session.test.js
@@ -1,5 +1,34 @@
-import {describe, expect, it} from 'vitest'
-import {getSiteSessionCookieDomain} from '../../src/utils/session/site-session.js'
+import {describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    upsert: vi.fn(),
+    providerConfiguration: {
+        cookies: {long: {httpOnly: true, secure: true}},
+        ttl: {SiteSession: 3600},
+    },
+}))
+
+vi.mock('../../src/adapters/redis.js', () => ({
+    default: class RedisAdapter {
+        upsert(...args) {
+            return mocks.upsert(...args)
+        }
+    },
+}))
+
+vi.mock('oidc-provider/lib/helpers/weak_cache.js', () => ({
+    default: () => ({configuration: mocks.providerConfiguration}),
+}))
+
+vi.mock('oidc-provider/lib/helpers/nanoid.js', () => ({
+    default: () => 'new-site-session-jti',
+}))
+
+import {
+    addSiteSession,
+    getLegacySiteSessionCookieDomain,
+    getSiteSessionCookieDomain,
+} from '../../src/utils/session/site-session.js'
 import {providerBaseDomain} from '../../src/utils/session/base-domain.js'
 
 describe('site session cookie scope', () => {
@@ -9,5 +38,29 @@ describe('site session cookie scope', () => {
 
     it('uses the provider base domain for forward-auth clients', () => {
         expect(getSiteSessionCookieDomain('apps.webmail')).toBe(providerBaseDomain)
+    })
+
+    it('expires a legacy domain cookie before setting the host-only dashboard cookie', async () => {
+        const set = vi.fn()
+
+        await addSiteSession(
+            {cookies: {set}},
+            {},
+            'session-id',
+            'account-id',
+            {clientId: 'passmower'},
+        )
+
+        expect(getLegacySiteSessionCookieDomain('passmower')).toBe(providerBaseDomain)
+        expect(set).toHaveBeenNthCalledWith(1, '_site_session.passmower', null, {
+            httpOnly: true,
+            secure: true,
+            domain: providerBaseDomain,
+        })
+        expect(set).toHaveBeenNthCalledWith(2, '_site_session.passmower', expect.any(String), {
+            httpOnly: true,
+            secure: true,
+            maxAge: 3600000,
+        })
     })
 })

--- a/test/unit/site-session.test.js
+++ b/test/unit/site-session.test.js
@@ -1,0 +1,13 @@
+import {describe, expect, it} from 'vitest'
+import {getSiteSessionCookieDomain} from '../../src/utils/session/site-session.js'
+import {providerBaseDomain} from '../../src/utils/session/base-domain.js'
+
+describe('site session cookie scope', () => {
+    it('uses a host-only cookie for the Passmower dashboard', () => {
+        expect(getSiteSessionCookieDomain('passmower')).toBeUndefined()
+    })
+
+    it('uses the provider base domain for forward-auth clients', () => {
+        expect(getSiteSessionCookieDomain('apps.webmail')).toBe(providerBaseDomain)
+    })
+})


### PR DESCRIPTION
## Summary
- make the Passmower dashboard site-session cookie host-only
- retain base-domain scoping for forward-auth client cookies
- reject legacy dashboard session records with the broader domain scope
- document the forward-auth same-base-domain constraint

## Testing
- npm test (127 passed)
- npm run test:integration (not completed: required Redis service unavailable at 127.0.0.1:6379)

Addresses the first security improvement proposed in #21. IP binding remains separate because it requires an explicit trusted-proxy and network-change policy.