### PR TITLE
fix: use ioredis 6 connection resilience

### DIFF
--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -62,21 +62,15 @@ export async function resolveHostIps(host, family = parseInt(process.env.REDIS_I
 let client;
 let timers = [];
 
-function createRedisClient(redisUrl, isInitial = false) {
-    const newClient = new Redis(redisUrl, {
+export function getRedisOptions(isInitial = false, env = process.env) {
+    return {
         keyPrefix: 'oidc:',
-        family: parseInt(process.env.REDIS_IP_FAMILY ?? '0'),
+        family: parseInt(env.REDIS_IP_FAMILY ?? '0'),
+        protocol: 3,
         // Only enable offline queue for initial connection, disable after ready
         enableOfflineQueue: isInitial,
         // Shorter timeouts for faster failover detection
         connectTimeout: 10000,
-        // Retry strategy with backoff
-        retryStrategy(times) {
-            if (times > 10) {
-                globalThis.logger?.warn('Redis: Max retry attempts reached, will keep trying...')
-            }
-            return Math.min(times * 100, 3000);
-        },
         // Reconnect on READONLY errors (replica promoted to master scenario)
         reconnectOnError(err) {
             const targetErrors = ['READONLY', 'MOVED', 'ASK', 'CLUSTERDOWN'];
@@ -87,7 +81,11 @@ function createRedisClient(redisUrl, isInitial = false) {
             }
             return false;
         },
-    });
+    };
+}
+
+function createRedisClient(redisUrl, isInitial = false) {
+    const newClient = new Redis(redisUrl, getRedisOptions(isInitial));
 
     newClient.on('error', (err) => {
         globalThis.logger?.error({ err }, 'Redis connection error')

--- a/test/unit/redis-connection.test.js
+++ b/test/unit/redis-connection.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { getRedisOptions } from '../../src/adapters/redis.js'
+
+describe('Redis connection options', () => {
+    it('uses RESP3 and the ioredis retry strategy', () => {
+        const options = getRedisOptions(true, { REDIS_IP_FAMILY: '6' })
+
+        expect(options).toMatchObject({
+            keyPrefix: 'oidc:',
+            family: 6,
+            protocol: 3,
+            enableOfflineQueue: true,
+            connectTimeout: 10000,
+        })
+        expect(options).not.toHaveProperty('retryStrategy')
+    })
+
+    it('disables the offline queue on replacement connections', () => {
+        expect(getRedisOptions(false, {})).toMatchObject({
+            family: 0,
+            protocol: 3,
+            enableOfflineQueue: false,
+        })
+    })
+
+    it.each(['READONLY', 'MOVED', 'ASK', 'CLUSTERDOWN'])(
+        'reconnects on %s failover errors',
+        error => {
+            const { reconnectOnError } = getRedisOptions()
+
+            expect(reconnectOnError(new Error(`${error} failover`))).toBe(true)
+        },
+    )
+
+    it('does not reconnect on unrelated Redis errors', () => {
+        const { reconnectOnError } = getRedisOptions()
+
+        expect(reconnectOnError(new Error('WRONGTYPE operation'))).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary
- explicitly use RESP3 with ioredis 6
- inherit ioredis 6's exponential retry strategy with jitter
- preserve Passmower's DNS, offline queue, failover, and teardown safeguards
- add connection-option regression coverage

## Validation
- npm test (159 passed)
- npm run test:integration (41 passed against Redis 7)
- npm run test:e2e (Dex browser login passed)
- Minikube pod ready; Redis CLIENT LIST reports ioredis 6.0.0 with resp=3