### PR TITLE
Add namespaced OIDCUser lifecycle Job hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,11 @@ Passmower can also accept automated user and group provisioning over SCIM 2.0.
 See [docs/scim-provisioning.md](docs/scim-provisioning.md) for endpoint,
 authentication, Entra configuration, and lifecycle behavior.
 
+Kubernetes-native lifecycle automation can run namespaced Jobs when matching
+users are added, changed, or deleted. See
+[docs/oidc-user-event-hooks.md](docs/oidc-user-event-hooks.md) for the hook CRD,
+event metadata, idempotency, and security model.
+
 ## Traefik middleware
 
 For legacy applications `forwardAuth` based middleware option is supported.

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -108,6 +108,116 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: oidcusereventhooks.codemowers.cloud
+spec:
+  group: codemowers.cloud
+  names:
+    plural: oidcusereventhooks
+    singular: oidcusereventhook
+    kind: OIDCUserEventHook
+    listKind: OIDCUserEventHookList
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [events, jobSpec]
+              properties:
+                events:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: string
+                    enum: [Added, Modified, Deleted]
+                selector:
+                  type: object
+                  description: Kubernetes LabelSelector matched against OIDCUser metadata.labels.
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        required: [key, operator]
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: [In, NotIn, Exists, DoesNotExist]
+                          values:
+                            type: array
+                            items:
+                              type: string
+                jobSpec:
+                  type: object
+                  description: batch/v1 JobSpec executed for each matching lifecycle event.
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                lastAttemptedJob:
+                  type: object
+                  required: [name, event, userName, userUID, generation, attemptedAt]
+                  properties:
+                    name:
+                      type: string
+                    event:
+                      type: string
+                      enum: [Added, Modified, Deleted]
+                    userName:
+                      type: string
+                    userUID:
+                      type: string
+                    generation:
+                      type: integer
+                      format: int64
+                    attemptedAt:
+                      type: string
+                      format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ['True', 'False', 'Unknown']
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - name: Last Job
+          type: string
+          jsonPath: .status.lastAttemptedJob.name
+  conversion:
+    strategy: None
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: scimsubjects.codemowers.cloud
 spec:
   group: codemowers.cloud

--- a/charts/passmower/templates/serviceaccount.yaml
+++ b/charts/passmower/templates/serviceaccount.yaml
@@ -24,6 +24,8 @@ rules:
     resources:
       - oidcusers
       - oidcusers/status
+      - oidcusereventhooks
+      - oidcusereventhooks/status
       - oidcclients
       - oidcclients/status
       - oidcmiddlewareclients

--- a/docs/oidc-user-event-hooks.md
+++ b/docs/oidc-user-event-hooks.md
@@ -53,10 +53,24 @@ not injected. A hook that requires them must use an explicitly authorized
 service account and query the Kubernetes API itself.
 
 Generated Jobs have deterministic names based on the hook, user UID,
-generation, and event type. This makes watch replay and concurrent Passmower
-replicas idempotent. Passmower defaults `restartPolicy` to `OnFailure` and
-`ttlSecondsAfterFinished` to `3600`; either can be overridden in `jobSpec`.
-Jobs are owned by the hook and labelled for monitoring.
+generation, and event type. This deduplicates concurrent Passmower replicas and
+routine watch reconnects while the process and Job still exist. Passmower
+defaults `restartPolicy` to `OnFailure` and `ttlSecondsAfterFinished` to `3600`;
+either can be overridden in `jobSpec`. Jobs are owned by the hook and labelled
+for monitoring.
+
+Hook delivery is **at least once**, not exactly once. Kubernetes replays
+existing resources as `Added` when a watch starts. Passmower suppresses those
+replays across watch reconnects within one process, but a Passmower pod restart
+loses that in-memory history. If the deterministic Added Job has already been
+reaped, the replacement pod can create it again. Hook workloads must therefore
+handle repeated Added events idempotently.
+
+The operator is edge-triggered and does not persist a user-event journal. A
+Deleted event that occurs while Passmower is stopped or outside an active watch
+can be missed permanently. Do not use this initial hook implementation as the
+only record for mandatory deprovisioning; periodically reconcile the target
+system or retain another authoritative lifecycle record.
 
 The hook status records the last attempted Job and a `Ready` condition. Failed
 Job creation sets `Ready=False` with reason `JobCreationFailed` and emits a

--- a/docs/oidc-user-event-hooks.md
+++ b/docs/oidc-user-event-hooks.md
@@ -61,10 +61,12 @@ for monitoring.
 
 Hook delivery is **at least once**, not exactly once. Kubernetes replays
 existing resources as `Added` when a watch starts. Passmower suppresses those
