### PR TITLE
Recheck account access policy during token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ downstream clients through the `email` scope. See
 [docs/email-verification.md](docs/email-verification.md) for provider rules,
 magic-link fallback, and client configuration.
 
+Refresh-token exchanges re-check the current Kubernetes account and client
+access policies, so deleted or newly ineligible users cannot retain access for
+the full refresh-token lifetime. See
+[docs/refresh-token-authorization.md](docs/refresh-token-authorization.md).
+
 ```
 apiVersion: codemowers.cloud/v1
 kind: OIDCUser

--- a/docs/refresh-token-authorization.md
+++ b/docs/refresh-token-authorization.md
@@ -1,0 +1,23 @@
+# Refresh-token authorization
+
+Passmower re-evaluates the current Kubernetes account whenever a refresh token
+is exchanged. A refresh token is rejected with the standard OAuth
+`invalid_grant` response when the account:
+
+- no longer exists;
+- no longer satisfies the global `REQUIRED_GROUP` approval policy;
+- no longer has the profile name required by the login policy;
+- no longer has a required Terms of Service acceptance; or
+- no longer matches the OIDC client `allowedUsers` / `allowedGroups` policy.
+
+This check uses the latest `OIDCUser` and client state rather than a snapshot
+stored in the refresh token. Policy changes therefore take effect on the next
+refresh exchange without waiting for the token TTL. Access tokens already
+issued before the change remain valid until their own expiry; resource servers
+that need faster revocation should use short access-token lifetimes or token
+introspection.
+
+Clients should handle `invalid_grant` by discarding the refresh token and
+starting a new interactive authorization flow. If the account is still
+eligible, that flow can satisfy any newly required prompt and establish a new
+grant.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -4,9 +4,22 @@ import setupPolicies from "./providers/setup-policies.js";
 import {errors} from "oidc-provider";
 import isOrigin from "./utils/session/is-origin.js";
 import {fetchExtraClaims} from "./utils/fetch-extra-claims.js";
+import {getAccountAccessFailure} from './utils/user/check-account-access.js';
+import {auditLog} from './utils/session/audit-log.js';
 
 export default {
-    findAccount: Account.findAccount,
+    async findAccount(ctx, id, token) {
+        const account = await Account.findAccount(ctx, id, token)
+        if (token?.kind === 'RefreshToken') {
+            const failure = getAccountAccessFailure(ctx.oidc?.client, account)
+            if (failure) {
+                auditLog(ctx, {accountId: id, clientId: ctx.oidc?.client?.clientId, failure},
+                    'Refresh token no longer satisfies account access policy')
+                return null
+            }
+        }
+        return account
+    },
     renderError,
     interactions: {
         url(ctx, interaction) { // eslint-disable-line no-unused-vars

--- a/src/utils/session/handle-oidc-flow-metrics.js
+++ b/src/utils/session/handle-oidc-flow-metrics.js
@@ -74,6 +74,8 @@ const inCluster = async (ctx) => {
 }
 
 export default (ctx, error, context) => {
+    const metric = globalThis.metrics?.[context]
+    if (!metric) return
     let urlParams = new URLSearchParams()
     try {
         const authUrl = parseurl(ctx.req)
@@ -87,8 +89,8 @@ export default (ctx, error, context) => {
             reason: normalizeReason(error?.error_detail || error?.error_description),
             in_cluster: inCluster,
         }
-        params = Object.fromEntries(Object.entries(params).filter(([key]) => globalThis.metrics[context]?.labelNames.includes(key)));
+        params = Object.fromEntries(Object.entries(params).filter(([key]) => metric.labelNames.includes(key)));
         params = Object.fromEntries(Object.entries(params).filter(([_, v]) => v != null)) // Nice one-liner to filter out undefined fields, such as client_id.
-        globalThis.metrics[context].inc(params)
+        metric.inc(params)
     })
 }

--- a/src/utils/user/check-account-access.js
+++ b/src/utils/user/check-account-access.js
@@ -1,0 +1,12 @@
+import {Approved} from '../../conditions/approved.js'
+import {checkAccountGroups} from './check-account-groups.js'
+import {tosRequired} from './tos-required.js'
+
+export const getAccountAccessFailure = (client, account) => {
+    if (!account) return 'account_missing'
+    if (!account.isAdmin && !(new Approved()).check(account)) return 'approval_required'
+    if (!account.profile?.name) return 'name_required'
+    if (tosRequired(account)) return 'tos_required'
+    if (!checkAccountGroups(client, account)) return 'client_access_required'
+    return null
+}

--- a/test/integration/email-login.test.js
+++ b/test/integration/email-login.test.js
@@ -38,11 +38,12 @@ describe('email magic-link login (HTTP)', () => {
             client_id: RP.client_id,
             client_secret: RP.client_secret,
             redirect_uris: [RP.redirect_uri],
-            grant_types: ['authorization_code'],
+            grant_types: ['authorization_code', 'refresh_token'],
             response_types: ['code'],
             token_endpoint_auth_method: 'client_secret_basic',
             // extraClientMetadata fields real clients always carry (addGrant reads availableScopes)
             availableScopes: ['openid', 'email'],
+            allowedGroups: ['local:staff'],
             allowedCORSOrigins: [],
         })
     })
@@ -59,12 +60,15 @@ describe('email magic-link login (HTTP)', () => {
         // has to clear the (auto-resolved) consent prompt.
         fakeKube.seed('OIDCUser', {
             metadata: { name: 'testuser', labels: {} },
-            spec: { email: 'test@example.com', name: 'Test User' },
+            spec: {
+                email: 'test@example.com', name: 'Test User',
+                groups: [{prefix: 'local', name: 'staff'}],
+            },
             passmower: { email: 'test@example.com' },
             status: {
                 primaryEmail: 'test@example.com',
                 emails: ['test@example.com'],
-                groups: [],
+                groups: [{prefix: 'local', name: 'staff'}],
                 profile: { name: 'Test User' },
                 conditions: [],
                 termsOfService: {
@@ -165,6 +169,7 @@ describe('email magic-link login (HTTP)', () => {
             .expect(200)
 
         expect(tokenRes.body.access_token).toBeTruthy()
+        expect(tokenRes.body.refresh_token).toBeTruthy()
         const idClaims = JSON.parse(Buffer.from(tokenRes.body.id_token.split('.')[1], 'base64url').toString())
         expect(idClaims.sub).toBe('testuser')
         expect(idClaims.nonce).toBe('nonce-123')
@@ -181,5 +186,38 @@ describe('email magic-link login (HTTP)', () => {
         expect(fakeKube.list('OIDCUser')[0].status.emailVerifications).toContainEqual(expect.objectContaining({
             email: 'test@example.com', status: 'verified', method: 'magic-link', provider: 'passmower',
         }))
+
+        // Refresh succeeds while the current Kubernetes account still passes
+        // the same compulsory policies used at the authorization endpoint.
+        await request(callback)
+            .post('/token')
+            .auth(RP.client_id, RP.client_secret)
+            .type('form')
+            .send({grant_type: 'refresh_token', refresh_token: tokenRes.body.refresh_token})
+            .expect(200)
+
+        // Losing a currently compulsory group immediately invalidates the
+        // existing refresh grant without waiting for its normal TTL.
+        const storedUser = fakeKube.store.get('OIDCUser/testuser')
+        storedUser.spec.groups = []
+        storedUser.status.groups = []
+        const denied = await request(callback)
+            .post('/token')
+            .auth(RP.client_id, RP.client_secret)
+            .type('form')
+            .send({grant_type: 'refresh_token', refresh_token: tokenRes.body.refresh_token})
+            .expect(400)
+        expect(denied.body.error).toBe('invalid_grant')
+
+        // A deleted account is also rejected even if the token and grant are
+        // otherwise still present in Redis.
+        fakeKube.store.delete('OIDCUser/testuser')
+        const deleted = await request(callback)
+            .post('/token')
+            .auth(RP.client_id, RP.client_secret)
+            .type('form')
+            .send({grant_type: 'refresh_token', refresh_token: tokenRes.body.refresh_token})
+            .expect(400)
+        expect(deleted.body.error).toBe('invalid_grant')
     })
 })

--- a/test/unit/check-account-access.test.js
+++ b/test/unit/check-account-access.test.js
@@ -1,0 +1,45 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import Account from '../../src/models/account.js'
+import {getAccountAccessFailure} from '../../src/utils/user/check-account-access.js'
+
+const account = ({name = 'Alice', groups = [], terms = true} = {}) => new Account().fromKubernetes({
+    metadata: {name: 'alice', labels: {}},
+    spec: {},
+    status: {
+        profile: {name},
+        groups: groups.map(displayName => {
+            const [prefix, ...rest] = displayName.split(':')
+            return {prefix, name: rest.join(':')}
+        }),
+        conditions: [],
+        termsOfService: terms ? {
+            acceptedAt: '2026-08-21T10:00:00.000Z', contentHash: 'hash',
+        } : undefined,
+    },
+})
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('current account access policy', () => {
+    it('accepts an unchanged eligible account', () => {
+        expect(getAccountAccessFailure({}, account())).toBeNull()
+    })
+
+    it('rejects missing accounts, profile data, ToS, and client membership', () => {
+        expect(getAccountAccessFailure({}, null)).toBe('account_missing')
+        expect(getAccountAccessFailure({}, account({name: null}))).toBe('name_required')
+        expect(getAccountAccessFailure({}, account({terms: false}))).toBe('tos_required')
+        expect(getAccountAccessFailure({allowedGroups: ['local:staff']}, account()))
+            .toBe('client_access_required')
+    })
+
+    it('rechecks global approval against current groups', () => {
+        vi.stubEnv('REQUIRED_GROUP', 'local:staff')
+        expect(getAccountAccessFailure({}, account())).toBe('approval_required')
+        expect(getAccountAccessFailure({}, account({groups: ['local:staff']}))).toBeNull()
+
+        const admin = account()
+        admin.isAdmin = true
+        expect(getAccountAccessFailure({}, admin)).toBeNull()
+    })
+})

--- a/test/unit/oidc-flow-metrics.test.js
+++ b/test/unit/oidc-flow-metrics.test.js
@@ -1,0 +1,15 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import handleOidcFlowMetrics from '../../src/utils/session/handle-oidc-flow-metrics.js'
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('OIDC flow metrics', () => {
+    it('does not create an unhandled rejection when metrics are not initialized', () => {
+        vi.stubGlobal('metrics', undefined)
+        expect(() => handleOidcFlowMetrics({req: {}, request: {headers: {}}}, {
+            error_description: 'refresh token invalid',
+        }, 'tokenError')).not.toThrow()
+    })
+})


### PR DESCRIPTION
Closes #18

## Summary
- reload the current Kubernetes account on every refresh-token exchange and fail with `invalid_grant` when compulsory access policy is no longer satisfied
- recheck global approval, required profile name, ToS acceptance, and client `allowedUsers` / `allowedGroups`; deleted accounts fail through the same path
- document refresh revocation semantics and ensure token-error metrics safely no-op before metrics initialization
- add unit coverage and a real Redis integration flow proving unchanged refresh succeeds while group loss and account deletion are rejected

## Validation
- `npm test` — 189 passed
- `npm run test:integration` — 42 passed
- Helm render and `git diff --check`
- Skaffold dev deployment to minikube; rollout healthy, Redis ready, watches active, public discovery endpoint reachable

Existing access tokens remain valid until their own expiry; this change applies at the next refresh exchange.