### PR TITLE
Render unhandled request errors safely

### DIFF
--- a/src/providers/setup-middlewares.js
+++ b/src/providers/setup-middlewares.js
@@ -9,9 +9,14 @@ import instance from "oidc-provider/lib/helpers/weak_cache.js";
 import {OIDCMiddlewareClientCrd} from "../utils/kubernetes/kube-constants.js";
 import Account from "../models/account.js";
 import nanoid from "oidc-provider/lib/helpers/nanoid.js";
+import requestErrorHandler from "../utils/request-error-handler.js";
 
 export default async (provider) => {
     const sessionMetadataRedis = new RedisAdapter('SessionMetadata')
+
+    // Keep this first so it encloses every Passmower middleware and route added
+    // after provider setup.
+    provider.use(requestErrorHandler)
 
     const directives = helmet.contentSecurityPolicy.getDefaultDirectives();
     delete directives['form-action'];

--- a/src/utils/render-error.js
+++ b/src/utils/render-error.js
@@ -1,7 +1,7 @@
 import htmlSafe from "oidc-provider/lib/helpers/html_safe.js";
 
 const renderError = (ctx, out, error) => {
-    globalThis.logger.debug({ctx, out, error})
+    globalThis.logger?.debug({ctx, out, error})
     // redirect_uri mismatches are hard to debug from the generic message, so
     // surface the attempted URI and the client's registered ones (#75).
     if (out.error === 'invalid_redirect_uri') {

--- a/src/utils/request-error-handler.js
+++ b/src/utils/request-error-handler.js
@@ -1,0 +1,24 @@
+import renderError from './render-error.js';
+
+const genericError = {
+    error: 'server_error',
+    error_description: 'An unexpected error occurred. Please try again later.',
+}
+
+export default async function requestErrorHandler(ctx, next) {
+    try {
+        await next()
+    } catch (error) {
+        // Once a response is on the wire, let Koa terminate it through its
+        // normal error path instead of attempting to append an HTML document.
+        if (ctx.headerSent) throw error
+
+        globalThis.logger?.error({
+            error,
+            method: ctx.method,
+            path: ctx.path,
+        }, 'Unhandled request error')
+        ctx.status = 500
+        renderError(ctx, genericError, error)
+    }
+}

--- a/src/utils/request-error-handler.js
+++ b/src/utils/request-error-handler.js
@@ -9,9 +9,9 @@ export default async function requestErrorHandler(ctx, next) {
     try {
         await next()
     } catch (error) {
-        // Once a response is on the wire, let Koa terminate it through its
-        // normal error path instead of attempting to append an HTML document.
-        if (ctx.headerSent) throw error
+        // Let Koa preserve intentional client errors, and once a response is
+        // on the wire do not attempt to append an HTML document.
+        if (ctx.headerSent || (error.status >= 400 && error.status < 500)) throw error
 
         globalThis.logger?.error({
             error,

--- a/test/unit/render-error.test.js
+++ b/test/unit/render-error.test.js
@@ -31,4 +31,14 @@ describe('renderError', () => {
         const body = render({ error: 'invalid_redirect_uri', error_description: 'mismatch' }, undefined)
         expect(body).toContain('mismatch')
     })
+
+    it('renders when logging is not initialized', () => {
+        const logger = globalThis.logger
+        delete globalThis.logger
+        try {
+            expect(render({ error: 'server_error', error_description: 'try later' }, {})).toContain('try later')
+        } finally {
+            globalThis.logger = logger
+        }
+    })
 })

--- a/test/unit/request-error-handler.test.js
+++ b/test/unit/request-error-handler.test.js
@@ -1,0 +1,40 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import requestErrorHandler from '../../src/utils/request-error-handler.js'
+
+describe('requestErrorHandler', () => {
+    beforeEach(() => {
+        globalThis.logger = {error: vi.fn(), debug: vi.fn()}
+    })
+
+    it('renders a safe HTML response for an unhandled request error', async () => {
+        const ctx = {method: 'GET', path: '/profile'}
+        const error = new Error('redis password was hunter2')
+
+        await requestErrorHandler(ctx, async () => {
+            throw error
+        })
+
+        expect(ctx.status).toBe(500)
+        expect(ctx.type).toBe('html')
+        expect(ctx.body).toContain('server_error')
+        expect(ctx.body).toContain('An unexpected error occurred')
+        expect(ctx.body).not.toContain(error.message)
+        expect(globalThis.logger.error).toHaveBeenCalledWith({
+            error,
+            method: 'GET',
+            path: '/profile',
+        }, 'Unhandled request error')
+    })
+
+    it('does not replace a response after its headers were sent', async () => {
+        const ctx = {headerSent: true}
+        const error = new Error('stream failed')
+
+        await expect(requestErrorHandler(ctx, async () => {
+            throw error
+        })).rejects.toBe(error)
+
+        expect(ctx.body).toBeUndefined()
+        expect(globalThis.logger.error).not.toHaveBeenCalled()
+    })
+})

--- a/test/unit/request-error-handler.test.js
+++ b/test/unit/request-error-handler.test.js
@@ -37,4 +37,20 @@ describe('requestErrorHandler', () => {
         expect(ctx.body).toBeUndefined()
         expect(globalThis.logger.error).not.toHaveBeenCalled()
     })
+
+    it('leaves intentional client errors to Koa', async () => {
+        const ctx = {method: 'GET', path: '/interaction/id/passkey/start'}
+        const error = Object.assign(new Error('Passkey login is disabled'), {
+            status: 404,
+            expose: true,
+        })
+
+        await expect(requestErrorHandler(ctx, async () => {
+            throw error
+        })).rejects.toBe(error)
+
+        expect(ctx.status).toBeUndefined()
+        expect(ctx.body).toBeUndefined()
+        expect(globalThis.logger.error).not.toHaveBeenCalled()
+    })
 })


### PR DESCRIPTION
## Summary
- install an outer error boundary around Passmower middleware and routes
- render unexpected failures through the existing branded error page with HTTP 500
- log the original exception while keeping its message out of the client response
- rethrow failures when response headers have already been sent

## Testing
- npm test (133 passed)

Fixes #2.