-replays across watch reconnects within one process, but a Passmower pod restart
-loses that in-memory history. If the deterministic Added Job has already been
-reaped, the replacement pod can create it again. Hook workloads must therefore
-handle repeated Added events idempotently.
+replays across watch reconnects within one process. If a known user's generation
+advanced during a watch gap, Passmower classifies the replay as `Modified` so
+that edge is not silently lost. A Passmower pod restart loses this in-memory
+history, however. If the deterministic Added Job has already been reaped, the
+replacement pod can create it again. Hook workloads must therefore handle
+repeated Added events idempotently.
 
 The operator is edge-triggered and does not persist a user-event journal. A
 Deleted event that occurs while Passmower is stopped or outside an active watch

--- a/docs/oidc-user-event-hooks.md
+++ b/docs/oidc-user-event-hooks.md
@@ -1,0 +1,72 @@
+# OIDCUser lifecycle Job hooks
+
+`OIDCUserEventHook` runs a Kubernetes `Job` when a matching `OIDCUser` is added,
+its spec generation changes, or it is deleted. Hooks and users must be in the
+same namespace; the generated Job also runs in that namespace.
+
+```yaml
+apiVersion: codemowers.cloud/v1
+kind: OIDCUserEventHook
+metadata:
+  name: directory-sync
+  namespace: passmower
+spec:
+  selector:
+    matchLabels:
+      directory-sync: enabled
+    matchExpressions:
+      - key: account-type
+        operator: In
+        values: [person, service]
+  events: [Added, Modified, Deleted]
+  jobSpec:
+    ttlSecondsAfterFinished: 900
+    template:
+      spec:
+        serviceAccountName: directory-sync
+        containers:
+          - name: sync
+            image: registry.example.com/directory-sync:1.0.0
+        restartPolicy: OnFailure
+```
+
+`selector` uses the Kubernetes `LabelSelector` shape: `matchLabels` plus the
+`In`, `NotIn`, `Exists`, and `DoesNotExist` match-expression operators. Omitting
+it matches every `OIDCUser` in the hook namespace. A `Modified` event is emitted
+only when `metadata.generation` changes, so status-only reconciliation does not
+run hooks.
+
+Passmower adds the following literal environment variables to every regular and
+init container, replacing same-named entries from the template:
+
+| Variable | Value |
+|---|---|
+| `PASSMOWER_EVENT_TYPE` | `Added`, `Modified`, or `Deleted` |
+| `PASSMOWER_RESOURCE_KIND` | `OIDCUser` |
+| `PASSMOWER_RESOURCE_NAMESPACE` | User namespace |
+| `PASSMOWER_RESOURCE_NAME` | User resource name |
+| `PASSMOWER_RESOURCE_UID` | User Kubernetes UID |
+| `PASSMOWER_RESOURCE_GENERATION` | User spec generation |
+
+The full `OIDCUser`, email addresses, identities, tokens, and credentials are
+not injected. A hook that requires them must use an explicitly authorized
+service account and query the Kubernetes API itself.
+
+Generated Jobs have deterministic names based on the hook, user UID,
+generation, and event type. This makes watch replay and concurrent Passmower
+replicas idempotent. Passmower defaults `restartPolicy` to `OnFailure` and
+`ttlSecondsAfterFinished` to `3600`; either can be overridden in `jobSpec`.
+Jobs are owned by the hook and labelled for monitoring.
+
+The hook status records the last attempted Job and a `Ready` condition. Failed
+Job creation sets `Ready=False` with reason `JobCreationFailed` and emits a
+Kubernetes Warning event on the hook.
+
+## Security
+
+Permission to create or update `OIDCUserEventHook` is workload-creation
+authority. Its `jobSpec` can execute arbitrary images and select any
+ServiceAccount that the namespace's admission and RBAC policies permit. Restrict
+hook writes to the same trusted administrators who may create Jobs, and enforce
+image, ServiceAccount, and pod-security policy with admission controls where
+required.

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -308,16 +308,20 @@ export class KubernetesAdapter {
         })
     }
 
