### PR TITLE
Preserve verified email provenance and emit email_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ spec:
     - code
   availableScopes:
     - openid
+    - email
     - profile
   tokenEndpointAuthMethod: none
 ```
@@ -316,6 +317,11 @@ Passmower validates email ownership across those resources and blocks newer
 duplicates from authentication. See
 [docs/identity-integrity.md](docs/identity-integrity.md) for provider linking,
 normalization, conflict status, metrics, and remediation.
+
+Verified-email provenance is retained per normalized address and exposed to
+downstream clients through the `email` scope. See
+[docs/email-verification.md](docs/email-verification.md) for provider rules,
+magic-link fallback, and client configuration.
 
 ```
 apiVersion: codemowers.cloud/v1

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -416,6 +416,8 @@ spec:
                       primary:
                         type: boolean
                         default: false
+                      verified:
+                        type: boolean
                 groups:
                   type: array
                   items:
@@ -456,6 +458,8 @@ spec:
                         primary:
                           type: boolean
                           default: false
+                        verified:
+                          type: boolean
                   groups:
                     type: array
                     items:
@@ -602,6 +606,26 @@ spec:
                   type: array
                   items:
                     type: string
+                emailVerifications:
+                  type: array
+                  description: Verification evidence scoped to an exact normalized email address.
+                  items:
+                    type: object
+                    required: [email, status, method, provider]
+                    properties:
+                      email:
+                        type: string
+                      status:
+                        type: string
+                        enum: [verified, unverified, unknown]
+                      method:
+                        type: string
+                        enum: [github-api, oidc-claim, discord-api, magic-link]
+                      provider:
+                        type: string
+                      verifiedAt:
+                        type: string
+                        format: date-time
                 passkeyCount:
                   type: integer
                   description: Number of registered passkeys
@@ -773,6 +797,7 @@ spec:
                     type: string
                     enum:
                       - openid
+                      - email
                       - profile
                       - offline_access
                       - groups

--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -7,7 +7,9 @@ address never verifies another address that later becomes primary.
 Evidence is projected into `OIDCUser.status.emailVerifications` with its status,
 method, provider, and an optional verification timestamp. Provider-backed
 evidence is recomputed from the provider data stored on the user; magic-link
-evidence is durable status maintained by Passmower.
+evidence is durable status maintained by Passmower. Magic-link evidence remains
+stored if its address is temporarily unlinked, but it can only affect claims
+when that exact address is selected as the current primary email.
 
 The current evidence rules are:
 

--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -1,0 +1,48 @@
+# Email verification claims
+
+Passmower tracks verification evidence for each normalized email address. It
+does not treat verification as an account-wide property: proving control of one
+address never verifies another address that later becomes primary.
+
+Evidence is projected into `OIDCUser.status.emailVerifications` with its status,
+method, provider, and an optional verification timestamp. Provider-backed
+evidence is recomputed from the provider data stored on the user; magic-link
+evidence is durable status maintained by Passmower.
+
+The current evidence rules are:
+
+- GitHub is verified only when the matching `/user/emails` result explicitly
+  has `verified: true`. GitHub entries stored before this field was added remain
+  `unknown` until the user signs in with GitHub again or completes a magic-link
+  challenge.
+- Generic OIDC providers, including Google, are verified only when the validated
+  ID token or UserInfo response explicitly contains `email_verified: true`.
+  Explicit `false` is unverified and an omitted claim is unknown.
+- Entra ID email, `preferred_username`, tenant membership, and domain names do
+  not imply verification. Without an explicit trustworthy claim, use the
+  Passmower magic-link login to prove control.
+- Passmower currently has no dedicated Discord adapter. A future adapter must
+  retain Discord's explicit per-address `verified` result rather than infer it.
+- Providers such as Codeberg or Forgejo follow the same rule: use explicit
+  per-address evidence when available; otherwise use a Passmower magic link.
+- Successfully opening a Passmower magic link verifies exactly the challenged
+  destination address with method `magic-link` and provider `passmower`.
+
+## Downstream OIDC clients
+
+Clients must both allow and request the `email` scope. Add it to the
+`OIDCClient` and include it in the authorization request:
+
+```yaml
+spec:
+  availableScopes:
+    - openid
+    - email
+    - profile
+```
+
+With that scope, Passmower emits `email` and a boolean `email_verified` in ID
+tokens and UserInfo. The value is `true` only if at least one trusted evidence
+record verifies the exact normalized address emitted as `email`; unknown and
+unverified addresses produce `false`. Without the `email` scope, both claims are
+omitted.

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -1,7 +1,7 @@
 # Migrating from Passmower 1.x to 2.0
 
