### PR TITLE
Report client reconciliation conditions and events

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -765,6 +765,9 @@ spec:
           type: string
           description: Passmower deployment which manages this client
           jsonPath: .status.instance
+        - name: Ready
+          type: string
+          jsonPath: '.status.conditions[?(@.type=="Ready")].status'
         - name: Disabled
           type: boolean
           jsonPath: .spec.disabled
@@ -876,6 +879,9 @@ spec:
           type: string
           description: Passmower deployment which manages this client
           jsonPath: .status.instance
+        - name: Ready
+          type: string
+          jsonPath: '.status.conditions[?(@.type=="Ready")].status'
         - name: Disabled
           type: boolean
           jsonPath: .spec.disabled

--- a/src/models/client-activity-state.js
+++ b/src/models/client-activity-state.js
@@ -29,9 +29,28 @@ export class ClientActivityState {
             message: inactive
                 ? `Client has not been used for at least ${inactiveAfterDays} days`
                 : `Client was used within the last ${inactiveAfterDays} days`,
-            lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : now.toISOString(),
+            lastTransitionTime: previous?.status === status && previous.lastTransitionTime
+                ? previous.lastTransitionTime
+                : now.toISOString(),
         }
         this.conditions = [...this.conditions.filter(item => item.type !== 'Inactive'), condition]
+    }
+
+    updateReadyCondition(ready, reason, message, now = new Date()) {
+        const previous = this.conditions.find(condition => condition.type === 'Ready')
+        const status = ready ? 'True' : 'False'
+        const condition = {
+            type: 'Ready',
+            status,
+            reason,
+            message,
+            lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : now.toISOString(),
+        }
+        this.conditions = [...this.conditions.filter(item => item.type !== 'Ready'), condition]
+        return !previous
+            || previous.status !== status
+            || previous.reason !== reason
+            || previous.message !== message
     }
 
     // metadata.generation covers spec changes but not annotations. Description

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -215,6 +215,18 @@ class OIDCClient {
         return this
     }
 
+    updateReadyCondition(ready, reason, message, now) {
+        return this.#activityState.updateReadyCondition(ready, reason, message, now)
+    }
+
+    getMetadata() {
+        return new KubeOwnerMetadata(
+            OIDCClientCrd,
+            this.#clientName,
+            this.#uid
+        )
+    }
+
     getReconcileFingerprint() {
         return this.#activityState.getReconcileFingerprint()
     }

--- a/src/models/oidc-middleware-client.js
+++ b/src/models/oidc-middleware-client.js
@@ -122,6 +122,10 @@ export default class OIDCMiddlewareClient {
         return this
     }
 
