### PR TITLE
Allow users to enroll multiple passkeys

### DIFF
--- a/src/services/webauthn/webauthn-service.js
+++ b/src/services/webauthn/webauthn-service.js
@@ -44,7 +44,7 @@ export class WebAuthnService {
             userDisplayName: account.profile?.name || account.username || account.accountId,
             // Prevent re-registration of existing credentials
             excludeCredentials: existingCredentials.map(cred => ({
-                id: base64URLToBuffer(cred.id),
+                id: cred.id,
                 transports: cred.transports,
             })),
             authenticatorSelection: {
@@ -130,7 +130,7 @@ export class WebAuthnService {
             const account = await this.userService.findUser(accountId);
             if (account?.webauthn?.credentials?.length) {
                 allowCredentials = account.webauthn.credentials.map(cred => ({
-                    id: base64URLToBuffer(cred.id),
+                    id: cred.id,
                     transports: cred.transports,
                 }));
             }
@@ -188,7 +188,7 @@ export class WebAuthnService {
                 expectedOrigin: this.origin,
                 expectedRPID: this.rpID,
                 credential: {
-                    id: base64URLToBuffer(credential.id),
+                    id: credential.id,
                     publicKey: base64URLToBuffer(credential.publicKey),
                     counter: credential.counter,
                     transports: credential.transports,

--- a/test/unit/webauthn-service.test.js
+++ b/test/unit/webauthn-service.test.js
@@ -1,0 +1,99 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    generateRegistrationOptions: vi.fn(),
+    generateAuthenticationOptions: vi.fn(),
+    verifyRegistrationResponse: vi.fn(),
+    verifyAuthenticationResponse: vi.fn(),
+    store: vi.fn(),
+    get: vi.fn(),
+    remove: vi.fn(),
+}))
+
+vi.mock('@simplewebauthn/server', () => ({
+    generateRegistrationOptions: mocks.generateRegistrationOptions,
+    generateAuthenticationOptions: mocks.generateAuthenticationOptions,
+    verifyRegistrationResponse: mocks.verifyRegistrationResponse,
+    verifyAuthenticationResponse: mocks.verifyAuthenticationResponse,
+}))
+
+vi.mock('../../src/services/webauthn/challenge-store.js', () => ({
+    WebAuthnChallengeStore: class WebAuthnChallengeStore {
+        store(...args) {
+            return mocks.store(...args)
+        }
+
+        get(...args) {
+            return mocks.get(...args)
+        }
+
+        remove(...args) {
+            return mocks.remove(...args)
+        }
+    },
+}))
+
+import {WebAuthnService} from '../../src/services/webauthn/webauthn-service.js'
+
+const credential = {
+    id: 'existing-credential_id',
+    publicKey: 'cHVibGljLWtleQ',
+    counter: 1,
+    transports: ['usb'],
+}
+
+const account = {
+    accountId: 'alice',
+    username: 'alice',
+    profile: {name: 'Alice'},
+    webauthn: {credentials: [credential]},
+}
+
+describe('WebAuthnService credential IDs', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.generateRegistrationOptions.mockResolvedValue({challenge: 'registration-challenge'})
+        mocks.generateAuthenticationOptions.mockResolvedValue({challenge: 'authentication-challenge'})
+    })
+
+    it('keeps existing credential IDs as base64url strings when registering another passkey', async () => {
+        const service = new WebAuthnService({})
+
+        await service.startRegistration(account)
+
+        expect(mocks.generateRegistrationOptions).toHaveBeenCalledWith(expect.objectContaining({
+            excludeCredentials: [{
+                id: credential.id,
+                transports: credential.transports,
+            }],
+        }))
+        expect(mocks.store).toHaveBeenCalledWith('reg:alice', 'registration-challenge')
+    })
+
+    it('keeps credential IDs as base64url strings in known-user authentication options', async () => {
+        const userService = {findUser: vi.fn().mockResolvedValue(account)}
+        const service = new WebAuthnService(userService)
+
+        await service.startAuthentication('interaction-id', account.accountId)
+
+        expect(mocks.generateAuthenticationOptions).toHaveBeenCalledWith(expect.objectContaining({
+            allowCredentials: [{
+                id: credential.id,
+                transports: credential.transports,
+            }],
+        }))
+    })
+
+    it('keeps the stored credential ID as a string during authentication verification', async () => {
+        mocks.get.mockResolvedValue('authentication-challenge')
+        mocks.verifyAuthenticationResponse.mockResolvedValue({verified: false})
+        const userService = {findUserByPasskeyId: vi.fn().mockResolvedValue(account)}
+        const service = new WebAuthnService(userService)
+
+        await service.finishAuthentication('interaction-id', {id: credential.id})
+
+        expect(mocks.verifyAuthenticationResponse).toHaveBeenCalledWith(expect.objectContaining({
+            credential: expect.objectContaining({id: credential.id}),
+        }))
+    })
+})


### PR DESCRIPTION
## Summary
- keep stored credential IDs as base64url strings when generating WebAuthn exclusion options
- apply the same SimpleWebAuthn v13 representation to known-user authentication and verification
- add regression coverage for registration with an existing credential

## Root cause
The first passkey worked because excludeCredentials was empty. Starting a second registration converted the existing base64url ID to a Buffer, which SimpleWebAuthn v13 rejects while generating registration options.

## Testing
- npm test (131 passed)

Fixes #162.