### PR TITLE
fix: recompute user status mutations on conflicts

### DIFF
--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -8,6 +8,7 @@ import {
 import {V1OwnerReference, V1Secret, setHeaderMiddleware, setHeaderOptions} from "@kubernetes/client-node";
 import {diff} from 'jsondiffpatch';
 import {format} from 'jsondiffpatch/formatters/jsonpatch';
+import isEqual from 'lodash/isEqual.js';
 
 // loadFromCluster() builds the API server URL straight from KUBERNETES_SERVICE_HOST,
 // which on IPv6-only / dual-stack clusters is a bare IPv6 literal — so the client
@@ -193,6 +194,9 @@ export class KubernetesAdapter {
                     name: id,
                 }, this.defaultOptions)
                 const status = await statusFunction(mapperFunction(current))
+                if (isEqual(current.status ?? {}, status ?? {})) {
+                    return mapperFunction(current)
+                }
                 const updated = await this.customObjectsApi.replaceNamespacedCustomObjectStatus({
                     group: apiGroup,
                     version: apiGroupVersion,
@@ -211,6 +215,9 @@ export class KubernetesAdapter {
                 }, this.defaultOptions)
                 return mapperFunction(updated)
             } catch (error) {
+                if (error.code === 404) {
+                    return null
+                }
                 if (error.code === 409 && attempt < 3) {
                     globalThis.logger?.warn(
                         {kind, namespace, id, attempt},

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -182,6 +182,48 @@ export class KubernetesAdapter {
         })
     }
 
+    async mutateNamespacedCustomObjectStatus(kind, namespace, id, mapperFunction, statusFunction, apiGroup = defaultApiGroup, apiGroupVersion = defaultApiGroupVersion) {
+        for (let attempt = 1; attempt <= 3; attempt++) {
+            try {
+                const current = await this.customObjectsApi.getNamespacedCustomObject({
+                    group: apiGroup,
+                    version: apiGroupVersion,
+                    namespace,
+                    plural: plurals[kind],
+                    name: id,
+                }, this.defaultOptions)
+                const status = await statusFunction(mapperFunction(current))
+                const updated = await this.customObjectsApi.replaceNamespacedCustomObjectStatus({
+                    group: apiGroup,
+                    version: apiGroupVersion,
+                    namespace,
+                    plural: plurals[kind],
+                    name: id,
+                    body: {
+                        apiVersion: apiGroup + '/' + apiGroupVersion,
+                        kind,
+                        metadata: {
+                            name: id,
+                            resourceVersion: current.metadata.resourceVersion,
+                        },
+                        status,
+                    },
+                }, this.defaultOptions)
+                return mapperFunction(updated)
+            } catch (error) {
+                if (error.code === 409 && attempt < 3) {
+                    globalThis.logger?.warn(
+                        {kind, namespace, id, attempt},
+                        'Kubernetes status mutation conflicted, recomputing from the latest resource'
+                    )
+                    continue
+                }
+                globalThis.logger.error(error)
+                return undefined
+            }
+        }
+    }
+
     async getSecret(namespace, id) {
         return await this.coreV1Api.readNamespacedSecret({
             name: id,

--- a/src/operators/kube-oidc-user-operator.js
+++ b/src/operators/kube-oidc-user-operator.js
@@ -35,13 +35,13 @@ export class KubeOIDCUserOperator {
         condition = condition.setStatus(true)
         OIDCUser.setLabels(condition.toLabels())
         await this.userService.replaceUserLabels(OIDCUser)
-        await this.userService.updateUserStatus(OIDCUser)
+        await this.userService.reconcileUserStatus(OIDCUser.accountId)
         await this.#scheduleEmailReconcile()
     }
 
     async #updateOIDCUser(OIDCUser) {
         if (OIDCUser.getMetadata()?.managedFields?.at(-1)?.manager !== this.instance) {
-            await this.userService.updateUserStatus(OIDCUser)
+            await this.userService.reconcileUserStatus(OIDCUser.accountId)
             await this.#scheduleEmailReconcile()
         }
     }

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -155,8 +155,10 @@ export default (provider) => {
         })
         let condition = new UsernameCommitted()
         condition = condition.setStatus(true)
-        account.addCondition(condition)
-        await ctx.kubeOIDCUserService.updateUserStatus(account)
+        await ctx.kubeOIDCUserService.mutateUserStatus(
+            account.accountId,
+            current => current.addCondition(condition),
+        )
         await Account.approve(ctx, account.accountId)
         auditLog(ctx, {email, onboardedBy}, 'Admin invited user')
         let accounts = await ctx.kubeOIDCUserService.listUsers()

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -503,8 +503,10 @@ export default (provider) => {
         }
         let condition = new UsernameCommitted()
         condition = condition.setStatus(true)
-        account.addCondition(condition)
-        await ctx.kubeOIDCUserService.updateUserStatus(account)
+        await ctx.kubeOIDCUserService.mutateUserStatus(
+            account.accountId,
+            current => current.addCondition(condition),
+        )
 
         if (interactionDetails?.lastSubmission?.oauth?.provider) {
             switch (interactionDetails.lastSubmission.oauth.provider) {

--- a/src/services/activity-tracker.js
+++ b/src/services/activity-tracker.js
@@ -130,6 +130,7 @@ export class ActivityTracker {
                 return account.getIntendedStatus()
             },
         )
+        if (updated === null) return
         if (!updated) throw new Error(`Failed to update activity status for OIDCUser ${accountId}`)
     }
 

--- a/src/services/activity-tracker.js
+++ b/src/services/activity-tracker.js
@@ -114,23 +114,21 @@ export class ActivityTracker {
     }
 
     async #flushUser(accountId, applications) {
-        const account = await this.adapter.getNamespacedCustomObject(
+        const updated = await this.adapter.mutateNamespacedCustomObjectStatus(
             OIDCUserCrd, this.adapter.namespace, accountId,
-            raw => new Account().fromKubernetes(raw)
-        )
-        if (!account) return
-        const merged = new Map(account.getRecentApplications().map(app => [app.clientId, app]))
-        for (const [clientId, app] of applications) {
-            const previous = merged.get(clientId)
-            merged.set(clientId, {...app, lastAuthenticatedAt: newer(previous?.lastAuthenticatedAt, app.lastAuthenticatedAt)})
-        }
-        const recent = [...merged.values()]
-            .sort((a, b) => new Date(b.lastAuthenticatedAt) - new Date(a.lastAuthenticatedAt))
-            .slice(0, intEnv('ACTIVITY_RECENT_APPLICATION_LIMIT', DEFAULT_RECENT_APPLICATION_LIMIT))
-        account.setRecentApplications(recent)
-        const updated = await this.adapter.replaceNamespacedCustomObjectStatus(
-            OIDCUserCrd, this.adapter.namespace, accountId, account.resourceVersion,
-            account.getIntendedStatus(), raw => new Account().fromKubernetes(raw)
+            raw => new Account().fromKubernetes(raw),
+            account => {
+                const merged = new Map(account.getRecentApplications().map(app => [app.clientId, app]))
+                for (const [clientId, app] of applications) {
+                    const previous = merged.get(clientId)
+                    merged.set(clientId, {...app, lastAuthenticatedAt: newer(previous?.lastAuthenticatedAt, app.lastAuthenticatedAt)})
+                }
+                const recent = [...merged.values()]
+                    .sort((a, b) => new Date(b.lastAuthenticatedAt) - new Date(a.lastAuthenticatedAt))
+                    .slice(0, intEnv('ACTIVITY_RECENT_APPLICATION_LIMIT', DEFAULT_RECENT_APPLICATION_LIMIT))
+                account.setRecentApplications(recent)
+                return account.getIntendedStatus()
+            },
         )
         if (!updated) throw new Error(`Failed to update activity status for OIDCUser ${accountId}`)
     }

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -107,20 +107,25 @@ export class KubeOIDCUserService {
                 ? conflicts.map(conflict => `${conflict.email} is owned by OIDCUser ${conflict.ownerAccountId}`).join('; ')
                 : 'All claimed email addresses are unique'
             if (previous?.status === status && previous?.reason === reason && previous?.message === message) continue
-            const condition = {
-                apiVersion: 'v1',
-                kind: 'Condition',
-                type: 'EmailUnique',
-                status,
-                reason,
-                message,
-                lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : new Date(),
-            }
             try {
-                const updated = await this.mutateUserStatus(account.accountId, current => current.setConditions([
-                    ...current.getConditions().filter(item => item.type !== 'EmailUnique'),
-                    condition,
-                ]))
+                const updated = await this.mutateUserStatus(account.accountId, current => {
+                    const currentPrevious = current.getConditions().find(condition => condition.type === 'EmailUnique')
+                    const condition = {
+                        apiVersion: 'v1',
+                        kind: 'Condition',
+                        type: 'EmailUnique',
+                        status,
+                        reason,
+                        message,
+                        lastTransitionTime: currentPrevious?.status === status
+                            ? currentPrevious.lastTransitionTime
+                            : new Date(),
+                    }
+                    return current.setConditions([
+                        ...current.getConditions().filter(item => item.type !== 'EmailUnique'),
+                        condition,
+                    ])
+                })
                 if (!updated) throw new Error(`Status update returned no OIDCUser for ${account.accountId}`)
                 if (status === 'False' && previous?.status !== 'False') {
                     await this.adapter.createEvent?.(

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -116,12 +116,11 @@ export class KubeOIDCUserService {
                 message,
                 lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : new Date(),
             }
-            account.setConditions([
-                ...account.getConditions().filter(item => item.type !== 'EmailUnique'),
-                condition,
-            ])
             try {
-                const updated = await this.updateUserStatus(account)
+                const updated = await this.mutateUserStatus(account.accountId, current => current.setConditions([
+                    ...current.getConditions().filter(item => item.type !== 'EmailUnique'),
+                    condition,
+                ]))
                 if (!updated) throw new Error(`Status update returned no OIDCUser for ${account.accountId}`)
                 if (status === 'False' && previous?.status !== 'False') {
                     await this.adapter.createEvent?.(
@@ -164,7 +163,7 @@ export class KubeOIDCUserService {
         if (!user) {
             return null
         }
-        return await this.updateUserStatus(user)
+        return await this.reconcileUserStatus(user.accountId)
     }
 
     async updateUserSpecs(accountId, {passmower, slack, github, identities} = {}) {
@@ -186,7 +185,7 @@ export class KubeOIDCUserService {
         if (!updatedUser) {
             throw new Error(`updateUserSpecs: Kubernetes rejected the spec patch for user "${accountId}"`)
         }
-        return await this.updateUserStatus(updatedUser)
+        return await this.reconcileUserStatus(updatedUser.accountId)
     }
 
     async replaceUserLabels(updatedUser) {
@@ -208,18 +207,21 @@ export class KubeOIDCUserService {
         )
     }
 
-    async updateUserStatus(account) {
-        if (!account) {
-            throw new Error('updateUserStatus: account is null (user creation or spec patch failed upstream)')
-        }
-        return await this.adapter.replaceNamespacedCustomObjectStatus(
+    async mutateUserStatus(accountId, mutation = () => {}) {
+        return await this.adapter.mutateNamespacedCustomObjectStatus(
             OIDCUserCrd,
             this.adapter.namespace,
-            account.accountId,
-            account.resourceVersion,
-            account.getIntendedStatus(),
-            (apiResponse) => (new Account()).fromKubernetes(apiResponse)
+            accountId,
+            (apiResponse) => (new Account()).fromKubernetes(apiResponse),
+            async account => {
+                await mutation(account)
+                return account.getIntendedStatus()
+            },
         )
+    }
+
+    async reconcileUserStatus(accountId) {
+        return await this.mutateUserStatus(accountId)
     }
 
     // WebAuthn/Passkey methods

--- a/src/utils/user/confirm-tos.js
+++ b/src/utils/user/confirm-tos.js
@@ -6,8 +6,10 @@ import {getEmailContent, getEmailSubject} from "../get-email-content.js";
 export const confirmTos = async (ctx, accountId, contentHash) => {
     let account = await Account.findAccount(ctx, accountId)
     const acceptedAt = new Date()
-    account.acceptTermsOfService(contentHash, acceptedAt)
-    await ctx.kubeOIDCUserService.updateUserStatus(account)
+    await ctx.kubeOIDCUserService.mutateUserStatus(
+        accountId,
+        current => current.acceptTermsOfService(contentHash, acceptedAt),
+    )
 
     const content = await getEmailContent('emails/tos', {
         name: account.profile.name,

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -79,6 +79,16 @@ export class FakeKubernetesAdapter {
         return mapperFunction(structuredClone(stored))
     }
 
+    async mutateNamespacedCustomObjectStatus(kind, _namespace, id, mapperFunction, statusFunction) {
+        const stored = this.store.get(this.#key(kind, id))
+        if (!stored) return undefined
+        const status = await statusFunction(mapperFunction(structuredClone(stored)))
+        stored.status = structuredClone(status)
+        stored.metadata.resourceVersion = this.#nextRv()
+        this.#emit('MODIFIED', kind, stored)
+        return mapperFunction(structuredClone(stored))
+    }
+
     // --- Secrets + pods (used by the client operator) -----------------------
 
     async getSecret(namespace, id) { return this.secrets.get(`${namespace}/${id}`) }

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -81,8 +81,11 @@ export class FakeKubernetesAdapter {
 
     async mutateNamespacedCustomObjectStatus(kind, _namespace, id, mapperFunction, statusFunction) {
         const stored = this.store.get(this.#key(kind, id))
-        if (!stored) return undefined
+        if (!stored) return null
         const status = await statusFunction(mapperFunction(structuredClone(stored)))
+        if (JSON.stringify(stored.status ?? {}) === JSON.stringify(status ?? {})) {
+            return mapperFunction(structuredClone(stored))
+        }
         stored.status = structuredClone(status)
         stored.metadata.resourceVersion = this.#nextRv()
         this.#emit('MODIFIED', kind, stored)

--- a/test/integration/kube-user-service.test.js
+++ b/test/integration/kube-user-service.test.js
@@ -110,6 +110,30 @@ describe('KubeOIDCUserService over the fake Kubernetes adapter', () => {
         expect((await service.findUserByEmails(['person@example.com'])).accountId).toBe('duplicate')
     })
 
+    it('preserves a concurrent EmailUnique transition time from the freshly read user', async () => {
+        adapter.seed('OIDCUser', rawUser('original', '2026-01-01T00:00:00Z', 'person@example.com'))
+        adapter.seed('OIDCUser', rawUser('duplicate', '2026-02-01T00:00:00Z', 'person@example.com'))
+        const transitionTime = new Date('2026-08-01T10:00:00.000Z')
+        const mutate = adapter.mutateNamespacedCustomObjectStatus.bind(adapter)
+        adapter.mutateNamespacedCustomObjectStatus = async (kind, namespace, id, mapper, statusFunction) => {
+            if (id === 'duplicate') {
+                adapter.list('OIDCUser').find(user => user.metadata.name === id).status.conditions = [{
+                    apiVersion: 'v1', kind: 'Condition', type: 'EmailUnique', status: 'False',
+                    reason: 'ConcurrentDecision', message: 'concurrently evaluated', lastTransitionTime: transitionTime,
+                }]
+            }
+            return mutate(kind, namespace, id, mapper, statusFunction)
+        }
+
+        await service.reconcileEmailUniqueness()
+
+        const condition = adapter.list('OIDCUser')
+            .find(user => user.metadata.name === 'duplicate')
+            .status.conditions.find(item => item.type === 'EmailUnique')
+        expect(condition).toMatchObject({status: 'False', reason: 'DuplicateEmail'})
+        expect(condition.lastTransitionTime).toEqual(transitionTime)
+    })
+
     it('rejects an upstream identity whose verified emails span multiple owners', async () => {
         adapter.seed('OIDCUser', rawUser('alice', '2026-01-01T00:00:00Z', 'alice@example.com'))
         adapter.seed('OIDCUser', rawUser('bob', '2026-01-02T00:00:00Z', 'bob@example.com'))

--- a/test/unit/activity-tracker.test.js
+++ b/test/unit/activity-tracker.test.js
@@ -91,6 +91,24 @@ describe('ActivityTracker', () => {
         expect(adapter.list('OIDCClient')[0].status.lastUsedAt).toBe('2026-08-05T11:30:00.000Z')
     })
 
+    it('drops pending activity when the user was deleted before flushing', async () => {
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
+        adapter.seed('OIDCUser', rawUser())
+        const mutate = adapter.mutateNamespacedCustomObjectStatus.bind(adapter)
+        adapter.mutateNamespacedCustomObjectStatus = vi.fn((...args) => mutate(...args))
+        const tracker = new ActivityTracker({adapter})
+        tracker.record({
+            accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
+            timestamp: '2026-08-05T11:30:00.000Z',
+        })
+        adapter.delete('OIDCUser', 'alice')
+
+        await tracker.flush()
+        await tracker.flush()
+
+        expect(adapter.mutateNamespacedCustomObjectStatus).toHaveBeenCalledOnce()
+    })
+
     it('preserves newer user activity recorded while a failed flush is in progress', async () => {
         const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
         adapter.seed('OIDCUser', rawUser())

--- a/test/unit/activity-tracker.test.js
+++ b/test/unit/activity-tracker.test.js
@@ -75,10 +75,10 @@ describe('ActivityTracker', () => {
         const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
         adapter.seed('OIDCUser', rawUser())
         adapter.seed('OIDCClient', rawClient())
-        const replace = adapter.replaceNamespacedCustomObjectStatus.bind(adapter)
-        adapter.replaceNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
+        const mutate = adapter.mutateNamespacedCustomObjectStatus.bind(adapter)
+        adapter.mutateNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
             if (kind === 'OIDCUser') return undefined
-            return replace(kind, ...args)
+            return mutate(kind, ...args)
         })
         const tracker = new ActivityTracker({adapter, now: () => new Date('2026-08-05T12:00:00.000Z')})
         tracker.registerClient(new OidcClient().fromIncomingClient(adapter.list('OIDCClient')[0]))
@@ -95,10 +95,10 @@ describe('ActivityTracker', () => {
         const adapter = new FakeKubernetesAdapter({namespace: 'apps'})
         adapter.seed('OIDCUser', rawUser())
         adapter.seed('OIDCClient', rawClient())
-        const replace = adapter.replaceNamespacedCustomObjectStatus.bind(adapter)
+        const mutate = adapter.mutateNamespacedCustomObjectStatus.bind(adapter)
         const tracker = new ActivityTracker({adapter})
         let fail = true
-        adapter.replaceNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
+        adapter.mutateNamespacedCustomObjectStatus = vi.fn(async (kind, ...args) => {
             if (kind === 'OIDCUser' && fail) {
                 tracker.record({
                     accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',
@@ -106,7 +106,7 @@ describe('ActivityTracker', () => {
                 })
                 return undefined
             }
-            return replace(kind, ...args)
+            return mutate(kind, ...args)
         })
         tracker.record({
             accountId: 'alice', clientId: 'apps.grafana', clientNamespace: 'apps', clientName: 'grafana',

--- a/test/unit/confirm-tos.test.js
+++ b/test/unit/confirm-tos.test.js
@@ -33,12 +33,12 @@ describe('confirmTos', () => {
             acceptTermsOfService: vi.fn(),
         }
         vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
-        const updateUserStatus = vi.fn()
+        const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
-        await confirmTos({kubeOIDCUserService: {updateUserStatus}}, 'alice', 'content-hash')
+        await confirmTos({kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
 
         expect(account.acceptTermsOfService).toHaveBeenCalledWith('content-hash', expect.any(Date))
-        expect(updateUserStatus).toHaveBeenCalledWith(account)
+        expect(mutateUserStatus).toHaveBeenCalledWith('alice', expect.any(Function))
         expect(mocks.sendMail).toHaveBeenCalledWith(
             'alice@example.com', 'Terms accepted', 'text', '<p>html</p>',
         )

--- a/test/unit/kubernetes-status-mutation.test.js
+++ b/test/unit/kubernetes-status-mutation.test.js
@@ -1,0 +1,74 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {KubernetesAdapter} from '../../src/adapters/kubernetes.js'
+
+describe('semantic Kubernetes status mutations', () => {
+    let adapter
+
+    beforeEach(() => {
+        globalThis.logger = {error: vi.fn(), warn: vi.fn()}
+        adapter = Object.create(KubernetesAdapter.prototype)
+        adapter.defaultOptions = {}
+    })
+
+    it('re-reads and recomputes the mutation after a resourceVersion conflict', async () => {
+        const before = {
+            metadata: {name: 'alice', resourceVersion: '1'},
+            status: {conditions: [{type: 'Approved'}]},
+        }
+        const concurrentlyUpdated = {
+            metadata: {name: 'alice', resourceVersion: '2'},
+            status: {
+                conditions: [{type: 'Approved'}],
+                recentApplications: [{clientId: 'grafana'}],
+            },
+        }
+        const replace = vi.fn()
+            .mockRejectedValueOnce(Object.assign(new Error('Conflict'), {code: 409}))
+            .mockImplementationOnce(({body}) => ({...concurrentlyUpdated, status: body.status}))
+        adapter.customObjectsApi = {
+            getNamespacedCustomObject: vi.fn()
+                .mockResolvedValueOnce(before)
+                .mockResolvedValueOnce(concurrentlyUpdated),
+            replaceNamespacedCustomObjectStatus: replace,
+        }
+        const statusFunction = vi.fn(resource => ({
+            ...resource.status,
+            conditions: [...resource.status.conditions, {type: 'EmailUnique'}],
+        }))
+
+        const result = await adapter.mutateNamespacedCustomObjectStatus(
+            'OIDCUser', 'users', 'alice', value => structuredClone(value), statusFunction,
+        )
+
+        expect(statusFunction).toHaveBeenCalledTimes(2)
+        expect(replace.mock.calls[1][0].body).toMatchObject({
+            metadata: {resourceVersion: '2'},
+            status: {
+                conditions: [{type: 'Approved'}, {type: 'EmailUnique'}],
+                recentApplications: [{clientId: 'grafana'}],
+            },
+        })
+        expect(result.status.recentApplications).toEqual([{clientId: 'grafana'}])
+        expect(globalThis.logger.warn).toHaveBeenCalledOnce()
+    })
+
+    it('stops after three conflicting recomputations', async () => {
+        const conflict = Object.assign(new Error('Conflict'), {code: 409})
+        adapter.customObjectsApi = {
+            getNamespacedCustomObject: vi.fn()
+                .mockResolvedValueOnce({metadata: {resourceVersion: '1'}, status: {}})
+                .mockResolvedValueOnce({metadata: {resourceVersion: '2'}, status: {}})
+                .mockResolvedValueOnce({metadata: {resourceVersion: '3'}, status: {}}),
+            replaceNamespacedCustomObjectStatus: vi.fn().mockRejectedValue(conflict),
+        }
+        const statusFunction = vi.fn(resource => resource.status)
+
+        const result = await adapter.mutateNamespacedCustomObjectStatus(
+            'OIDCUser', 'users', 'alice', value => value, statusFunction,
+        )
+
+        expect(result).toBeUndefined()
+        expect(statusFunction).toHaveBeenCalledTimes(3)
+        expect(globalThis.logger.error).toHaveBeenCalledWith(conflict)
+    })
+})

--- a/test/unit/kubernetes-status-mutation.test.js
+++ b/test/unit/kubernetes-status-mutation.test.js
@@ -61,7 +61,7 @@ describe('semantic Kubernetes status mutations', () => {
                 .mockResolvedValueOnce({metadata: {resourceVersion: '3'}, status: {}}),
             replaceNamespacedCustomObjectStatus: vi.fn().mockRejectedValue(conflict),
         }
-        const statusFunction = vi.fn(resource => resource.status)
+        const statusFunction = vi.fn(resource => ({...resource.status, reconciled: true}))
 
         const result = await adapter.mutateNamespacedCustomObjectStatus(
             'OIDCUser', 'users', 'alice', value => value, statusFunction,
@@ -70,5 +70,39 @@ describe('semantic Kubernetes status mutations', () => {
         expect(result).toBeUndefined()
         expect(statusFunction).toHaveBeenCalledTimes(3)
         expect(globalThis.logger.error).toHaveBeenCalledWith(conflict)
+    })
+
+    it('returns null without logging when the resource disappears', async () => {
+        const gone = Object.assign(new Error('Not Found'), {code: 404})
+        adapter.customObjectsApi = {
+            getNamespacedCustomObject: vi.fn().mockRejectedValue(gone),
+            replaceNamespacedCustomObjectStatus: vi.fn(),
+        }
+
+        const result = await adapter.mutateNamespacedCustomObjectStatus(
+            'OIDCUser', 'users', 'alice', value => value, resource => resource.status,
+        )
+
+        expect(result).toBeNull()
+        expect(globalThis.logger.error).not.toHaveBeenCalled()
+        expect(adapter.customObjectsApi.replaceNamespacedCustomObjectStatus).not.toHaveBeenCalled()
+    })
+
+    it('skips a status write when the recomputed status is unchanged', async () => {
+        const current = {
+            metadata: {name: 'alice', resourceVersion: '7'},
+            status: {conditions: [{type: 'Approved', status: 'True'}]},
+        }
+        adapter.customObjectsApi = {
+            getNamespacedCustomObject: vi.fn().mockResolvedValue(current),
+            replaceNamespacedCustomObjectStatus: vi.fn(),
+        }
+
+        const result = await adapter.mutateNamespacedCustomObjectStatus(
+            'OIDCUser', 'users', 'alice', value => structuredClone(value), resource => resource.status,
+        )
+
+        expect(result).toEqual(current)
+        expect(adapter.customObjectsApi.replaceNamespacedCustomObjectStatus).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Summary
- preserve the existing resourceVersion-guarded status replace API unchanged
- add a semantic status mutation API that reads the latest resource before every attempt
- rerun the mutation callback after a 409 instead of replaying stale status
- bound retries to three attempts
- migrate all OIDCUser status writers, including reconciliation, ToS, username conditions, email uniqueness, and activity projections
- add regression coverage proving concurrent status fields survive a conflict retry

A deployment-wide Lease is intentionally not part of this change: leader election can deduplicate controller loops, but it cannot serialize request-driven login, ToS, and activity writes. Correct compare-and-swap semantics are required regardless.

## Validation
- npm test: 161 passed
- npm run test:integration: 41 passed
- npm run test:e2e: Dex browser login passed
- Minikube rollout healthy, zero restarts, public endpoint returns 200