-    async createJob(namespace, jobManifest) {
+    async createJob(namespace, jobManifest, {ignoreAlreadyExists = false} = {}) {
         return await this.batchV1Api.createNamespacedJob({
             namespace,
             body: jobManifest
         }, this.defaultOptions).then((r) => {
             return r.status
         }).catch((e) => {
+            const statusCode = e.code ?? e.statusCode ?? e.response?.statusCode
+            if (ignoreAlreadyExists && statusCode === 409) {
+                return {alreadyExists: true}
+            }
             // Surface failures (not just 404) — a swallowed secret-refresh
             // failure was a source of "refresh not triggering" confusion (#69).
-            globalThis.logger.error({ err: e, job: jobManifest?.metadata?.name }, 'Failed to create secret-refresh Job')
+            globalThis.logger.error({ err: e, job: jobManifest?.metadata?.name }, 'Failed to create Kubernetes Job')
             return null
         })
     }

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import KubeScimConnectionOperator from "./operators/kube-scim-connection-operato
 import metricsServer from "./routes/metrics-server.js";
 import {getUsernameSource} from "./utils/username-source.js";
 import {getActivityTracker} from './services/activity-tracker.js';
+import KubeOidcUserEventHookOperator from './operators/kube-oidc-user-event-hook-operator.js';
 
 const __dirname = dirname(import.meta.url);
 
@@ -53,6 +54,8 @@ export async function startOperators(provider) {
     await kubeMiddlewareClientOperator.watchClients()
     const kubeUserOperator = new KubeOidcUserOperator(provider)
     await kubeUserOperator.watchUsers()
+    const kubeUserEventHookOperator = new KubeOidcUserEventHookOperator()
+    await kubeUserEventHookOperator.watchUsers()
     const scimConnectionOperator = new KubeScimConnectionOperator()
     await scimConnectionOperator.watchConnections()
     activityTracker.start()

--- a/src/models/oidc-user-event-hook.js
+++ b/src/models/oidc-user-event-hook.js
@@ -1,0 +1,128 @@
+import {createHash} from 'node:crypto'
+import {OIDCUserEventHookCrd, OIDCUserCrd} from '../utils/kubernetes/kube-constants.js'
+import {KubeOwnerMetadata} from '../utils/kubernetes/kube-owner-metadata.js'
+
+const injectedEnvironment = {
+    eventType: 'PASSMOWER_EVENT_TYPE',
+    resourceKind: 'PASSMOWER_RESOURCE_KIND',
+    namespace: 'PASSMOWER_RESOURCE_NAMESPACE',
+    name: 'PASSMOWER_RESOURCE_NAME',
+    uid: 'PASSMOWER_RESOURCE_UID',
+    generation: 'PASSMOWER_RESOURCE_GENERATION',
+}
+
+function matchesSelector(labels, selector = {}) {
+    labels ??= {}
+    if (Object.entries(selector.matchLabels ?? {}).some(([key, value]) => labels[key] !== value)) return false
+    return (selector.matchExpressions ?? []).every(({key, operator, values = []}) => {
+        const present = Object.hasOwn(labels, key)
+        if (operator === 'In') return present && values.includes(labels[key])
+        if (operator === 'NotIn') return !present || !values.includes(labels[key])
+        if (operator === 'Exists') return present
+        if (operator === 'DoesNotExist') return !present
+        return false
+    })
+}
+
+function injectEnvironment(containers = [], event) {
+    const values = {
+        eventType: event.type,
+        resourceKind: OIDCUserCrd,
+        namespace: event.user.metadata.namespace,
+        name: event.user.metadata.name,
+        uid: event.user.metadata.uid,
+        generation: String(event.user.metadata.generation ?? 1),
+    }
+    for (const container of containers) {
+        const injectedNames = new Set(Object.values(injectedEnvironment))
+        container.env = [
+            ...(container.env ?? []).filter(item => !injectedNames.has(item.name)),
+            ...Object.entries(injectedEnvironment).map(([field, name]) => ({name, value: values[field]})),
+        ]
+    }
+}
+
+function labelValue(value) {
+    const text = String(value)
+    if (text.length <= 63) return text
+    const digest = createHash('sha256').update(text).digest('hex').slice(0, 12)
+    return `${text.slice(0, 50)}-${digest}`
+}
+
+export class OidcUserEventHook {
+    fromKubernetes(resource) {
+        this.resource = resource
+        this.name = resource.metadata.name
+        this.namespace = resource.metadata.namespace
+        this.uid = resource.metadata.uid
+        this.resourceVersion = resource.metadata.resourceVersion
+        this.spec = resource.spec
+        this.status = resource.status ?? {}
+        return this
+    }
+
+    matches(event) {
+        return (this.spec.events ?? []).includes(event.type)
+            && matchesSelector(event.user.metadata.labels, this.spec.selector)
+    }
+
+    getJob(event) {
+        const generation = String(event.user.metadata.generation ?? 1)
+        const identity = [this.uid ?? this.name, event.user.metadata.uid, generation, event.type].join('\0')
+        const digest = createHash('sha256').update(identity).digest('hex').slice(0, 12)
+        const prefix = this.name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '').slice(0, 35)
+        const jobSpec = structuredClone(this.spec.jobSpec)
+        jobSpec.template ??= {}
+        jobSpec.template.spec ??= {}
+        jobSpec.template.spec.restartPolicy ??= 'OnFailure'
+        jobSpec.ttlSecondsAfterFinished ??= 3600
+        injectEnvironment(jobSpec.template.spec.initContainers, event)
+        injectEnvironment(jobSpec.template.spec.containers, event)
+        return {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            metadata: {
+                name: `${prefix}-${event.type.toLowerCase()}-${digest}`,
+                namespace: this.namespace,
+                ownerReferences: [new KubeOwnerMetadata(OIDCUserEventHookCrd, this.name, this.uid)],
+                labels: {
+                    'app.kubernetes.io/managed-by': 'passmower',
+                    'app.kubernetes.io/component': 'oidc-user-event-hook',
+                    'codemowers.cloud/oidc-user-event-hook': labelValue(this.name),
+                    'codemowers.cloud/event': event.type.toLowerCase(),
+                    'codemowers.cloud/oidc-user': labelValue(event.user.metadata.name),
+                },
+            },
+            spec: jobSpec,
+        }
+    }
+
+    getMetadata() {
+        return new KubeOwnerMetadata(OIDCUserEventHookCrd, this.name, this.uid)
+    }
+
+    withAttempt(event, jobName, ready, reason, message, now = new Date()) {
+        const previous = this.status.conditions?.find(condition => condition.type === 'Ready')
+        const status = ready ? 'True' : 'False'
+        const condition = {
+            type: 'Ready', status, reason, message,
+            lastTransitionTime: previous?.status === status ? previous.lastTransitionTime : now,
+        }
+        this.status = {
+            ...this.status,
+            lastAttemptedJob: {
+                name: jobName,
+                event: event.type,
+                userName: event.user.metadata.name,
+                userUID: event.user.metadata.uid,
+                generation: event.user.metadata.generation ?? 1,
+                attemptedAt: now,
+            },
+            conditions: [...(this.status.conditions ?? []).filter(item => item.type !== 'Ready'), condition],
+        }
+        return this.status
+    }
+}
+
+export {matchesSelector}
+export default OidcUserEventHook

--- a/src/operators/kube-oidc-user-event-hook-operator.js
+++ b/src/operators/kube-oidc-user-event-hook-operator.js
@@ -22,7 +22,12 @@ export class KubeOidcUserEventHookOperator {
     }
 
     async #added(user) {
-        this.generations.set(user.metadata.uid, user.metadata.generation ?? 1)
+        const generation = user.metadata.generation ?? 1
+        // Kubernetes reports every existing object as ADDED when a watch is
+        // re-established. Suppress those synthetic events within this process,
+        // including after the user has advanced to a newer generation.
+        if (this.generations.get(user.metadata.uid) === generation) return
+        this.generations.set(user.metadata.uid, generation)
         await this.#dispatch({type: 'Added', user})
     }
 