-Passmower 2.0 is a major release. It carries two consumer-facing breaking changes
-(Helm values and one `OIDCClient` CRD field) plus a sweep of major dependency
+Passmower 2.0 is a major release. It carries three consumer-facing breaking changes
+(Helm values, one `OIDCClient` CRD field, and standard OIDC email scoping) plus a sweep of major dependency
 upgrades. This note lists everything you must change, and what changed for the better.
 
 > The 2.0 line ships from the `develop` branch as `2.0.0-dev` (image
@@ -14,7 +14,7 @@ upgrades. This note lists everything you must change, and what changed for the b
 - Back up your `values.yaml` (or HelmRelease/ArgoCD Application values).
 - Back up your `OIDCClient` and `OIDCUser` custom resources:
   `kubectl get oidcclients,oidcusers,oidcmiddlewareclients -A -o yaml > passmower-crs.bak.yaml`.
-- Read the two **action required** sections below and edit your values / CRs before
+- Read the three **action required** sections below and edit your values / CRs before
   upgrading.
 
 ---
@@ -140,7 +140,34 @@ labels.
 
 ---
 
-## 3. CRDs promoted to `codemowers.cloud/v1` — **no immediate action, but migrate your manifests**
+## 3. Add the `email` scope to clients that consume email claims — **action required**
+
+Passmower 1.x emitted `email` with the `profile` scope. Passmower 2.0 follows the
+standard OIDC scope boundary: `email` and `email_verified` are emitted only when
+the relying party is allowed to request, and actually requests, the `email` scope.
+
+Add `email` to each affected `OIDCClient` and to the relying party's authorization
+request. Otherwise authentication continues to work, but both email claims are
+omitted.
+
+```diff
+ spec:
+   availableScopes:
+     - openid
++    - email
+     - profile
+```
+
+Existing GitHub identities must sign in through GitHub once after upgrade to
+capture GitHub's explicit per-address verification result. Alternatively, users
+can prove control through a Passmower magic link. Passmower does not infer
+verification from legacy records that lack evidence.
+
+See [email-verification.md](email-verification.md) for provider-specific trust rules.
+
+---
+
+## 4. CRDs promoted to `codemowers.cloud/v1` — **no immediate action, but migrate your manifests**
 
 The custom resources (`OIDCUser`, `OIDCClient`, `OIDCMiddlewareClient`) are promoted
 from `codemowers.cloud/v1beta1` to **`codemowers.cloud/v1`**. This is done the
@@ -181,7 +208,7 @@ the old condition should switch to `status.termsOfService.acceptedAt`.
 
 ---
 
-## 4. RBAC change — automatic
+## 5. RBAC change — automatic
 
 The chart's `ClusterRole` now grants `create` on `batch/jobs` instead of core `pods`
 (the operator creates the refresh **Job** described above). This is applied for you by
@@ -191,7 +218,7 @@ you may drop the old `pods` `create` grant.
 
 ---
 
-## 5. Major dependency upgrades — informational
+## 6. Major dependency upgrades — informational
 
 2.0 upgrades several runtime dependencies across major versions, most notably
 `oidc-provider` 8 → 9, `openid-client` 5 → 6, and `koa` 2 → 3 (also `helmet` 8,
@@ -203,7 +230,7 @@ exists specifically to guard these upgrades.
 
 ---
 
-## 6. What's new (non-breaking)
+## 7. What's new (non-breaking)
 
 You don't have to do anything to get these, but they're the reason to upgrade:
 
@@ -221,7 +248,7 @@ You don't have to do anything to get these, but they're the reason to upgrade:
 
 ---
 
-## 7. Upgrade
+## 8. Upgrade
 
 After editing your values (section 1) and any `OIDCClient`s that used
 `secretRefreshPod` (section 2):

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -70,7 +70,6 @@ export default {
             'username',
         ],
         profile: [
-            'email',
             'emails',
             'name',
             'nickname',

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -317,9 +317,8 @@ class Account {
     }
 
     getEmailVerifications() {
-        const claimedEmails = new Set(this.getClaimedEmails())
         const evidence = this.#emailVerifications
-            .filter(item => item.method === 'magic-link' && claimedEmails.has(canonicalizeEmail(item.email)))
+            .filter(item => item.method === 'magic-link')
             .map(item => ({...item, email: canonicalizeEmail(item.email)}))
         for (const item of this.#github?.emails ?? []) {
             const email = canonicalizeEmail(item.email)

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -37,6 +37,7 @@ class Account {
     #webauthn = null
     #conditions = []
     #termsOfService = null
+    #emailVerifications = []
     #labels = {}
     #metadata = {}
     #ctx = null
@@ -62,6 +63,7 @@ class Account {
         this.slackId = apiResponse.status?.slackId ?? null
         this.#conditions = apiResponse.status?.conditions ?? []
         this.#termsOfService = apiResponse.status?.termsOfService ?? null
+        this.#emailVerifications = apiResponse.status?.emailVerifications ?? []
         this.#recentApplications = apiResponse.status?.recentApplications ?? []
         this.#labels = apiResponse.metadata?.labels ?? {}
         this.#metadata = apiResponse.metadata
@@ -99,8 +101,11 @@ class Account {
             sub: username, // it is essential to always return a sub claim
             username,
             nickname: username,
-            email: this.primaryEmail,
         };
+        if (scope.split(' ').includes('email')) {
+            response.email = this.primaryEmail
+            response.email_verified = this.isPrimaryEmailVerified()
+        }
         if (scope.includes('profile')) {
             response = {
                 ...response,
@@ -177,6 +182,7 @@ class Account {
             conditions: this.#conditions.filter(condition => condition.type !== 'ToSv1'),
             termsOfService: this.getTermsOfServiceAcceptance(),
             recentApplications: this.#recentApplications,
+            emailVerifications: this.getEmailVerifications(),
         }
     }
 
@@ -310,6 +316,64 @@ class Account {
         ].map(canonicalizeEmail).filter(Boolean))]
     }
 
+    getEmailVerifications() {
+        const claimedEmails = new Set(this.getClaimedEmails())
+        const evidence = this.#emailVerifications
+            .filter(item => item.method === 'magic-link' && claimedEmails.has(canonicalizeEmail(item.email)))
+            .map(item => ({...item, email: canonicalizeEmail(item.email)}))
+        for (const item of this.#github?.emails ?? []) {
+            const email = canonicalizeEmail(item.email)
+            if (!email) continue
+            evidence.push({
+                email,
+                status: item.verified === true ? 'verified' : item.verified === false ? 'unverified' : 'unknown',
+                method: 'github-api',
+                provider: 'github',
+            })
+        }
+        for (const [provider, identity] of Object.entries(this.#identities ?? {})) {
+            for (const item of identity.emails ?? []) {
+                const email = canonicalizeEmail(item.email)
+                if (!email) continue
+                evidence.push({
+                    email,
+                    status: item.verified === true ? 'verified' : item.verified === false ? 'unverified' : 'unknown',
+                    method: 'oidc-claim',
+                    provider,
+                })
+            }
+        }
+        return [...new Map(evidence.map(item => [
+            `${item.email}\0${item.method}\0${item.provider}`,
+            item,
+        ])).values()]
+    }
+
+    isPrimaryEmailVerified() {
+        const primaryEmail = canonicalizeEmail(this.primaryEmail)
+        if (!primaryEmail) return false
+        return this.getEmailVerifications().some(item =>
+            item.email === primaryEmail && item.status === 'verified')
+    }
+
+    verifyEmail(email, {method = 'magic-link', provider = 'passmower', verifiedAt = new Date()} = {}) {
+        email = canonicalizeEmail(email)
+        if (!email || !this.getClaimedEmails().includes(email)) return this
+        const verification = {
+            email, status: 'verified', method, provider,
+            verifiedAt: verifiedAt instanceof Date ? verifiedAt.toISOString() : verifiedAt,
+        }
+        this.#emailVerifications = [
+            ...this.#emailVerifications.filter(item => !(
+                canonicalizeEmail(item.email) === email
+                && item.method === method
+                && item.provider === provider
+            )),
+            verification,
+        ]
+        return this
+    }
+
     getIdentity(providerKey) {
         return this.#identities?.[providerKey]
     }
@@ -361,7 +425,8 @@ class Account {
                 const ghEmail = canonicalizeEmail(e.email)
                 return {
                     email: ghEmail,
-                    primary: e.primary
+                    primary: e.primary,
+                    verified: typeof e.verified === 'boolean' ? e.verified : undefined,
                 }
             })
             githubEmails = [...new Map(githubEmails.map(v => [v.email, v])).values()]

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -355,7 +355,9 @@ export default (provider) => {
             })
         }
         auditLog(ctx, {uid: ctx.params.uid}, 'Completing email login on original device')
