### PR TITLE
Record the administrator who invited a user

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -323,6 +323,9 @@ spec:
                   type: string
                 name:
                   type: string
+                onboardedBy:
+                  type: string
+                  description: Account ID of the administrator who invited this user
             identities:
               # Federated identities from generic OIDC upstream providers
               # (e.g. google, gitlab, entraid), keyed by provider name.

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -323,9 +323,6 @@ spec:
                   type: string
                 name:
                   type: string
-                onboardedBy:
-                  type: string
-                  description: Account ID of the administrator who invited this user
             identities:
               # Federated identities from generic OIDC upstream providers
               # (e.g. google, gitlab, entraid), keyed by provider name.
@@ -404,6 +401,9 @@ spec:
                         type: string
                 name:
                   type: string
+                onboardedBy:
+                  type: string
+                  description: Account ID of the administrator who invited this user
             slack:
               type: object
               properties:

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -22,6 +22,7 @@
                 <h3>{{ account.accountId }}</h3>
                 <p>Name: {{ account.name }}</p>
                 <p>Primary email: {{ account.email }}</p>
+                <p v-if="account.onboardedBy">Invited by: {{ account.onboardedBy }}</p>
                 <p>Conditions: {{ account.conditions.filter(c => c.status === 'True').map(c => c.type).join(', ') }}</p>
                 <p v-if="emailConflict(account)" class="notice">
                     Email conflict: {{ emailConflict(account).message }}

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -195,6 +195,7 @@ class Account {
                 impersonationEnabled: requesterAccountId !== this.accountId,
                 approved: this.isAdmin || (new Approved()).check(this),
                 conditions: this.#conditions,
+                onboardedBy: this.#passmower?.onboardedBy ?? null,
                 // Refined read-only activity projection for the admin UI. Do not
                 // expose the rest of the CRD status or any raw audit-log fields.
                 recentApplications: this.#recentApplications.map(application => ({

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -149,12 +149,16 @@ export default (provider) => {
             ctx.body = {errors: [{param: 'email', msg: 'Email is already taken'}]}
             return
         }
+        const onboardedBy = ctx.adminSession.accountId
+        await ctx.kubeOIDCUserService.updateUserSpecs(account.accountId, {
+            passmower: {onboardedBy},
+        })
         let condition = new UsernameCommitted()
         condition = condition.setStatus(true)
         account.addCondition(condition)
         await ctx.kubeOIDCUserService.updateUserStatus(account)
         await Account.approve(ctx, account.accountId)
-        auditLog(ctx, {email}, 'Admin invited user')
+        auditLog(ctx, {email, onboardedBy}, 'Admin invited user')
         let accounts = await ctx.kubeOIDCUserService.listUsers()
         ctx.body = {
             accounts: accounts.map((acc) => acc.getProfileResponse(true))

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -95,6 +95,17 @@ describe('Account.getProfileResponse', () => {
         const response = account({status: {recentApplications}}).getProfileResponse()
         expect(response.recentApplications).toBeUndefined()
     })
+
+    it('exposes the onboarder only in the admin profile response', () => {
+        const invited = account({passmower: {onboardedBy: 'admin-user'}})
+
+        expect(invited.getProfileResponse(true).onboardedBy).toBe('admin-user')
+        expect(invited.getProfileResponse().onboardedBy).toBeUndefined()
+    })
+
+    it('returns null onboarder metadata for users not created through an admin invite', () => {
+        expect(account().getProfileResponse(true).onboardedBy).toBeNull()
+    })
 })
 
 describe('Account.claims', () => {

--- a/test/unit/crd-schema.test.js
+++ b/test/unit/crd-schema.test.js
@@ -1,0 +1,14 @@
+import {readFileSync} from 'node:fs'
+import {describe, expect, it} from 'vitest'
+
+const crds = readFileSync(new URL('../../charts/passmower/templates/crds.yaml', import.meta.url), 'utf8')
+
+describe('OIDCUser CRD schema', () => {
+    it('declares onboardedBy under passmower rather than an upstream identity', () => {
+        const github = crds.slice(crds.indexOf('\n            github:'), crds.indexOf('\n            identities:'))
+        const passmower = crds.slice(crds.indexOf('\n            passmower:'), crds.indexOf('\n            slack:'))
+
+        expect(github).not.toContain('onboardedBy:')
+        expect(passmower).toContain('onboardedBy:')
+    })
+})


### PR DESCRIPTION
## Summary
- persist the inviting administrator account ID as passmower.onboardedBy
- expose onboarder metadata only in the admin account API projection
- display the inviter in the admin user list
- leave self-enrolled, SCIM, and GitOps-created users unset

## Testing
- npm test (137 passed)
- frontend npm run lint:check
- helm template passmower charts/passmower

Fixes #61.