--- a/src/operators/kube-oidc-user-event-hook-operator.js
+++ b/src/operators/kube-oidc-user-event-hook-operator.js
@@ -1,0 +1,77 @@
+import {KubernetesAdapter} from '../adapters/kubernetes.js'
+import {OidcUserEventHook} from '../models/oidc-user-event-hook.js'
+import {NamespaceFilter} from '../utils/kubernetes/namespace-filter.js'
+import {OIDCUserCrd, OIDCUserEventHookCrd} from '../utils/kubernetes/kube-constants.js'
+
+export class KubeOidcUserEventHookOperator {
+    constructor(adapter = new KubernetesAdapter()) {
+        this.adapter = adapter
+        this.generations = new Map()
+    }
+
+    async watchUsers() {
+        this.adapter.setWatchParameters(
+            OIDCUserCrd,
+            user => user,
+            user => this.#added(user),
+            user => this.#modified(user),
+            user => this.#deleted(user),
+            new NamespaceFilter(this.adapter.namespace),
+        )
+        await this.adapter.watchObjects()
+    }
+
+    async #added(user) {
+        this.generations.set(user.metadata.uid, user.metadata.generation ?? 1)
+        await this.#dispatch({type: 'Added', user})
+    }
+
+    async #modified(user) {
+        const generation = user.metadata.generation ?? 1
+        if (this.generations.get(user.metadata.uid) === generation) return
+        this.generations.set(user.metadata.uid, generation)
+        await this.#dispatch({type: 'Modified', user})
+    }
+
+    async #deleted(user) {
+        this.generations.delete(user.metadata.uid)
+        await this.#dispatch({type: 'Deleted', user})
+    }
+
+    async #dispatch(event) {
+        const hooks = await this.adapter.listNamespacedCustomObject(
+            OIDCUserEventHookCrd,
+            event.user.metadata.namespace,
+            resource => new OidcUserEventHook().fromKubernetes(resource),
+        ) ?? []
+        for (const hook of hooks.filter(item => item.matches(event))) {
+            await this.#runHook(hook, event)
+        }
+    }
+
+    async #runHook(hook, event) {
+        const job = hook.getJob(event)
+        const result = await this.adapter.createJob(hook.namespace, job, {ignoreAlreadyExists: true})
+        const ready = Boolean(result)
+        const reason = ready
+            ? (result.alreadyExists ? 'JobAlreadyExists' : 'JobCreated')
+            : 'JobCreationFailed'
+        const message = ready
+            ? `${event.type} hook Job ${job.metadata.name} ${result.alreadyExists ? 'already exists' : 'was created'}`
+            : `Failed to create ${event.type} hook Job ${job.metadata.name}`
+        await this.adapter.mutateNamespacedCustomObjectStatus(
+            OIDCUserEventHookCrd, hook.namespace, hook.name,
+            resource => new OidcUserEventHook().fromKubernetes(resource),
+            current => current.withAttempt(event, job.metadata.name, ready, reason, message),
+        )
+        if (!ready) {
+            await this.adapter.createEvent(hook.namespace, hook.getMetadata(), reason, message)
+            globalThis.logger?.error(
+                {hook: hook.name, user: event.user.metadata.name, event: event.type},
+                'Failed to execute OIDCUserEventHook',
+            )
+        }
+    }
+}
+
+export default KubeOidcUserEventHookOperator

