### PR TITLE
Store Terms of Service acceptance outside conditions

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -520,6 +520,17 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 slackId:
                   type: string
+                termsOfService:
+                  type: object
+                  description: Durable Terms of Service acceptance state; not a Kubernetes condition
+                  properties:
+                    acceptedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    contentHash:
+                      type: string
+                      nullable: true
                 recentApplications:
                   type: array
                   description: >-

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -170,6 +170,15 @@ non-breaking way:
 > 2.0 window so the eventual removal is a no-op for you. (A version can only be dropped
 > once no stored objects remain on it — re-applying your resources as `v1` ensures that.)
 
+### Terms of Service acceptance moved out of conditions
+
+ToS acceptance is durable account state, not an observation about the current
+resource, so new acceptances are stored under `OIDCUser.status.termsOfService` with
+`acceptedAt` and `contentHash` fields. Passmower continues to recognize the legacy
+`status.conditions[type=ToSv1]` entry and automatically replaces it on the next status
+write. No user action or renewed acceptance is required. External tooling that reads
+the old condition should switch to `status.termsOfService.acceptedAt`.
+
 ---
 
 ## 4. RBAC change — automatic

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -23,6 +23,9 @@
                 <p>Name: {{ account.name }}</p>
                 <p>Primary email: {{ account.email }}</p>
                 <p v-if="account.onboardedBy">Invited by: {{ account.onboardedBy }}</p>
+                <p v-if="account.tos_accepted_at">
+                    Terms of Service accepted: {{ formatDate(account.tos_accepted_at) }}
+                </p>
                 <p>Conditions: {{ account.conditions.filter(c => c.status === 'True').map(c => c.type).join(', ') }}</p>
                 <p v-if="emailConflict(account)" class="notice">
                     Email conflict: {{ emailConflict(account).message }}

--- a/src/conditions/tosv1.js
+++ b/src/conditions/tosv1.js
@@ -1,5 +1,0 @@
-import {BaseCondition} from "./base-condition.js";
-
-export class ToSv1 extends BaseCondition {
-    type = 'ToSv1'
-}

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -36,6 +36,7 @@ class Account {
     #identities = {}
     #webauthn = null
     #conditions = []
+    #termsOfService = null
     #labels = {}
     #metadata = {}
     #ctx = null
@@ -60,6 +61,7 @@ class Account {
         this.profile = apiResponse.status?.profile ?? {}
         this.slackId = apiResponse.status?.slackId ?? null
         this.#conditions = apiResponse.status?.conditions ?? []
+        this.#termsOfService = apiResponse.status?.termsOfService ?? null
         this.#recentApplications = apiResponse.status?.recentApplications ?? []
         this.#labels = apiResponse.metadata?.labels ?? {}
         this.#metadata = apiResponse.metadata
@@ -172,7 +174,8 @@ class Account {
             },
             slackId: this.#slack?.id ?? null,
             passkeyCount: this.#webauthn?.credentials?.length ?? 0,
-            conditions: this.#conditions,
+            conditions: this.#conditions.filter(condition => condition.type !== 'ToSv1'),
+            termsOfService: this.getTermsOfServiceAcceptance(),
             recentApplications: this.#recentApplications,
         }
     }