-        return new EmailLogin().completeLogin(ctx, provider, interactionDetails.result.email)
+        return new EmailLogin().completeLogin(
+            ctx, provider, interactionDetails.result.email, interactionDetails.result.emailVerifiedAt,
+        )
     });
 
     // ============================================

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -10,7 +10,7 @@ import Router from '@koa/router';
 import GithubLogin from "../services/login/github-login.js";
 import OidcLogin from "../services/login/oidc-login.js";
 import {getOidcProvider, getOidcProviders} from "../utils/oidc-providers.js";
-import {EmailLogin} from "../services/login/email-login.js";
+import {EmailLogin, recordSubmittedMagicLinkVerification} from "../services/login/email-login.js";
 import accessDenied from "../utils/session/access-denied.js";
 import getLoginResult from "../utils/user/get-login-result.js";
 import Account from "../models/account.js";
@@ -492,7 +492,7 @@ export default (provider) => {
             }, true)
         }
 
-        const account = await ctx.kubeOIDCUserService.createUser(username, interactionDetails.lastSubmission?.email, interactionDetails.lastSubmission?.githubEmails)
+        let account = await ctx.kubeOIDCUserService.createUser(username, interactionDetails.lastSubmission?.email, interactionDetails.lastSubmission?.githubEmails)
         // The Kubernetes create is the authoritative uniqueness check; the
         // pre-validation can miss a taken name on a transient API error. If
         // creation failed, re-render the form instead of crashing on a null account.