--- a/src/operators/kube-oidc-user-event-hook-operator.js
+++ b/src/operators/kube-oidc-user-event-hook-operator.js
@@ -23,12 +23,14 @@ export class KubeOidcUserEventHookOperator {
 
     async #added(user) {
         const generation = user.metadata.generation ?? 1
+        const previousGeneration = this.generations.get(user.metadata.uid)
         // Kubernetes reports every existing object as ADDED when a watch is
-        // re-established. Suppress those synthetic events within this process,
-        // including after the user has advanced to a newer generation.
-        if (this.generations.get(user.metadata.uid) === generation) return
+        // re-established. Suppress unchanged synthetic events within this
+        // process; if the generation advanced during the watch gap, preserve
+        // that missed spec edge by dispatching it as Modified instead.
+        if (previousGeneration === generation) return
         this.generations.set(user.metadata.uid, generation)
-        await this.#dispatch({type: 'Added', user})
+        await this.#dispatch({type: previousGeneration === undefined ? 'Added' : 'Modified', user})
     }
 
     async #modified(user) {

--- a/src/utils/kubernetes/kube-constants.js
+++ b/src/utils/kubernetes/kube-constants.js
@@ -2,6 +2,8 @@ export const metadata = 'metadata';
 export const spec = 'spec';
 export const OIDCUserCrd = 'OIDCUser';
 export const OIDCUsers = 'oidcusers';
+export const OIDCUserEventHookCrd = 'OIDCUserEventHook';
+export const OIDCUserEventHooks = 'oidcusereventhooks';
 export const OIDCClientCrd = 'OIDCClient';
 export const OIDCClients = 'oidcclients';
 export const OIDCMiddlewareClientCrd = 'OIDCMiddlewareClient';