@@ -186,7 +189,7 @@ class Account {
             phones: this.profile.phones,
             isAdmin: this.isAdmin,
             groups: this.#mapGroups(),
-            tos_accepted_at: this.#conditions.find(c => c.type === 'ToSv1')?.lastTransitionTime,
+            tos_accepted_at: this.getTermsOfServiceAcceptance()?.acceptedAt,
         }
         if (forAdmin) {
             profile = {
@@ -253,6 +256,24 @@ class Account {
 
     setConditions(conditions) {
         this.#conditions = conditions
+        return this
+    }
+
+    getTermsOfServiceAcceptance() {
+        if (this.#termsOfService) return this.#termsOfService
+        const legacy = this.#conditions.find(condition => condition.type === 'ToSv1' && condition.status === 'True')
+        return legacy ? {
+            acceptedAt: legacy.lastTransitionTime ?? null,
+            contentHash: null,
+        } : undefined
+    }
+
+    acceptTermsOfService(contentHash, acceptedAt = new Date()) {
+        this.#termsOfService = {
+            acceptedAt: acceptedAt instanceof Date ? acceptedAt.toISOString() : acceptedAt,
+            contentHash,
+        }
+        this.#conditions = this.#conditions.filter(condition => condition.type !== 'ToSv1')
         return this
     }
 

--- a/src/utils/user/confirm-tos.js
+++ b/src/utils/user/confirm-tos.js
@@ -1,19 +1,17 @@
 import Account from "../../models/account.js";
-import {ToSv1} from "../../conditions/tosv1.js";
 import EmailAdapter from "../../adapters/email.js";
 import {getText, ToSTextName} from "../get-text.js";
 import {getEmailContent, getEmailSubject} from "../get-email-content.js";
 
 export const confirmTos = async (ctx, accountId, contentHash) => {
     let account = await Account.findAccount(ctx, accountId)
-    let condition = new ToSv1()
-    condition = condition.setStatus(true)
-    account.addCondition(condition)
+    const acceptedAt = new Date()
+    account.acceptTermsOfService(contentHash, acceptedAt)
     await ctx.kubeOIDCUserService.updateUserStatus(account)
 
     const content = await getEmailContent('emails/tos', {
         name: account.profile.name,
-        timestamp: new Date(),
+        timestamp: acceptedAt,
         hash: contentHash,
         content: getText(ToSTextName)
     })

--- a/src/utils/user/tos-required.js
+++ b/src/utils/user/tos-required.js
@@ -1,5 +1,3 @@
-import { ToSv1 } from "../../conditions/tosv1.js"
-
 // Whether the account must accept the Terms of Service before continuing.
 // ToS only applies to people — service accounts, orgs and groups skip it
 // (#62). An account with no type set is treated as a person.
@@ -8,5 +6,5 @@ export const tosRequired = (account) => {
     if (type && type !== 'person') {
         return false
     }
-    return !(new ToSv1()).check(account)
+    return !account?.getTermsOfServiceAcceptance()
 }

--- a/test/integration/email-login.test.js
+++ b/test/integration/email-login.test.js
@@ -66,7 +66,11 @@ describe('email magic-link login (HTTP)', () => {
                 emails: ['test@example.com'],
                 groups: [],
                 profile: { name: 'Test User' },
-                conditions: [{ type: 'ToSv1', status: 'True' }],
+                conditions: [],
+                termsOfService: {
+                    acceptedAt: '2026-08-06T12:00:00.000Z',
+                    contentHash: 'test-content-hash',
+                },
             },
         })
     })

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -67,6 +67,31 @@ describe('Account.getIntendedStatus', () => {
         expect(status.profile.name).toBe('GH Name')
         expect(status.profile.company).toBe('GH Co')
     })
+
+    it('stores ToS acceptance outside conditions', () => {
+        const acceptedAt = new Date('2026-08-06T12:00:00.000Z')
+        const status = account({status: {conditions: [{type: 'Ready', status: 'True'}]}})
+            .acceptTermsOfService('content-hash', acceptedAt)
+            .getIntendedStatus()
+
+        expect(status.termsOfService).toEqual({
+            acceptedAt: acceptedAt.toISOString(),
+            contentHash: 'content-hash',
+        })
+        expect(status.conditions).toEqual([{type: 'Ready', status: 'True'}])
+    })
+
+    it('migrates legacy ToSv1 acceptance on the next status projection', () => {
+        const status = account({status: {conditions: [{
+            type: 'ToSv1', status: 'True', lastTransitionTime: '2025-01-01T00:00:00.000Z',
+        }, {type: 'Ready', status: 'True'}]}}).getIntendedStatus()
+
+        expect(status.termsOfService).toEqual({
+            acceptedAt: '2025-01-01T00:00:00.000Z',
+            contentHash: null,
+        })
+        expect(status.conditions).toEqual([{type: 'Ready', status: 'True'}])
+    })
 })
 
 describe('Account.getProfileResponse', () => {
@@ -105,6 +130,16 @@ describe('Account.getProfileResponse', () => {
 
     it('returns null onboarder metadata for users not created through an admin invite', () => {
         expect(account().getProfileResponse(true).onboardedBy).toBeNull()
+    })
+
+    it('projects the dedicated ToS acceptance timestamp without exposing its content hash', () => {
+        const response = account({status: {termsOfService: {
+            acceptedAt: '2026-08-06T12:00:00.000Z',
+            contentHash: 'content-hash',
+        }}}).getProfileResponse()
+
+        expect(response.tos_accepted_at).toBe('2026-08-06T12:00:00.000Z')
+        expect(response.termsOfService).toBeUndefined()
     })
 })
 

--- a/test/unit/conditions.test.js
+++ b/test/unit/conditions.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import Account from '../../src/models/account.js'
-import { ToSv1 } from '../../src/conditions/tosv1.js'
 import { Approved } from '../../src/conditions/approved.js'
 
 afterEach(() => vi.unstubAllEnvs())
@@ -11,21 +10,6 @@ function accountWith({ conditions = [], groups = [] } = {}) {
         status: { conditions, groups },
     })
 }