@@ -510,16 +510,21 @@ export default (provider) => {
             current => current.addCondition(condition),
         )
 
-        if (interactionDetails?.lastSubmission?.oauth?.provider) {
-            switch (interactionDetails.lastSubmission.oauth.provider) {
+        const submission = interactionDetails.lastSubmission
+        account = await recordSubmittedMagicLinkVerification(
+            ctx.kubeOIDCUserService, account, submission,
+        )
+
+        if (submission?.oauth?.provider) {
+            switch (submission.oauth.provider) {
                 case "GitHub":
                     await GithubLogin(ctx, provider)
                     break
                 default:
                     throw new Error('not implemented')
             }
-        } else if (interactionDetails?.lastSubmission?.oidc?.provider) {
-            const providerConfig = getOidcProvider(interactionDetails.lastSubmission.oidc.provider)
+        } else if (submission?.oidc?.provider) {
+            const providerConfig = getOidcProvider(submission.oidc.provider)
             if (!providerConfig) {
                 throw new Error('not implemented')
             }

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -229,6 +229,13 @@ export class KubeOIDCUserService {
         return await this.mutateUserStatus(accountId)
     }
 
+    async recordEmailVerification(accountId, email, verification) {
+        return await this.mutateUserStatus(
+            accountId,
+            account => account.verifyEmail(email, verification),
+        )
+    }
+
     // WebAuthn/Passkey methods
 
     /**

--- a/src/services/login/email-login.js
+++ b/src/services/login/email-login.js
@@ -91,7 +91,7 @@ export class EmailLogin {
 
         // Mark verified so the original device's polling can complete the login.
         const ttl = interaction.exp ? Math.max(1, Math.floor(interaction.exp - Date.now() / 1000)) : 3600
-        interaction.result = {...interaction.result, emailVerified: true}
+        interaction.result = {...interaction.result, emailVerified: true, emailVerifiedAt: new Date().toISOString()}
         await interaction.save(ttl)
         auditLog(ctx, {uid, email: interaction.result.email}, 'Email verified via login link')
 
@@ -103,7 +103,7 @@ export class EmailLogin {
         } catch { /* different device/browser — no interaction cookie */ }
 
         if (sameBrowser) {
-            return this.completeLogin(ctx, provider, interaction.result.email)
+            return this.completeLogin(ctx, provider, interaction.result.email, interaction.result.emailVerifiedAt)
         }
         return this.#renderMessage(ctx, 'Email verified',
             'Your email is verified. Return to the window or device where you started signing in — it will continue automatically.')
@@ -119,10 +119,14 @@ export class EmailLogin {
     // Complete the login in the original browser (interaction cookie present),
     // where account creation / username prompt have full context. Relies on the
     // server-side emailVerified flag, which only a valid token could have set.
-    async completeLogin(ctx, provider, email) {
-        const account = await Account.createOrUpdateByEmails(ctx, provider, email)
+    async completeLogin(ctx, provider, email, verifiedAt = new Date().toISOString()) {
+        let account = await Account.createOrUpdateByEmails(ctx, provider, email)
         if (!account) {
             auditLog(ctx, {email}, 'Unable to determine account from login link')
+        } else {
+            account = await ctx.kubeOIDCUserService.recordEmailVerification(account.accountId, email, {
+                method: 'magic-link', provider: 'passmower', verifiedAt,
+            })
         }
         return provider.interactionFinished(ctx.req, ctx.res, await getLoginResult(ctx, provider, account, 'LoginLink'), {
             mergeWithLastSubmission: true,

--- a/src/services/login/email-login.js
+++ b/src/services/login/email-login.js
@@ -10,6 +10,17 @@ import {parseRequestMetadata} from "../../utils/session/parse-request-headers.js
 import {auditLog} from "../../utils/session/audit-log.js";
 import {IdentityIntegrityError} from "../../utils/user/identity-integrity.js";
 
+export async function recordMagicLinkVerification(service, account, email, verifiedAt) {
+    return await service.recordEmailVerification(account.accountId, email, {
+        method: 'magic-link', provider: 'passmower', verifiedAt,
+    }) ?? account
+}
+
+export async function recordSubmittedMagicLinkVerification(service, account, submission) {
+    if (!submission?.emailVerified || !submission.email) return account
+    return recordMagicLinkVerification(service, account, submission.email, submission.emailVerifiedAt)
+}
+
 export class EmailLogin {
     constructor() {
         this.adapter = new EmailAdapter()
@@ -124,9 +135,9 @@ export class EmailLogin {
         if (!account) {
             auditLog(ctx, {email}, 'Unable to determine account from login link')
         } else {
-            account = await ctx.kubeOIDCUserService.recordEmailVerification(account.accountId, email, {
-                method: 'magic-link', provider: 'passmower', verifiedAt,
-            })
+            account = await recordMagicLinkVerification(
+                ctx.kubeOIDCUserService, account, email, verifiedAt,
+            )
         }
         return provider.interactionFinished(ctx.req, ctx.res, await getLoginResult(ctx, provider, account, 'LoginLink'), {
             mergeWithLastSubmission: true,

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -8,7 +8,7 @@ import ScimLinkService from "../scim-link-service.js";
 
 // Map the validated id_token / userinfo claims onto the structure we persist
 // under identities.<provider> and the values createOrUpdateByEmails expects.
-const extractIdentity = (providerConfig, profile) => {
+export const extractIdentity = (providerConfig, profile) => {
     const primaryEmail = profile.email;
     let groups = [];
     if (providerConfig.groupsClaim && Array.isArray(profile[providerConfig.groupsClaim])) {
@@ -22,7 +22,11 @@ const extractIdentity = (providerConfig, profile) => {
         name: profile.name ?? null,
         company: null,
         primaryEmail,
-        emails: [{ email: primaryEmail, primary: true }],
+        emails: [{
+            email: primaryEmail,
+            primary: true,
+            verified: typeof profile.email_verified === 'boolean' ? profile.email_verified : undefined,
+        }],
         groups,
         preferredUsername: profile.preferred_username ?? profile.nickname,
         linkClaims: Object.fromEntries(providerConfig.linkingClaims

--- a/test/integration/email-login.test.js
+++ b/test/integration/email-login.test.js
@@ -42,7 +42,7 @@ describe('email magic-link login (HTTP)', () => {
             response_types: ['code'],
             token_endpoint_auth_method: 'client_secret_basic',
             // extraClientMetadata fields real clients always carry (addGrant reads availableScopes)
-            availableScopes: ['openid'],
+            availableScopes: ['openid', 'email'],
             allowedCORSOrigins: [],
         })
     })
@@ -123,7 +123,7 @@ describe('email magic-link login (HTTP)', () => {
             client_id: RP.client_id,
             redirect_uri: RP.redirect_uri,
             response_type: 'code',
-            scope: 'openid',
+            scope: 'openid email',
             state: 'state-123',
             nonce: 'nonce-123',
             code_challenge: challenge,
@@ -168,5 +168,18 @@ describe('email magic-link login (HTTP)', () => {
         const idClaims = JSON.parse(Buffer.from(tokenRes.body.id_token.split('.')[1], 'base64url').toString())
         expect(idClaims.sub).toBe('testuser')
         expect(idClaims.nonce).toBe('nonce-123')
+        expect(idClaims.email).toBe('test@example.com')
+        expect(idClaims.email_verified).toBe(true)
+
+        const userinfo = await request(callback)
+            .get('/me')
+            .set('Authorization', `Bearer ${tokenRes.body.access_token}`)
+            .expect(200)
+        expect(userinfo.body.email).toBe('test@example.com')
+        expect(userinfo.body.email_verified).toBe(true)
+
+        expect(fakeKube.list('OIDCUser')[0].status.emailVerifications).toContainEqual(expect.objectContaining({
+            email: 'test@example.com', status: 'verified', method: 'magic-link', provider: 'passmower',
+        }))
     })
 })

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -234,6 +234,22 @@ describe('Account.claims', () => {
         })
     })
 
+    it('retains durable magic-link evidence while its address is unlinked', () => {
+        const status = account({
+            status: {
+                primaryEmail: null, emails: [], groups: [], profile: {},
+                emailVerifications: [{
+                    email: 'old@x.com', status: 'verified', method: 'magic-link',
+                    provider: 'passmower', verifiedAt: '2026-08-16T21:00:00.000Z',
+                }],
+            },
+        }).getIntendedStatus()
+
+        expect(status.emailVerifications).toContainEqual(expect.objectContaining({
+            email: 'old@x.com', status: 'verified', method: 'magic-link',
+        }))
+    })
+
     it('omits namespaces when the enrichment webhook is not configured', async () => {
         const a = account({ status: { primaryEmail: 'a@x.com', groups: [], profile: {} } })
         const claims = await a.claims('id_token', 'openid namespaces', {}, [])

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -144,14 +144,18 @@ describe('Account.getProfileResponse', () => {
 })
 
 describe('Account.claims', () => {
-    it('returns sub/username/email for openid scope', async () => {
+    it('returns email claims only for the email scope', async () => {
         const a = account({
             status: { primaryEmail: 'a@x.com', emails: [{ email: 'a@x.com', primary: true }], groups: [], profile: {} },
         })
-        const claims = await a.claims('id_token', 'openid', {}, [])
+        const openidClaims = await a.claims('id_token', 'openid', {}, [])
+        const claims = await a.claims('id_token', 'openid email', {}, [])
+        expect(openidClaims.email).toBeUndefined()
+        expect(openidClaims.email_verified).toBeUndefined()
         expect(claims.sub).toBe('u-test')
         expect(claims.username).toBe('u-test')
         expect(claims.email).toBe('a@x.com')
+        expect(claims.email_verified).toBe(false)
     })
 
     it('adds profile fields and emails for the profile scope', async () => {
@@ -167,6 +171,67 @@ describe('Account.claims', () => {
         expect(claims.name).toBe('Jane')
         expect(claims.company).toBe('Acme')
         expect(claims.emails).toEqual([{ email: 'a@x.com', primary: true }])
+    })
+
+    it('marks a primary GitHub email verified only with explicit GitHub evidence', async () => {
+        const a = account({
+            github: {emails: [{email: 'a@x.com', primary: true, verified: true}]},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com'], groups: [], profile: {}},
+        })
+        const legacy = account({
+            github: {emails: [{email: 'a@x.com', primary: true}]},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com'], groups: [], profile: {}},
+        })
+
+        expect((await a.claims('id_token', 'openid email', {}, [])).email_verified).toBe(true)
+        expect((await legacy.claims('id_token', 'openid email', {}, [])).email_verified).toBe(false)
+    })
+
+    it('only marks generic OIDC email provenance verified when upstream explicitly confirmed it', async () => {
+        const verified = account({
+            identities: {google: {emails: [{email: 'a@x.com', primary: true, verified: true}]}},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com'], groups: [], profile: {}},
+        })
+        const unverified = account({
+            identities: {google: {emails: [{email: 'a@x.com', primary: true, verified: false}]}},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com'], groups: [], profile: {}},
+        })
+        const unspecified = account({
+            identities: {google: {emails: [{email: 'a@x.com', primary: true}]}},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com'], groups: [], profile: {}},
+        })
+
+        expect((await verified.claims('id_token', 'openid email', {}, [])).email_verified).toBe(true)
+        expect(unverified.getIntendedStatus().emailVerifications).toContainEqual({
+            email: 'a@x.com', status: 'unverified', method: 'oidc-claim', provider: 'google',
+        })
+        expect((await unspecified.claims('id_token', 'openid email', {}, [])).email_verified).toBe(false)
+        expect(unspecified.getIntendedStatus().emailVerifications).toContainEqual({
+            email: 'a@x.com', status: 'unknown', method: 'oidc-claim', provider: 'google',
+        })
+    })
+
+    it('does not transfer verification when the emitted primary email changes', async () => {
+        const a = account({
+            spec: {email: 'new@x.com'},
+            github: {emails: [{email: 'old@x.com', primary: true, verified: true}]},
+            status: {primaryEmail: 'new@x.com', emails: ['new@x.com', 'old@x.com'], groups: [], profile: {}},
+        })
+
+        expect((await a.claims('id_token', 'openid email', {}, [])).email_verified).toBe(false)
+    })
+
+    it('records durable magic-link evidence for the exact claimed address', () => {
+        const verifiedAt = '2026-08-16T21:00:00.000Z'
+        const status = account({
+            spec: {email: 'a@x.com'},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com'], groups: [], profile: {}},
+        }).verifyEmail('A@X.COM', {verifiedAt}).getIntendedStatus()
+
+        expect(status.emailVerifications).toContainEqual({
+            email: 'a@x.com', status: 'verified', method: 'magic-link',
+            provider: 'passmower', verifiedAt,
+        })
     })
 
     it('omits namespaces when the enrichment webhook is not configured', async () => {

--- a/test/unit/identity-integrity-boundaries.test.js
+++ b/test/unit/identity-integrity-boundaries.test.js
@@ -1,6 +1,10 @@
 import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
 import Account from '../../src/models/account.js';
-import {EmailLogin} from '../../src/services/login/email-login.js';
+import {
+    EmailLogin,
+    recordMagicLinkVerification,
+    recordSubmittedMagicLinkVerification,
+} from '../../src/services/login/email-login.js';
 import koaValidator, {checkIfEmailIsTaken} from '../../src/utils/session/validator.js';
 import {IdentityIntegrityError} from '../../src/utils/user/identity-integrity.js';
 
@@ -11,6 +15,32 @@ beforeAll(() => {
 afterEach(() => vi.restoreAllMocks())
 
 describe('identity-integrity error boundaries', () => {
+    it('keeps the existing account when recording magic-link evidence fails', async () => {
+        const account = {accountId: 'alice'}
+        const service = {recordEmailVerification: vi.fn().mockResolvedValue(undefined)}
+
+        await expect(recordMagicLinkVerification(
+            service, account, 'alice@example.com', '2026-08-17T10:00:00.000Z',
+        )).resolves.toBe(account)
+        expect(service.recordEmailVerification).toHaveBeenCalledWith('alice', 'alice@example.com', {
+            method: 'magic-link', provider: 'passmower', verifiedAt: '2026-08-17T10:00:00.000Z',
+        })
+    })
+
+    it('records verified email submission after prompt-based user creation', async () => {
+        const account = {accountId: 'alice'}
+        const updated = {accountId: 'alice', verified: true}
+        const service = {recordEmailVerification: vi.fn().mockResolvedValue(updated)}
+
+        await expect(recordSubmittedMagicLinkVerification(service, account, {
+            email: 'alice@example.com', emailVerified: true,
+            emailVerifiedAt: '2026-08-17T10:00:00.000Z',
+        })).resolves.toBe(updated)
+        expect(service.recordEmailVerification).toHaveBeenCalledWith('alice', 'alice@example.com', {
+            method: 'magic-link', provider: 'passmower', verifiedAt: '2026-08-17T10:00:00.000Z',
+        })
+    })
+
     it('renders access denied when magic-link lookup encounters a conflict', async () => {
         vi.spyOn(Account, 'findByEmail').mockRejectedValue(new IdentityIntegrityError('duplicate'))
         const login = Object.create(EmailLogin.prototype)

--- a/test/unit/oidc-login.test.js
+++ b/test/unit/oidc-login.test.js
@@ -1,0 +1,21 @@
+import {describe, expect, it} from 'vitest'
+import {extractIdentity} from '../../src/services/login/oidc-login.js'
+
+const provider = {groupsClaim: null, linkingClaims: []}
+
+describe('generic OIDC email verification evidence', () => {
+    it.each([
+        [true, true],
+        [false, false],
+        [undefined, undefined],
+    ])('maps email_verified=%s without inferring missing evidence', (emailVerified, expected) => {
+        const profile = {sub: 'subject', email: 'Person@Example.COM'}
+        if (emailVerified !== undefined) profile.email_verified = emailVerified
+
+        const identity = extractIdentity(provider, profile)
+
+        expect(identity.emails).toEqual([{
+            email: 'Person@Example.COM', primary: true, verified: expected,
+        }])
+    })
+})


### PR DESCRIPTION
Closes #194

## Summary
- retain per-address verified, unverified, or unknown evidence from GitHub and generic OIDC providers
- persist magic-link verification and emit email/email_verified only for the email scope
- extend the CRDs, client scope enum, documentation, and regression coverage

## Validation
- npm test (182 passed)
- npm run test:integration (42 passed)
- frontend lint and build
- styles production build
- Helm render and git diff check
- minikube pod healthy; live CRD exposes status.emailVerifications; platform-manager client exposes openid,email,profile,groups

The local E2E harness could not start because kind is not installed. GitHub CI provisions kind and will run the Playwright suite.