@@ -46,6 +48,7 @@ export const TraefikMiddlewareForwardAuthAddress = (deployment, namespace, clien
 
 export const plurals = {
     [OIDCUserCrd]: OIDCUsers,
+    [OIDCUserEventHookCrd]: OIDCUserEventHooks,
     [OIDCClientCrd]: OIDCClients,
     [OIDCMiddlewareClientCrd]: OIDCMiddlewareClients,
     [SCIMConnectionCrd]: SCIMConnections,

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -98,7 +98,13 @@ export class FakeKubernetesAdapter {
     async createSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
     async patchSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
     async deleteSecret(namespace, id) { this.secrets.delete(`${namespace}/${id}`) }
-    async createJob(namespace, jobManifest) { this.jobs.push({ namespace, jobManifest: structuredClone(jobManifest) }); return { active: 1 } }
+    async createJob(namespace, jobManifest, {ignoreAlreadyExists = false} = {}) {
+        const existing = this.jobs.find(job => job.namespace === namespace
+            && job.jobManifest.metadata.name === jobManifest.metadata.name)
+        if (existing) return ignoreAlreadyExists ? {alreadyExists: true} : null
+        this.jobs.push({ namespace, jobManifest: structuredClone(jobManifest) })
+        return { active: 1 }
+    }
     async createEvent(namespace, involvedObject, reason, message, type = 'Warning') {
         const event = {namespace, involvedObject: structuredClone(involvedObject), reason, message, type}
         this.events.push(event)

--- a/test/unit/kubernetes-job.test.js
+++ b/test/unit/kubernetes-job.test.js
@@ -1,0 +1,33 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {KubernetesAdapter} from '../../src/adapters/kubernetes.js'
+
+describe('Kubernetes Job creation', () => {
+    let adapter
+    const job = {metadata: {name: 'deterministic-hook-job'}}
+
+    beforeEach(() => {
+        globalThis.logger = {error: vi.fn()}
+        adapter = Object.create(KubernetesAdapter.prototype)
+        adapter.defaultOptions = {}
+    })
+
+    it('treats an existing deterministic Job as a successful replay', async () => {
+        adapter.batchV1Api = {
+            createNamespacedJob: vi.fn().mockRejectedValue(Object.assign(new Error('Already exists'), {code: 409})),
+        }
+
+        await expect(adapter.createJob('users', job, {ignoreAlreadyExists: true}))
+            .resolves.toEqual({alreadyExists: true})
+        expect(globalThis.logger.error).not.toHaveBeenCalled()
+    })
+
+    it('continues surfacing other Job creation failures', async () => {
+        const forbidden = Object.assign(new Error('Forbidden'), {code: 403})
+        adapter.batchV1Api = {createNamespacedJob: vi.fn().mockRejectedValue(forbidden)}
+
+        await expect(adapter.createJob('users', job, {ignoreAlreadyExists: true})).resolves.toBeNull()
+        expect(globalThis.logger.error).toHaveBeenCalledWith(
+            {err: forbidden, job: 'deterministic-hook-job'}, 'Failed to create Kubernetes Job',
+        )
+    })
+})

--- a/test/unit/oidc-user-event-hook-operator.test.js
+++ b/test/unit/oidc-user-event-hook-operator.test.js
@@ -1,0 +1,100 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js'
+import {KubeOidcUserEventHookOperator} from '../../src/operators/kube-oidc-user-event-hook-operator.js'
+
+function rawHook(name = 'sync', overrides = {}) {
+    return {
+        metadata: {name, namespace: 'users', uid: `uid-${name}`},
+        spec: {
+            events: ['Added', 'Modified', 'Deleted'],
+            selector: {matchLabels: {tenant: 'acme'}},
+            jobSpec: {template: {spec: {containers: [{name: 'sync', image: 'busybox'}]}}},
+            ...overrides,
+        },
+    }
+}
+
+function rawUser(name = 'alice', generation = 1, labels = {tenant: 'acme'}) {
+    return {
+        metadata: {name, namespace: 'users', uid: `uid-${name}`, generation, labels},
+        spec: {type: 'person', email: `${name}@example.com`},
+        status: {},
+    }
+}
+
+describe('KubeOidcUserEventHookOperator', () => {
+    let adapter
+
+    beforeEach(() => {
+        globalThis.logger = {error: vi.fn(), info: vi.fn(), warn: vi.fn()}
+        adapter = new FakeKubernetesAdapter({namespace: 'users'})
+        adapter.seed('OIDCUserEventHook', rawHook())
+    })
+
+    async function operator() {
+        const result = new KubeOidcUserEventHookOperator(adapter)
+        await result.watchUsers()
+        return result
+    }
+
+    it('creates Jobs for Added, generation-changing Modified, and Deleted events', async () => {
+        await operator()
+        adapter.seed('OIDCUser', rawUser())
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+        adapter.seed('OIDCUser', rawUser('alice', 2))
+        await adapter.fireWatch('MODIFIED', 'OIDCUser', 'alice')
+        await adapter.fireWatch('DELETED', 'OIDCUser', 'alice')
+
+        expect(adapter.jobs.map(item => item.jobManifest.metadata.labels['codemowers.cloud/event']))
+            .toEqual(['added', 'modified', 'deleted'])
+        expect(adapter.jobs.every(item => item.namespace === 'users')).toBe(true)
+        expect(adapter.list('OIDCUserEventHook')[0].status).toMatchObject({
+            lastAttemptedJob: {event: 'Deleted', userName: 'alice', generation: 2},
+            conditions: [{type: 'Ready', status: 'True', reason: 'JobCreated'}],
+        })
+    })
+
+    it('does not create Jobs for status-only changes or replayed events', async () => {
+        await operator()
+        adapter.seed('OIDCUser', rawUser())
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+        await adapter.fireWatch('MODIFIED', 'OIDCUser', 'alice')
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+
+        expect(adapter.jobs).toHaveLength(1)
+        expect(adapter.list('OIDCUserEventHook')[0].status.conditions[0]).toMatchObject({
+            status: 'True', reason: 'JobAlreadyExists',
+        })
+    })
+
+    it('enforces event filters and label selectors', async () => {
+        adapter.seed('OIDCUserEventHook', rawHook('added-acme', {events: ['Added']}))
+        await operator()
+        adapter.seed('OIDCUser', rawUser('bob', 1, {tenant: 'other'}))
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'bob')
+        adapter.seed('OIDCUser', rawUser('alice'))
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+        adapter.seed('OIDCUser', rawUser('alice', 2))
+        await adapter.fireWatch('MODIFIED', 'OIDCUser', 'alice')
+
+        const jobsByHook = adapter.jobs.map(item => item.jobManifest.metadata.labels['codemowers.cloud/oidc-user-event-hook'])
+        expect(jobsByHook.filter(name => name === 'sync')).toHaveLength(2)
+        expect(jobsByHook.filter(name => name === 'added-acme')).toHaveLength(1)
+    })
+
+    it('records a degraded status and emits a Warning event when Job creation fails', async () => {
+        adapter.createJob = vi.fn().mockResolvedValue(null)
+        await operator()
+        adapter.seed('OIDCUser', rawUser())
+
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+
+        expect(adapter.list('OIDCUserEventHook')[0].status).toMatchObject({
+            lastAttemptedJob: {event: 'Added', userName: 'alice'},
+            conditions: [{type: 'Ready', status: 'False', reason: 'JobCreationFailed'}],
+        })
+        expect(adapter.events).toContainEqual(expect.objectContaining({
+            reason: 'JobCreationFailed', type: 'Warning',
+        }))
+    })
+})

--- a/test/unit/oidc-user-event-hook-operator.test.js
+++ b/test/unit/oidc-user-event-hook-operator.test.js
@@ -72,6 +72,23 @@ describe('KubeOidcUserEventHookOperator', () => {
         })
     })
 
+    it('classifies an advanced generation replayed after a watch gap as Modified', async () => {
+        await operator()
+        adapter.seed('OIDCUser', rawUser())
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+        adapter.seed('OIDCUser', rawUser('alice', 2))
+
+        // A re-established Kubernetes watch reports existing resources as
+        // ADDED even when their spec changed while the watch was disconnected.
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+
+        expect(adapter.jobs.map(item => item.jobManifest.metadata.labels['codemowers.cloud/event']))
+            .toEqual(['added', 'modified'])
+        expect(adapter.list('OIDCUserEventHook')[0].status.lastAttemptedJob).toMatchObject({
+            event: 'Modified', generation: 2,
+        })
+    })
+
     it('enforces event filters and label selectors', async () => {
         adapter.seed('OIDCUserEventHook', rawHook('added-acme', {events: ['Added']}))
         await operator()

--- a/test/unit/oidc-user-event-hook-operator.test.js
+++ b/test/unit/oidc-user-event-hook-operator.test.js
@@ -54,16 +54,21 @@ describe('KubeOidcUserEventHookOperator', () => {
         })
     })
 
-    it('does not create Jobs for status-only changes or replayed events', async () => {
+    it('does not create Jobs for status-only changes or reconnect replays at the current generation', async () => {
         await operator()
         adapter.seed('OIDCUser', rawUser())
         await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
         await adapter.fireWatch('MODIFIED', 'OIDCUser', 'alice')
         await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
+        adapter.seed('OIDCUser', rawUser('alice', 2))
+        await adapter.fireWatch('MODIFIED', 'OIDCUser', 'alice')
+        await adapter.fireWatch('ADDED', 'OIDCUser', 'alice')
 
-        expect(adapter.jobs).toHaveLength(1)
+        expect(adapter.jobs).toHaveLength(2)
+        expect(adapter.jobs.map(item => item.jobManifest.metadata.labels['codemowers.cloud/event']))
+            .toEqual(['added', 'modified'])
         expect(adapter.list('OIDCUserEventHook')[0].status.conditions[0]).toMatchObject({
-            status: 'True', reason: 'JobAlreadyExists',
+            status: 'True', reason: 'JobCreated',
         })
     })
 

--- a/test/unit/oidc-user-event-hook.test.js
+++ b/test/unit/oidc-user-event-hook.test.js
@@ -1,0 +1,95 @@
+import {describe, expect, it} from 'vitest'
+import {OidcUserEventHook, matchesSelector} from '../../src/models/oidc-user-event-hook.js'
+
+function hook(overrides = {}) {
+    return new OidcUserEventHook().fromKubernetes({
+        metadata: {name: 'directory-sync', namespace: 'users', uid: 'hook-uid', resourceVersion: '1'},
+        spec: {
+            events: ['Added', 'Modified', 'Deleted'],
+            selector: {matchLabels: {tenant: 'acme'}},
+            jobSpec: {
+                template: {
+                    spec: {
+                        containers: [{name: 'sync', image: 'example/sync', env: [{name: 'EXISTING', value: 'yes'}]}],
+                        initContainers: [{name: 'prepare', image: 'example/prepare'}],
+                    },
+                },
+            },
+        },
+        status: {},
+        ...overrides,
+    })
+}
+
+function event(type = 'Added', overrides = {}) {
+    return {
+        type,
+        user: {
+            apiVersion: 'codemowers.cloud/v1', kind: 'OIDCUser',
+            metadata: {
+                name: 'alice', namespace: 'users', uid: 'user-uid', generation: 3,
+                labels: {tenant: 'acme', active: 'true'},
+                ...overrides,
+            },
+            spec: {email: 'alice@example.com'},
+        },
+    }
+}
+
+describe('OIDCUserEventHook model', () => {
+    it('matches Kubernetes LabelSelector expressions', () => {
+        const labels = {tenant: 'acme', active: 'true'}
+        expect(matchesSelector(labels, {matchLabels: {tenant: 'acme'}})).toBe(true)
+        expect(matchesSelector(labels, {matchExpressions: [
+            {key: 'tenant', operator: 'In', values: ['acme']},
+            {key: 'deleted', operator: 'DoesNotExist'},
+            {key: 'active', operator: 'Exists'},
+        ]})).toBe(true)
+        expect(matchesSelector(labels, {matchExpressions: [
+            {key: 'tenant', operator: 'NotIn', values: ['acme']},
+        ]})).toBe(false)
+    })
+
+    it('builds a deterministic, owned and labelled Job with non-sensitive metadata', () => {
+        const model = hook()
+        const first = model.getJob(event())
+        const replay = model.getJob(event())
+
+        expect(replay.metadata.name).toBe(first.metadata.name)
+        expect(first.metadata).toMatchObject({
+            namespace: 'users',
+            ownerReferences: [{kind: 'OIDCUserEventHook', name: 'directory-sync', uid: 'hook-uid'}],
+            labels: {
+                'app.kubernetes.io/managed-by': 'passmower',
+                'app.kubernetes.io/component': 'oidc-user-event-hook',
+                'codemowers.cloud/oidc-user-event-hook': 'directory-sync',
+                'codemowers.cloud/event': 'added',
+                'codemowers.cloud/oidc-user': 'alice',
+            },
+        })
+        expect(first.spec.template.spec.restartPolicy).toBe('OnFailure')
+        expect(first.spec.ttlSecondsAfterFinished).toBe(3600)
+        for (const container of [...first.spec.template.spec.containers, ...first.spec.template.spec.initContainers]) {
+            expect(Object.fromEntries(container.env.map(item => [item.name, item.value]))).toMatchObject({
+                PASSMOWER_EVENT_TYPE: 'Added',
+                PASSMOWER_RESOURCE_KIND: 'OIDCUser',
+                PASSMOWER_RESOURCE_NAMESPACE: 'users',
+                PASSMOWER_RESOURCE_NAME: 'alice',
+                PASSMOWER_RESOURCE_UID: 'user-uid',
+                PASSMOWER_RESOURCE_GENERATION: '3',
+            })
+            expect(JSON.stringify(container.env)).not.toContain('alice@example.com')
+        }
+    })
+
+    it('changes the Job identity across generation and event type', () => {
+        const model = hook()
+        const names = new Set([
+            model.getJob(event('Added')).metadata.name,
+            model.getJob(event('Modified')).metadata.name,
+            model.getJob(event('Modified', {generation: 4})).metadata.name,
+            model.getJob(event('Deleted', {generation: 4})).metadata.name,
+        ])
+        expect(names.size).toBe(4)
+    })
+})


### PR DESCRIPTION
## Summary
- add the namespaced OIDCUserEventHook CRD, Helm RBAC, and runtime operator
- create deterministic, replay-safe Jobs for matching Added, generation-changing Modified, and Deleted events
- inject only non-sensitive resource metadata and report Job attempts through hook status and Kubernetes events
- document the workload-creation security boundary and add model, adapter, and fake-operator regression coverage

Implements #179.

## Validation
- npm test (174 passed)
- npm run test:integration (42 passed)
- helm template + Kubernetes server-side dry-run
- minikube smoke test: Added, Modified, and Deleted each created one labelled Job with the expected environment; status-only updates created none