-
-describe('ToSv1 condition', () => {
-    it('check() is true only when a True ToSv1 condition is present', () => {
-        const cond = new ToSv1()
-        expect(cond.check(accountWith({ conditions: [{ type: 'ToSv1', status: 'True' }] }))).toBe(true)
-        expect(cond.check(accountWith({ conditions: [{ type: 'ToSv1', status: 'False' }] }))).toBe(false)
-        expect(cond.check(accountWith({ conditions: [] }))).toBeFalsy()
-    })
-
-    it('set()/add() append a True condition that check() then accepts', () => {
-        const account = accountWith()
-        new ToSv1().setStatus(true).set(account)
-        expect(new ToSv1().check(account)).toBe(true)
-    })
-})
 
 describe('Approved condition', () => {
     it('approves everyone when REQUIRED_GROUP is not set', () => {

--- a/test/unit/confirm-tos.test.js
+++ b/test/unit/confirm-tos.test.js
@@ -42,6 +42,5 @@ describe('confirmTos', () => {
         expect(mocks.sendMail).toHaveBeenCalledWith(
             'alice@example.com', 'Terms accepted', 'text', '<p>html</p>',
         )
-        expect(account.addCondition).toBeUndefined()
     })
 })

--- a/test/unit/confirm-tos.test.js
+++ b/test/unit/confirm-tos.test.js
@@ -1,0 +1,47 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({sendMail: vi.fn()}))
+
+vi.mock('../../src/adapters/email.js', () => ({
+    default: class EmailAdapter {
+        sendMail(...args) {
+            return mocks.sendMail(...args)
+        }
+    },
+}))
+
+vi.mock('../../src/utils/get-email-content.js', () => ({
+    getEmailContent: vi.fn().mockResolvedValue({text: 'text', html: '<p>html</p>'}),
+    getEmailSubject: vi.fn().mockReturnValue('Terms accepted'),
+}))
+
+vi.mock('../../src/utils/get-text.js', () => ({
+    getText: vi.fn().mockReturnValue('Terms'),
+    ToSTextName: 'termsOfService',
+}))
+
+import Account from '../../src/models/account.js'
+import {confirmTos} from '../../src/utils/user/confirm-tos.js'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('confirmTos', () => {
+    it('persists dedicated acceptance state before sending confirmation email', async () => {
+        const account = {
+            profile: {name: 'Alice'},
+            primaryEmail: 'alice@example.com',
+            acceptTermsOfService: vi.fn(),
+        }
+        vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
+        const updateUserStatus = vi.fn()
+
+        await confirmTos({kubeOIDCUserService: {updateUserStatus}}, 'alice', 'content-hash')
+
+        expect(account.acceptTermsOfService).toHaveBeenCalledWith('content-hash', expect.any(Date))
+        expect(updateUserStatus).toHaveBeenCalledWith(account)
+        expect(mocks.sendMail).toHaveBeenCalledWith(
+            'alice@example.com', 'Terms accepted', 'text', '<p>html</p>',
+        )
+        expect(account.addCondition).toBeUndefined()
+    })
+})

--- a/test/unit/crd-schema.test.js
+++ b/test/unit/crd-schema.test.js
@@ -11,4 +11,15 @@ describe('OIDCUser CRD schema', () => {
         expect(github).not.toContain('onboardedBy:')
         expect(passmower).toContain('onboardedBy:')
     })
+
+    it('declares Terms of Service acceptance in status rather than spec', () => {
+        const oidcUserSchema = crds.slice(crds.indexOf('&oidcUserSchema'), crds.indexOf('\n    additionalPrinterColumns:', crds.indexOf('&oidcUserSchema')))
+        const specStart = oidcUserSchema.indexOf('\n            spec:')
+        const statusStart = oidcUserSchema.indexOf('\n            status:')
+        const spec = oidcUserSchema.slice(specStart, statusStart)
+        const status = oidcUserSchema.slice(statusStart)
+
+        expect(spec).not.toContain('termsOfService:')
+        expect(status).toContain('termsOfService:')
+    })
 })