+    updateReadyCondition(ready, reason, message, now) {
+        return this.#activityState.updateReadyCondition(ready, reason, message, now)
+    }
+
     getReconcileFingerprint() {
         return this.#activityState.getReconcileFingerprint()
     }

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -92,7 +92,12 @@ export class KubeOIDCClientOperator {
 
     async #updateOIDCClient(OIDCClient) {
         if (!this.reconcileState.shouldReconcile(OIDCClient)) return
-        if (OIDCClient.getInstance() !== this.instance) return
+        if (OIDCClient.getInstance() !== this.instance) {
+            if (OIDCClient.getInstance()) return
+            const claimedClient = await this.#replaceClientStatus(OIDCClient)
+            if (claimedClient?.getInstance() !== this.instance) return
+            OIDCClient = claimedClient
+        }
         try {
             if (OIDCClient.isDisabled()) {
                 await this.redisAdapter.destroy(OIDCClient.getClientId())

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -10,8 +10,8 @@ import {getActivityTracker} from "../services/activity-tracker.js";
 import {ClientReconcileState} from '../models/client-activity-state.js';
 
 export class KubeOIDCClientOperator {
-    constructor(provider, adapter = new KubernetesAdapter()) {
-        this.redisAdapter = new RedisAdapter('Client')
+    constructor(provider, adapter = new KubernetesAdapter(), redisAdapter = new RedisAdapter('Client')) {
+        this.redisAdapter = redisAdapter
         this.provider = provider
         this.adapter = adapter
         this.instance = this.adapter.instance
@@ -32,35 +32,49 @@ export class KubeOIDCClientOperator {
 
     async #createOIDCClient (OIDCClient) {
         this.reconcileState.register(OIDCClient)
-        if (OIDCClient.getInstance() === this.instance) {
-            if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
-                let secret = await this.adapter.getSecret(
-                    OIDCClient.getClientNamespace(),
-                    OIDCClient.getSecretName()
-                )
-                if (secret) {
-                    OIDCClient.setSecret(secret.data[OIDCClientSecretClientSecretKey])
-                } else {
-                    OIDCClient.generateSecret()
-                    await this.adapter.deleteSecret(
+        try {
+            if (OIDCClient.getInstance() === this.instance) {
+                if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
+                    let secret = await this.adapter.getSecret(
                         OIDCClient.getClientNamespace(),
                         OIDCClient.getSecretName()
                     )
-                    await this.#createKubeSecret(OIDCClient)
+                    if (secret) {
+                        OIDCClient.setSecret(secret.data[OIDCClientSecretClientSecretKey])
+                    } else {
+                        OIDCClient.generateSecret()
+                        await this.adapter.deleteSecret(
+                            OIDCClient.getClientNamespace(),
+                            OIDCClient.getSecretName()
+                        )
+                        await this.#createKubeSecret(OIDCClient)
+                    }
                 }
+            } else if (!OIDCClient.getInstance()) {
+                // Claim that client. Continue with the returned resource so later
+                // status writes use the resourceVersion produced by the claim.
+                const claimedClient = await this.#replaceClientStatus(OIDCClient)
+                if (claimedClient?.getInstance() === this.instance) {
+                    OIDCClient = claimedClient
+                    OIDCClient.generateSecret()
+                    await this.#createKubeSecret(OIDCClient)
+                } else {
+                    return
+                }
+            } else {
+                return
             }
-        } else if (!OIDCClient.getInstance()) {
-            // Claim that client
-            const claimedClient = await this.#replaceClientStatus(OIDCClient)
-            if (claimedClient?.getInstance() === this.instance) {
-                OIDCClient.generateSecret()
-                await this.#createKubeSecret(OIDCClient)
+            if (OIDCClient.isDisabled()) {
+                await this.redisAdapter.destroy(OIDCClient.getClientId())
+                await this.#reportReady(OIDCClient, 'Disabled', 'Client is disabled and absent from Redis')
+            } else {
+                if (OIDCClient.hasSecret()) {
+                    await this.redisAdapter.upsert(OIDCClient.getClientId(), OIDCClient.toRedis())
+                }
+                await this.#reportReady(OIDCClient, 'Reconciled', 'Client reconciliation completed successfully')
             }
-        }
-        if (OIDCClient.isDisabled()) {
-            await this.redisAdapter.destroy(OIDCClient.getClientId())
-        } else if (OIDCClient.hasSecret()) {
-            await this.redisAdapter.upsert(OIDCClient.getClientId(), OIDCClient.toRedis())
+        } catch (error) {
+            await this.#reportFailure(OIDCClient, error)
         }
     }
 
@@ -78,58 +92,96 @@ export class KubeOIDCClientOperator {
 
     async #updateOIDCClient(OIDCClient) {
         if (!this.reconcileState.shouldReconcile(OIDCClient)) return
-        if (OIDCClient.isDisabled()) {
-            await this.redisAdapter.destroy(OIDCClient.getClientId())
-            return
-        }
-        await new Promise(res => setTimeout(res, 1000));
-        let secret = await this.adapter.getSecret(
-            OIDCClient.getClientNamespace(),
-            OIDCClient.getSecretName()
-        )
-        if (secret) {
-            OIDCClient.setSecret(secret.data[OIDCClientSecretClientSecretKey])
-            await this.#patchKubeSecret(OIDCClient, secret)
-        } else {
-            OIDCClient.generateSecret()
-            await this.adapter.deleteSecret(
+        if (OIDCClient.getInstance() !== this.instance) return
+        try {
+            if (OIDCClient.isDisabled()) {
+                await this.redisAdapter.destroy(OIDCClient.getClientId())
+                await this.#reportReady(OIDCClient, 'Disabled', 'Client is disabled and absent from Redis')
+                return
+            }
+            await new Promise(res => setTimeout(res, 1000));
+            let secret = await this.adapter.getSecret(
                 OIDCClient.getClientNamespace(),
                 OIDCClient.getSecretName()
             )
-            await this.#createKubeSecret(OIDCClient)
+            if (secret) {
+                OIDCClient.setSecret(secret.data[OIDCClientSecretClientSecretKey])
+                await this.#patchKubeSecret(OIDCClient, secret)
+            } else {
+                OIDCClient.generateSecret()
+                await this.adapter.deleteSecret(
+                    OIDCClient.getClientNamespace(),
+                    OIDCClient.getSecretName()
+                )
+                await this.#createKubeSecret(OIDCClient)
+            }
+            await this.redisAdapter.upsert(OIDCClient.getClientId(), OIDCClient.toRedis())
+            await this.#reportReady(OIDCClient, 'Reconciled', 'Client reconciliation completed successfully')
+        } catch (error) {
+            await this.#reportFailure(OIDCClient, error)
         }
-        await this.redisAdapter.upsert(OIDCClient.getClientId(), OIDCClient.toRedis())
     }
 
     async #createKubeSecret(OIDCClient) {
-        await this.adapter.createSecret(
+        const secret = await this.adapter.createSecret(
             OIDCClient.getClientNamespace(),
             OIDCClient.getSecretName(),
             OIDCClient.toClientSecret(this.provider),
             OIDCClient.toClientSecretMetadata(),
         )
+        if (!secret) throw this.#reconcileError('SecretReconcileFailed', 'Failed to create client Secret')
         if (OIDCClient.getSecretRefreshJob()) {
-            await this.adapter.createJob(
+            const job = await this.adapter.createJob(
                 OIDCClient.getClientNamespace(),
                 OIDCClient.getSecretRefreshJob()
             )
+            if (!job) throw this.#reconcileError('RefreshJobReconcileFailed', 'Failed to create secret-refresh Job')
         }
     }
 
     async #patchKubeSecret(OIDCClient, existingSecret) {
-        await this.adapter.patchSecret(
+        const secret = await this.adapter.patchSecret(
             OIDCClient.getClientNamespace(),
             OIDCClient.getSecretName(),
             OIDCClient.toClientSecret(this.provider),
             OIDCClient.toClientSecretMetadata(),
             existingSecret
         )
+        if (!secret) throw this.#reconcileError('SecretReconcileFailed', 'Failed to update client Secret')
         if (OIDCClient.getSecretRefreshJob()) {
-            await this.adapter.createJob(
+            const job = await this.adapter.createJob(
                 OIDCClient.getClientNamespace(),
                 OIDCClient.getSecretRefreshJob()
             )
+            if (!job) throw this.#reconcileError('RefreshJobReconcileFailed', 'Failed to create secret-refresh Job')
         }
+    }
+
+    #reconcileError(reason, message) {
+        return Object.assign(new Error(message), {reason})
+    }
+
+    async #reportReady(OIDCClient, reason, message) {
+        const changed = OIDCClient.updateReadyCondition(true, reason, message)
+        const updatedClient = await this.#replaceClientStatus(OIDCClient)
+        if (changed && updatedClient) {
+            await this.adapter.createEvent(
+                OIDCClient.getClientNamespace(), OIDCClient.getMetadata(), reason, message, 'Normal'
+            )
+        }
+    }
+
+    async #reportFailure(OIDCClient, error) {
+        const reason = error.reason ?? 'ReconcileFailed'
+        const message = error.message ?? 'Client reconciliation failed'
+        const changed = OIDCClient.updateReadyCondition(false, reason, message)
+        await this.#replaceClientStatus(OIDCClient)
+        if (changed) {
+            await this.adapter.createEvent(
+                OIDCClient.getClientNamespace(), OIDCClient.getMetadata(), reason, message
+            )
+        }
+        globalThis.logger.error({error, client: OIDCClient.getClientId()}, 'Failed to reconcile OIDCClient')
     }
 
     async #deleteOIDCClient (OIDCClient) {

--- a/src/operators/kube-oidc-middleware-client-operator.js
+++ b/src/operators/kube-oidc-middleware-client-operator.js
@@ -11,8 +11,8 @@ import {getActivityTracker} from '../services/activity-tracker.js';
 import {ClientReconcileState} from '../models/client-activity-state.js';
 
 export class KubeOIDCMiddlewareClientOperator {
-    constructor(provider, adapter = new KubernetesAdapter()) {
-        this.redisAdapter = new RedisAdapter('Client')
+    constructor(provider, adapter = new KubernetesAdapter(), redisAdapter = new RedisAdapter('Client')) {
+        this.redisAdapter = redisAdapter
         this.provider = provider
         this.adapter = adapter
         this.instance = this.adapter.instance
@@ -33,32 +33,50 @@ export class KubeOIDCMiddlewareClientOperator {
 
     async #createOIDCClient (OIDCMiddlewareClient) {
         this.reconcileState.register(OIDCMiddlewareClient)
-        if (OIDCMiddlewareClient.getInstance() === this.instance) {
-            if (!await this.redisAdapter.find(OIDCMiddlewareClient.getClientId())) {
+        try {
+            if (OIDCMiddlewareClient.getInstance() === this.instance) {
                 await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
                 if (!OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
+            } else if (!OIDCMiddlewareClient.getInstance()) {
+                // Continue with the claimed resourceVersion for the readiness write.
+                const claimedClient = await this.#replaceClientStatus(OIDCMiddlewareClient)
+                if (claimedClient?.getInstance() === this.instance) {
+                    OIDCMiddlewareClient = claimedClient
+                    await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
+                    if (!OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
+                } else {
+                    return
+                }
+            } else {
+                return
             }
-        } else if (!OIDCMiddlewareClient.getInstance()) {
-            // Claim that client
-            const claimedClient = await this.#replaceClientStatus(OIDCMiddlewareClient)
-            if (claimedClient?.getInstance() === this.instance) {
-                await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
-                if (!OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
+            if (OIDCMiddlewareClient.isDisabled()) {
+                await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
+                await this.#reportReady(OIDCMiddlewareClient, 'Disabled', 'Client is disabled and absent from Redis')
+            } else {
+                await this.#reportReady(OIDCMiddlewareClient, 'Reconciled', 'Traefik Middleware and Redis record are up to date')
             }
+        } catch (error) {
+            await this.#reportFailure(OIDCMiddlewareClient, error)
         }
-        if (OIDCMiddlewareClient.isDisabled()) await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
     }
 
     async #updateOIDCClient(OIDCMiddlewareClient) {
         if (!this.reconcileState.shouldReconcile(OIDCMiddlewareClient)) return
-        if (OIDCMiddlewareClient.isDisabled()) {
-            await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
-            return
+        if (OIDCMiddlewareClient.getInstance() !== this.instance) return
+        try {
+            if (OIDCMiddlewareClient.isDisabled()) {
+                await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())
+                await this.#reportReady(OIDCMiddlewareClient, 'Disabled', 'Client is disabled and absent from Redis')
+                return
+            }
+            await new Promise(res => setTimeout(res, 1000)); // Wait second as the client is momentarily updated after creation, resulting 404.
+            await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
+            await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
+            await this.#reportReady(OIDCMiddlewareClient, 'Reconciled', 'Traefik Middleware and Redis record are up to date')
+        } catch (error) {
+            await this.#reportFailure(OIDCMiddlewareClient, error)
         }
-        await new Promise(res => setTimeout(res, 1000)); // Wait second as the client is momentarily updated after creation, resulting 404.
-        await this.#createOrReplaceClientMiddleware(OIDCMiddlewareClient)
-        await this.redisAdapter.upsert(OIDCMiddlewareClient.getClientId(), OIDCMiddlewareClient.toRedis())
-
     }
 
     async #deleteOIDCClient (OIDCMiddlewareClient) {
@@ -78,7 +96,7 @@ export class KubeOIDCMiddlewareClientOperator {
             TraefikMiddlewareApiGroupVersion
         )
         if (!existingMiddleware) {
-            return await this.adapter.createNamespacedCustomObject(
+            const middleware = await this.adapter.createNamespacedCustomObject(
                 TraefikMiddleware,
                 OIDCMiddlewareClient.getClientNamespace(),
                 OIDCMiddlewareClient.getClientName(),
@@ -91,8 +109,10 @@ export class KubeOIDCMiddlewareClientOperator {
                 TraefikMiddlewareApiGroup,
                 TraefikMiddlewareApiGroupVersion
             )
+            if (!middleware) throw this.#reconcileError('MiddlewareReconcileFailed', 'Failed to create Traefik Middleware')
+            return middleware
         } else {
-            return await this.adapter.patchNamespacedCustomObject(
+            const middleware = await this.adapter.patchNamespacedCustomObject(
                 TraefikMiddleware,
                 OIDCMiddlewareClient.getClientNamespace(),
                 OIDCMiddlewareClient.getClientName(),
@@ -102,7 +122,36 @@ export class KubeOIDCMiddlewareClientOperator {
                 TraefikMiddlewareApiGroup,
                 TraefikMiddlewareApiGroupVersion
             )
+            if (!middleware) throw this.#reconcileError('MiddlewareReconcileFailed', 'Failed to update Traefik Middleware')
+            return middleware
         }
+    }
+
+    #reconcileError(reason, message) {
+        return Object.assign(new Error(message), {reason})
+    }
+
+    async #reportReady(OIDCMiddlewareClient, reason, message) {
+        const changed = OIDCMiddlewareClient.updateReadyCondition(true, reason, message)
+        const updatedClient = await this.#replaceClientStatus(OIDCMiddlewareClient)
+        if (changed && updatedClient) {
+            await this.adapter.createEvent(
+                OIDCMiddlewareClient.getClientNamespace(), OIDCMiddlewareClient.getMetadata(), reason, message, 'Normal'
+            )
+        }
+    }
+
+    async #reportFailure(OIDCMiddlewareClient, error) {
+        const reason = error.reason ?? 'ReconcileFailed'
+        const message = error.message ?? 'Middleware client reconciliation failed'
+        const changed = OIDCMiddlewareClient.updateReadyCondition(false, reason, message)
+        await this.#replaceClientStatus(OIDCMiddlewareClient)
+        if (changed) {
+            await this.adapter.createEvent(
+                OIDCMiddlewareClient.getClientNamespace(), OIDCMiddlewareClient.getMetadata(), reason, message
+            )
+        }
+        globalThis.logger.error({error, client: OIDCMiddlewareClient.getClientId()}, 'Failed to reconcile OIDCMiddlewareClient')
     }
 
     async #replaceClientStatus (OIDCMiddlewareClient) {

--- a/src/operators/kube-oidc-middleware-client-operator.js
+++ b/src/operators/kube-oidc-middleware-client-operator.js
@@ -63,7 +63,12 @@ export class KubeOIDCMiddlewareClientOperator {
 
     async #updateOIDCClient(OIDCMiddlewareClient) {
         if (!this.reconcileState.shouldReconcile(OIDCMiddlewareClient)) return
-        if (OIDCMiddlewareClient.getInstance() !== this.instance) return
+        if (OIDCMiddlewareClient.getInstance() !== this.instance) {
+            if (OIDCMiddlewareClient.getInstance()) return
+            const claimedClient = await this.#replaceClientStatus(OIDCMiddlewareClient)
+            if (claimedClient?.getInstance() !== this.instance) return
+            OIDCMiddlewareClient = claimedClient
+        }
         try {
             if (OIDCMiddlewareClient.isDisabled()) {
                 await this.redisAdapter.destroy(OIDCMiddlewareClient.getClientId())

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -10,7 +10,7 @@ describe('KubeOIDCClientOperator reconciliation', () => {
     let provider, adapter, operator
     const clientRedis = () => new RedisAdapter('Client')
 
-    function rawClient(name, { secretRefreshJobSpec, disabled = false, description } = {}) {
+    function rawClient(name, { secretRefreshJobSpec, disabled = false, description, status = {} } = {}) {
         return {
             metadata: {
                 name, namespace: 'apps', resourceVersion: '1', generation: disabled ? 2 : 1, uid: `uid-${name}`,
@@ -25,7 +25,7 @@ describe('KubeOIDCClientOperator reconciliation', () => {
                 disabled,
                 ...(secretRefreshJobSpec ? { secretRefreshJobSpec } : {}),
             },
-            status: {}, // unclaimed
+            status,
         }
     }
     const refreshJobSpec = { template: { spec: { containers: [{ name: 'refresh', image: 'busybox' }] } } }
@@ -95,7 +95,8 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         adapter.seed('OIDCClient', rawClient('app-c', { secretRefreshJobSpec: refreshJobSpec }))
         await adapter.fireWatch('ADDED', 'OIDCClient', 'app-c')
         const afterCreate = adapter.jobs.length
-        const modified = rawClient('app-c', { secretRefreshJobSpec: refreshJobSpec })
+        const status = structuredClone(adapter.list('OIDCClient')[0].status)
+        const modified = rawClient('app-c', {secretRefreshJobSpec: refreshJobSpec, status})
         modified.metadata.generation = 2
         adapter.seed('OIDCClient', modified)
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-c')
@@ -117,7 +118,8 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         await adapter.fireWatch('ADDED', 'OIDCClient', 'app-description')
         expect((await clientRedis().find(idOf('app-description'))).description).toBe('Old description')
 
-        adapter.seed('OIDCClient', rawClient('app-description', {description: 'New description'}))
+        const status = structuredClone(adapter.list('OIDCClient')[0].status)
+        adapter.seed('OIDCClient', rawClient('app-description', {description: 'New description', status}))
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-description')
 
         expect((await clientRedis().find(idOf('app-description'))).description).toBe('New description')
@@ -138,7 +140,8 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         const secret = adapter.secrets.get('apps/oidc-client-app-disabled-owner-secrets')
         expect(await clientRedis().find(idOf('app-disabled'))).toBeTruthy()
 
-        adapter.seed('OIDCClient', rawClient('app-disabled', {disabled: true}))
+        const status = structuredClone(adapter.list('OIDCClient')[0].status)
+        adapter.seed('OIDCClient', rawClient('app-disabled', {disabled: true, status}))
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-disabled')
 
         expect(await clientRedis().find(idOf('app-disabled'))).toBeUndefined()

--- a/test/integration/client-operator.test.js
+++ b/test/integration/client-operator.test.js
@@ -65,6 +65,12 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         expect(configured.clientNamespace).toBe('apps')
         expect(configured.clientName).toBe('app-a')
         expect(configured.kind).toBe('OIDCClient')
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'True', reason: 'Reconciled',
+        }))
+        expect(adapter.events).toContainEqual(expect.objectContaining({
+            reason: 'Reconciled', type: 'Normal',
+        }))
     })
 
     it('creates the secretRefreshJob when configured (#69/#70)', async () => {
@@ -100,8 +106,10 @@ describe('KubeOIDCClientOperator reconciliation', () => {
         adapter.seed('OIDCClient', rawClient('app-status', {secretRefreshJobSpec: refreshJobSpec}))
         await adapter.fireWatch('ADDED', 'OIDCClient', 'app-status')
         const jobs = adapter.jobs.length
+        const events = adapter.events.length
         await adapter.fireWatch('MODIFIED', 'OIDCClient', 'app-status')
         expect(adapter.jobs).toHaveLength(jobs)
+        expect(adapter.events).toHaveLength(events)
     })
 
     it('reconciles description annotation changes without a generation bump', async () => {
@@ -135,5 +143,23 @@ describe('KubeOIDCClientOperator reconciliation', () => {
 
         expect(await clientRedis().find(idOf('app-disabled'))).toBeUndefined()
         expect(adapter.secrets.get('apps/oidc-client-app-disabled-owner-secrets')).toEqual(secret)
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'True', reason: 'Disabled',
+        }))
+    })
+
+    it('reports a failed secret-refresh Job in status and a Warning event', async () => {
+        adapter.createJob = async () => null
+        adapter.seed('OIDCClient', rawClient('app-job-failure', {secretRefreshJobSpec: refreshJobSpec}))
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'app-job-failure')
+
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'False', reason: 'RefreshJobReconcileFailed',
+        }))
+        expect(adapter.events).toContainEqual(expect.objectContaining({
+            reason: 'RefreshJobReconcileFailed', type: 'Warning',
+        }))
+        expect(await clientRedis().find(idOf('app-job-failure'))).toBeUndefined()
     })
 })

--- a/test/unit/client-activity-state.test.js
+++ b/test/unit/client-activity-state.test.js
@@ -36,4 +36,21 @@ describe.each([
             lastUsedAt: '2026-08-05T12:00:00.000Z',
         })))).toBe(true)
     })
+
+    it('tracks readiness without changing transition time for the same status', () => {
+        const client = new Model().fromIncomingClient(resource(kind))
+        const first = new Date('2026-08-06T10:00:00.000Z')
+        const later = new Date('2026-08-06T11:00:00.000Z')
+
+        expect(client.updateReadyCondition(false, 'SecretReconcileFailed', 'Secret creation failed', first)).toBe(true)
+        expect(client.updateReadyCondition(false, 'RedisReconcileFailed', 'Redis update failed', later)).toBe(true)
+        expect(client.getConditions().find(condition => condition.type === 'Ready')).toEqual({
+            type: 'Ready', status: 'False', reason: 'RedisReconcileFailed', message: 'Redis update failed',
+            lastTransitionTime: first.toISOString(),
+        })
+
+        expect(client.updateReadyCondition(true, 'Reconciled', 'Client reconciliation completed', later)).toBe(true)
+        expect(client.updateReadyCondition(true, 'Reconciled', 'Client reconciliation completed', later)).toBe(false)
+        expect(client.getConditions().find(condition => condition.type === 'Ready').lastTransitionTime).toBe(later.toISOString())
+    })
 })

--- a/test/unit/client-operator-status.test.js
+++ b/test/unit/client-operator-status.test.js
@@ -1,0 +1,103 @@
+import {beforeEach, describe, expect, it} from 'vitest'
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js'
+import {KubeOIDCMiddlewareClientOperator} from '../../src/operators/kube-oidc-middleware-client-operator.js'
+import {KubeOIDCClientOperator} from '../../src/operators/kube-oidc-client-operator.js'
+
+class FakeRedisAdapter {
+    records = new Map()
+
+    async find(id) { return this.records.get(id) }
+    async upsert(id, value) { this.records.set(id, value) }
+    async destroy(id) { this.records.delete(id) }
+}
+
+function middlewareClient(name) {
+    return {
+        metadata: {
+            name, namespace: 'apps', generation: 1, uid: `uid-${name}`,
+        },
+        spec: {
+            uri: `https://${name}.example.com`,
+            headerMapping: {user: 'Remote-User'},
+        },
+        status: {},
+    }
+}
+
+function oidcClient(name) {
+    return {
+        metadata: {name, namespace: 'apps', generation: 1, uid: `uid-${name}`},
+        spec: {
+            grantTypes: ['authorization_code'], responseTypes: ['code'],
+            redirectUris: [`https://${name}.example.com/callback`], availableScopes: ['openid'],
+            secretRefreshJobSpec: {template: {spec: {containers: [{name: 'refresh', image: 'busybox'}]}}},
+        },
+        status: {},
+    }
+}
+
+describe('OIDCMiddlewareClient reconciliation status', () => {
+    let adapter, redis, operator
+
+    beforeEach(async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        adapter.deployment = 'passmower'
+        redis = new FakeRedisAdapter()
+        operator = new KubeOIDCMiddlewareClientOperator({}, adapter, redis)
+        await operator.watchClients()
+    })
+
+    it('marks a reconciled client Ready and emits one Normal event', async () => {
+        adapter.seed('OIDCMiddlewareClient', middlewareClient('grafana'))
+
+        await adapter.fireWatch('ADDED', 'OIDCMiddlewareClient', 'grafana')
+
+        expect(adapter.list('OIDCMiddlewareClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'True', reason: 'Reconciled',
+        }))
+        expect(adapter.events).toEqual([expect.objectContaining({reason: 'Reconciled', type: 'Normal'})])
+        expect(redis.records.size).toBe(1)
+
+        await adapter.fireWatch('MODIFIED', 'OIDCMiddlewareClient', 'grafana')
+        expect(adapter.events).toHaveLength(1)
+    })
+
+    it('marks a failed middleware creation Not Ready and emits a Warning event', async () => {
+        adapter.createNamespacedCustomObject = async () => null
+        adapter.seed('OIDCMiddlewareClient', middlewareClient('broken'))
+
+        await adapter.fireWatch('ADDED', 'OIDCMiddlewareClient', 'broken')
+
+        expect(adapter.list('OIDCMiddlewareClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'False', reason: 'MiddlewareReconcileFailed',
+        }))
+        expect(adapter.events).toEqual([expect.objectContaining({
+            reason: 'MiddlewareReconcileFailed', type: 'Warning',
+        })])
+        expect(redis.records.size).toBe(0)
+    })
+})
+
+describe('OIDCClient reconciliation status', () => {
+    it('reports a failed secret-refresh Job without writing an incomplete Redis record', async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        adapter.createJob = async () => null
+        const redis = new FakeRedisAdapter()
+        const provider = {urlFor: endpoint => `https://id.example.com/${endpoint}`}
+        const operator = new KubeOIDCClientOperator(provider, adapter, redis)
+        await operator.watchClients()
+        adapter.seed('OIDCClient', oidcClient('broken-job'))
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'broken-job')
+
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'False', reason: 'RefreshJobReconcileFailed',
+        }))
+        expect(adapter.events).toEqual([expect.objectContaining({
+            reason: 'RefreshJobReconcileFailed', type: 'Warning',
+        })])
+        expect(redis.records.size).toBe(0)
+    })
+})

--- a/test/unit/client-operator-status.test.js
+++ b/test/unit/client-operator-status.test.js
@@ -11,10 +11,10 @@ class FakeRedisAdapter {
     async destroy(id) { this.records.delete(id) }
 }
 
-function middlewareClient(name) {
+function middlewareClient(name, generation = 1) {
     return {
         metadata: {
-            name, namespace: 'apps', generation: 1, uid: `uid-${name}`,
+            name, namespace: 'apps', generation, uid: `uid-${name}`,
         },
         spec: {
             uri: `https://${name}.example.com`,
@@ -76,6 +76,28 @@ describe('OIDCMiddlewareClient reconciliation status', () => {
             reason: 'MiddlewareReconcileFailed', type: 'Warning',
         })])
         expect(redis.records.size).toBe(0)
+    })
+
+    it('retries claiming an unclaimed client after a spec update', async () => {
+        const replaceStatus = adapter.replaceNamespacedCustomObjectStatus.bind(adapter)
+        let claimAttempts = 0
+        adapter.replaceNamespacedCustomObjectStatus = async (...args) => {
+            claimAttempts++
+            if (claimAttempts === 1) return undefined
+            return replaceStatus(...args)
+        }
+        adapter.seed('OIDCMiddlewareClient', middlewareClient('claim-retry'))
+        await adapter.fireWatch('ADDED', 'OIDCMiddlewareClient', 'claim-retry')
+        expect(adapter.list('OIDCMiddlewareClient')[0].status.instance).toBeUndefined()
+
+        adapter.seed('OIDCMiddlewareClient', middlewareClient('claim-retry', 2))
+        await adapter.fireWatch('MODIFIED', 'OIDCMiddlewareClient', 'claim-retry')
+
+        expect(adapter.list('OIDCMiddlewareClient')[0].status.instance).toBe('test-passmower')
+        expect(adapter.list('OIDCMiddlewareClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'True', reason: 'Reconciled',
+        }))
+        expect(redis.records.size).toBe(1)
     })
 })
 


### PR DESCRIPTION
## Summary
- persist a Ready condition after OIDCClient and OIDCMiddlewareClient reconciliation
- emit transition-only Normal and Warning Kubernetes Events for success, disabled clients, and failures
- use the claimed resourceVersion for follow-up status writes and retry transient claim failures on later spec updates
- expose Ready in kubectl columns and inject Redis adapters for deterministic operator tests

OIDCMiddlewareClient watch replay intentionally reapplies the idempotent Traefik Middleware patch and Redis upsert. This adds startup API writes, but lets Ready assert that both desired resources were reconciled rather than merely found in Redis. Failure Events are intentionally emitted even if the readiness status write conflicts, so an API conflict does not hide the underlying reconciliation failure.

## Tests
- npm test (150 passed)
- npm run test:integration (41 passed)
- targeted client operator status tests (8 passed)
- helm template passmower charts/passmower

Refs #60