--- a/test/unit/tos-required.test.js
+++ b/test/unit/tos-required.test.js
@@ -2,11 +2,19 @@ import { describe, it, expect } from 'vitest'
 import Account from '../../src/models/account.js'
 import { tosRequired } from '../../src/utils/user/tos-required.js'
 
-function account({ type, tosAccepted = false } = {}) {
+function account({ type, tosAccepted = false, legacyAccepted = false } = {}) {
     return new Account().fromKubernetes({
         metadata: { name: 'u', labels: {} },
         spec: type ? { type } : {},
-        status: { conditions: tosAccepted ? [{ type: 'ToSv1', status: 'True' }] : [] },
+        status: {
+            termsOfService: tosAccepted ? {
+                acceptedAt: '2026-08-06T12:00:00.000Z',
+                contentHash: 'sha256',
+            } : undefined,
+            conditions: legacyAccepted ? [{
+                type: 'ToSv1', status: 'True', lastTransitionTime: '2025-01-01T00:00:00.000Z',
+            }] : [],
+        },
     })
 }
 
@@ -17,6 +25,10 @@ describe('tosRequired (#62: ToS only applies to people)', () => {
 
     it('does not require ToS once a person has accepted it', () => {
         expect(tosRequired(account({ type: 'person', tosAccepted: true }))).toBe(false)
+    })
+
+    it('accepts the legacy ToSv1 condition during migration', () => {
+        expect(tosRequired(account({type: 'person', legacyAccepted: true}))).toBe(false)
     })
 
     it('treats an account with no type as a person', () => {


### PR DESCRIPTION
## Summary
- persist durable ToS acceptance in OIDCUser status.termsOfService with acceptedAt and contentHash
- stop writing new ToSv1 Kubernetes conditions
- continue recognizing legacy ToSv1=True conditions during rollout
- automatically migrate legacy acceptance and remove only the legacy condition on the next status write
- preserve the existing profile tos_accepted_at API
- document the automatic migration for external status consumers

## Testing
- npm test (146 passed)
- helm template passmower charts/passmower
- one email-login integration fixture uses the new status representation; legacy fixtures retain migration coverage

Fixes #54.