### PR TITLE
Support deployments without email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | `OIDC_PROVIDERS` | JSON object of generic upstream OIDC providers keyed by provider slug. |
 | `OIDC_ALLOW_INSECURE_UPSTREAM` | Permit `http://` upstreams (local dev only). |
 | `GITHUB_ENABLED`, `GH_CLIENT_ID/SECRET`, `GITHUB_ORGANIZATION` | GitHub upstream. |
-| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Email magic-links. |
+| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Global email capability. `false` disables all delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email. When enabled (the default), all SMTP variables except `EMAIL_FROM` are required at boot. |
 | `WEBAUTHN_ENABLED`, `WEBAUTHN_RP_NAME` | Passkeys. |
 | `SLACK_TOKEN` | Slack integration. |
 | `GROUP_PREFIX`, `ADMIN_GROUP`, `REQUIRED_GROUP` | Group/authorization policy. |

--- a/README.md
+++ b/README.md
@@ -123,8 +123,14 @@ continues to work unchanged.
 
 Passmower authenticates users against GitHub (a dedicated handler), email
 magic-links, and any number of **standards-compliant OIDC providers** through a
-single generic connector (discovery + PKCE + `id_token` validation). Users are
-linked across providers by verified email.
+single generic connector (discovery + PKCE + `id_token` validation). Stable
+provider subjects identify returning users; verified email can additionally
+link identities across providers.
+
+Set `passmower.emailEnabled: false` to run without SMTP credentials or email
+addresses. This disables all delivery and email-based login/invitations while
+allowing upstream enrollment by stable provider identity. See
+[docs/email-configuration.md](docs/email-configuration.md).
 
 OIDC providers are configured entirely at deploy time — adding Google, GitLab,
 EntraID, Keycloak, Okta, Authentik, Zitadel, etc. requires no code change, just

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.passmower.emailEnabled (not .Values.passmower.emailCredentialsSecretRef) }}
+{{- fail "passmower.emailCredentialsSecretRef is required when passmower.emailEnabled is true" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -161,7 +164,7 @@ spec:
           envFrom:
             - secretRef:
                 name: oidc-keys
-            {{- if .Values.passmower.emailCredentialsSecretRef }}
+            {{- if and .Values.passmower.emailEnabled .Values.passmower.emailCredentialsSecretRef }}
             - secretRef:
                 name: {{ .Values.passmower.emailCredentialsSecretRef }}
             {{- end }}

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -50,7 +50,9 @@ passmower:
   webauthnEnabled: true
   # Enable GitHub OAuth login. Requires githubClientSecretRef to be set.
   githubEnabled: true
-  # Enable email magic-link login. Requires emailCredentialsSecretRef to be set.
+  # Enable all email delivery, including magic-link login and ToS receipts.
+  # When false, no SMTP credentials are mounted and upstream users may enroll
+  # using their stable provider identity without an email address.
   emailEnabled: true
   # Email credentials secret name. Secret must contain EMAIL_HOST, EMAIL_PASSWORD, EMAIL_PORT, EMAIL_SSL and EMAIL_USERNAME
   emailCredentialsSecretRef: "email-credentials"

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -1,0 +1,35 @@
+# Email delivery and email-free operation
+
+`EMAIL_ENABLED=false` (Helm: `passmower.emailEnabled: false`) disables every
+outbound email path. Passmower does not initialize Nodemailer, does not mount
+`emailCredentialsSecretRef`, hides magic-link login and email-based admin
+invitations, and records Terms of Service acceptance without attempting to send
+a receipt.
+
+Email-free installations can enroll users from GitHub or generic OIDC by the
+provider's stable identity (GitHub numeric ID or OIDC provider key plus `sub`).
+Generic providers default to the `openid profile` scopes in this mode, and
+GitHub does not request `user:email` or call the email API. Provider definitions
+may still explicitly request `email`; an address returned in that case is
+retained for identity linking and downstream claims, but it is not required.
+
+Accounts without a primary address omit `email` and `email_verified` from ID
+tokens and UserInfo, even when a downstream client requests the `email` scope.
+Forward-auth also omits the configured email header for those accounts.
+
+```yaml
+passmower:
+  emailEnabled: false
+  # emailCredentialsSecretRef may be empty or omitted
+  oidcProviders:
+    dex:
+      issuer: https://dex.example.com
+      clientSecretRef: dex-client
+      scopes: [openid, profile]
+```
+
+When email is enabled, Passmower fails at startup unless `EMAIL_HOST`,
+`EMAIL_PORT`, `EMAIL_SSL`, `EMAIL_USERNAME`, and `EMAIL_PASSWORD` are present.
+The Helm chart likewise requires `passmower.emailCredentialsSecretRef`. A
+temporary ToS receipt failure is logged but does not undo acceptance or block
+login; magic-link delivery failures remain fatal to that login attempt.

--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -4,6 +4,10 @@ Passmower tracks verification evidence for each normalized email address. It
 does not treat verification as an account-wide property: proving control of one
 address never verifies another address that later becomes primary.
 
+Email is optional when delivery is globally disabled. Accounts without a
+primary address omit both downstream email claims; see
+[email-configuration.md](email-configuration.md).
+
 Evidence is projected into `OIDCUser.status.emailVerifications` with its status,
 method, provider, and an optional verification timestamp. Provider-backed
 evidence is recomputed from the provider data stored on the user; magic-link

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -1,7 +1,7 @@
 # Migrating from Passmower 1.x to 2.0
 
-Passmower 2.0 is a major release. It carries three consumer-facing breaking changes
-(Helm values, one `OIDCClient` CRD field, and standard OIDC email scoping) plus a sweep of major dependency
+Passmower 2.0 is a major release. It carries four consumer-facing breaking changes
+(Helm values, one `OIDCClient` CRD field, standard OIDC email scoping, and strict email configuration) plus a sweep of major dependency
 upgrades. This note lists everything you must change, and what changed for the better.
 
 > The 2.0 line ships from the `develop` branch as `2.0.0-dev` (image
@@ -14,8 +14,32 @@ upgrades. This note lists everything you must change, and what changed for the b
 - Back up your `values.yaml` (or HelmRelease/ArgoCD Application values).
 - Back up your `OIDCClient` and `OIDCUser` custom resources:
   `kubectl get oidcclients,oidcusers,oidcmiddlewareclients -A -o yaml > passmower-crs.bak.yaml`.
-- Read the three **action required** sections below and edit your values / CRs before
+- Read the **action required** sections below and edit your values / CRs before
   upgrading.
+
+---
+
+## Email configuration is now enforced — **action required**
+
+`EMAIL_ENABLED` is now the global switch for every email-dependent feature, not
+only magic-link login. It defaults to enabled. When enabled, Passmower validates
+`EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_SSL`, `EMAIL_USERNAME`, and `EMAIL_PASSWORD` at
+boot and exits if any are missing. The Helm chart likewise rejects an enabled
+configuration without `passmower.emailCredentialsSecretRef`.
+
+Deployments that previously left email enabled but supplied incomplete or no SMTP
+configuration will crash-loop after upgrading. Before upgrading, choose one of:
+
+- configure a credentials Secret containing all five required variables and set
+  `passmower.emailCredentialsSecretRef`, or
+- set `passmower.emailEnabled: false` explicitly. This disables SMTP delivery,
+  magic-link login, ToS receipts, and email invitations while permitting users to
+  enroll through GitHub or another OIDC provider using their stable upstream
+  identity without an email address.
+
+SMTP delivery errors are no longer swallowed. A failed magic-link send now fails
+that login attempt; ToS acceptance remains successful if its receipt cannot be sent.
+See [email-configuration.md](email-configuration.md) for the complete behavior.
 
 ---
 

--- a/frontend/src/Admin.vue
+++ b/frontend/src/Admin.vue
@@ -30,12 +30,13 @@ export default {
         fetch('/admin/api/metadata').then((r) => r.json()).then((r) => {
             this.setGroupPrefix(r.groupPrefix)
             this.setRequireUsername(r.requireUsername)
+            this.setEmailEnabled(r.emailEnabled)
             this.setDisableEditing(r.disableEditing)
             this.setDisableEditingText(r.disableEditingText)
         })
     },
     methods: {
-        ...mapActions(userAdminStore, ['setGroupPrefix', 'setRequireUsername', 'setDisableEditing', 'setDisableEditingText']),
+        ...mapActions(userAdminStore, ['setGroupPrefix', 'setRequireUsername', 'setEmailEnabled', 'setDisableEditing', 'setDisableEditingText']),
     }
 }
 

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -21,7 +21,7 @@
             <div class="item-details">
                 <h3>{{ account.accountId }}</h3>
                 <p>Name: {{ account.name }}</p>
-                <p>Primary email: {{ account.email }}</p>
+                <p v-if="account.email">Primary email: {{ account.email }}</p>
                 <p v-if="account.onboardedBy">Invited by: {{ account.onboardedBy }}</p>
                 <p v-if="account.tos_accepted_at">
                     Terms of Service accepted: {{ formatDate(account.tos_accepted_at) }}

--- a/frontend/src/components/Admin/InviteUser.vue
+++ b/frontend/src/components/Admin/InviteUser.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="profile-section">
+  <div v-if="emailEnabled" class="profile-section">
     <div class="profile-section-header no-flex">
       <h2>Invite new user</h2>
       <p>You can also create users by creating OIDCUser CRDs</p>
@@ -32,7 +32,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(userAdminStore, ['requireUsername', 'disableEditing', 'disableEditingText']),
+    ...mapState(userAdminStore, ['requireUsername', 'emailEnabled', 'disableEditing', 'disableEditingText']),
   },
   methods: {
     ...mapActions(useAccountsStore, ['setAccounts']),

--- a/frontend/src/components/User/Profile.vue
+++ b/frontend/src/components/User/Profile.vue
@@ -6,9 +6,9 @@
         </div>
         <p><strong>Name: </strong> {{ account.name }}</p>
         <p v-if="account.company"><strong>Company: </strong> {{ account.company }}</p>
-        <p><strong>Primary email: </strong> {{ account.email }}</p>
-        <p><strong>Emails: </strong></p>
-        <ul>
+        <p v-if="account.email"><strong>Primary email: </strong> {{ account.email }}</p>
+        <p v-if="account.emails.length"><strong>Emails: </strong></p>
+        <ul v-if="account.emails.length">
             <li v-for="email in account.emails" :key="email">{{ email }}</li>
         </ul>
         <p><strong>Phones: </strong></p>

--- a/frontend/src/stores/admin.js
+++ b/frontend/src/stores/admin.js
@@ -5,6 +5,7 @@ export const userAdminStore = defineStore('admin', {
       return {
           groupPrefix: null,
           requireUsername: false,
+          emailEnabled: false,
           disableEditing: false,
           disableEditingText: null,
       }
@@ -15,6 +16,9 @@ export const userAdminStore = defineStore('admin', {
         },
         setRequireUsername(val) {
             this.requireUsername = val
+        },
+        setEmailEnabled(val) {
+            this.emailEnabled = val
         },
         setDisableEditing(val) {
             this.disableEditing = val

--- a/src/adapters/email.js
+++ b/src/adapters/email.js
@@ -1,28 +1,30 @@
 import Nodemailer from "nodemailer";
-
-const transporter = Nodemailer.createTransport({
-    host: process.env.EMAIL_HOST,
-    port: process.env.EMAIL_PORT,
-    ssl: process.env.EMAIL_SSL,
-    auth: {
-        user: process.env.EMAIL_USERNAME,
-        pass: process.env.EMAIL_PASSWORD
-    }
-});
+import {isEmailEnabled, validateEmailConfiguration} from '../utils/email-configuration.js';
 
 class EmailAdapter {
+    #transporter
+
     async sendMail(to, subject, textContent, htmlContent) {
-        return await transporter.sendMail(
-            {
-                to,
-                subject,
-                headers: {
-                    From: `${process.env.EMAIL_FROM || process.env.EMAIL_USERNAME} <${process.env.EMAIL_USERNAME}>`,
-                },
-                text: textContent,
-                html: htmlContent
-            })
-            .catch(e => console.error(e));
+        if (!isEmailEnabled()) throw new Error('Email delivery is disabled')
+        validateEmailConfiguration()
+        this.#transporter ??= Nodemailer.createTransport({
+            host: process.env.EMAIL_HOST,
+            port: process.env.EMAIL_PORT,
+            ssl: process.env.EMAIL_SSL,
+            auth: {
+                user: process.env.EMAIL_USERNAME,
+                pass: process.env.EMAIL_PASSWORD
+            }
+        })
+        return await this.#transporter.sendMail({
+            to,
+            subject,
+            headers: {
+                From: `${process.env.EMAIL_FROM || process.env.EMAIL_USERNAME} <${process.env.EMAIL_USERNAME}>`,
+            },
+            text: textContent,
+            html: htmlContent
+        })
     }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ import KubeOidcUserOperator from "./operators/kube-oidc-user-operator.js";
 import KubeScimConnectionOperator from "./operators/kube-scim-connection-operator.js";
 import metricsServer from "./routes/metrics-server.js";
 import {getUsernameSource} from "./utils/username-source.js";
+import {validateEmailConfiguration} from './utils/email-configuration.js';
 import {getActivityTracker} from './services/activity-tracker.js';
 import KubeOidcUserEventHookOperator from './operators/kube-oidc-user-event-hook-operator.js';
 
@@ -68,6 +69,7 @@ export async function main() {
     try {
         setupLogger()
         getUsernameSource() // validate USERNAME_SOURCE (and warn on deprecated flags) at boot
+        validateEmailConfiguration()
         const provider = await buildProvider()
         server = provider.listen(PORT, () => {
         globalThis.logger.info(`application is listening on port ${PORT}, check its /.well-known/openid-configuration`);

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -13,13 +13,14 @@ export const GroupPrefix = process.env.GROUP_PREFIX;
 
 // Stash the upstream identity in the interaction and halt the flow so the user
 // can pick a username via the enter-username form.
-async function requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername}) {
+async function requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername, identity}) {
     const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res)
     await provider.interactionResult(ctx.req, ctx.res, {
         requireCustomUsername: true,
         email,
         githubEmails,
         preferredUsername,
+        stableIdentity: identity,
         ...interactionDetails.result
     }, {
         mergeWithLastSubmission: true,
@@ -102,7 +103,7 @@ class Account {
             username,
             nickname: username,
         };
-        if (scope.split(' ').includes('email')) {
+        if (scope.split(' ').includes('email') && this.primaryEmail) {
             response.email = this.primaryEmail
             response.email_verified = this.isPrimaryEmailVerified()
         }
@@ -220,12 +221,12 @@ class Account {
     }
 
     getRemoteHeaders(headerMapping) {
-        return {
-            [headerMapping['user']]: this.accountId,
-            [headerMapping['name']]: this.profile.name,
-            [headerMapping['email']]: this.primaryEmail,
-            [headerMapping['groups']]: this.#mapGroups().map(g => g.displayName).join(',')
-        }
+        return Object.fromEntries([
+            [headerMapping['user'], this.accountId],
+            [headerMapping['name'], this.profile.name],
+            [headerMapping['email'], this.primaryEmail],
+            [headerMapping['groups'], this.#mapGroups().map(g => g.displayName).join(',')],
+        ].filter(([header, value]) => header && value != null))
     }
 
     getSpecs() {
@@ -467,19 +468,19 @@ class Account {
                 }
                 const source = getUsernameSource()
                 if (source === 'prompt') {
-                    return await requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername})
+                    return await requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername, identity})
                 } else if (source === 'upstream') {
                     const candidate = sanitizeUsername(preferredUsername)
                     if (candidate && isUsernameValid(candidate) && await isUsernameAvailable(ctx, candidate)) {
                         username = candidate
                     } else {
                         // No usable upstream username — fall back to the prompt form.
-                        return await requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername: candidate ?? preferredUsername})
+                        return await requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername: candidate ?? preferredUsername, identity})
                     }
                 }
                 // source === 'generated' → leave username unset; getUid() below.
             }
-            user = await ctx.kubeOIDCUserService.createUser(username ?? this.getUid(), email, githubEmails)
+            user = await ctx.kubeOIDCUserService.createUser(username ?? this.getUid(), email, githubEmails, identity)
             if (user) {
                 auditLog(ctx, {emails, email, githubEmails, username}, 'Created new user')
             } else {

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -14,6 +14,7 @@ import validator, {
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import {getText} from "../utils/get-text.js";
 import {getUsernameSource} from "../utils/username-source.js";
+import {isEmailEnabled} from '../utils/email-configuration.js';
 
 export default (provider) => {
     const router = new Router();
@@ -45,6 +46,7 @@ export default (provider) => {
         ctx.body = {
             groupPrefix: GroupPrefix,
             requireUsername: getUsernameSource() !== 'generated',
+            emailEnabled: isEmailEnabled(),
             disableEditing: process.env.DISABLE_FRONTEND_EDIT === 'true',
             disableEditingText: getText('disable_frontend_edit'),
         }
@@ -126,6 +128,9 @@ export default (provider) => {
     })
 
     router.post('/admin/api/account/invite', async (ctx, next) => {
+        if (!isEmailEnabled()) {
+            ctx.throw(404, 'Email-based invitations are disabled')
+        }
         const email = ctx.request.body.email
         let username = ctx.request.body.username
 

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -30,13 +30,14 @@ import {clientId, responseType, scope} from "../utils/session/self-oidc-client.j
 import {auditLog} from "../utils/session/audit-log.js";
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import validator, {checkEmail, checkRealName, checkUsername} from "../utils/session/validator.js";
+import {isEmailEnabled} from '../utils/email-configuration.js';
 
 // Which login methods are surfaced on the sign-in page. Each is enabled
 // unless explicitly disabled via env var, preserving previous behaviour.
 const authMethodsEnabled = () => ({
     webauthnEnabled: process.env.WEBAUTHN_ENABLED !== 'false',
     githubEnabled: process.env.GITHUB_ENABLED !== 'false',
-    emailEnabled: process.env.EMAIL_ENABLED !== 'false',
+    emailEnabled: isEmailEnabled(),
     oidcProviders: getOidcProviders(),
 });
 
@@ -492,7 +493,12 @@ export default (provider) => {
             }, true)
         }
 
-        let account = await ctx.kubeOIDCUserService.createUser(username, interactionDetails.lastSubmission?.email, interactionDetails.lastSubmission?.githubEmails)
+        let account = await ctx.kubeOIDCUserService.createUser(
+            username,
+            interactionDetails.lastSubmission?.email,
+            interactionDetails.lastSubmission?.githubEmails,
+            interactionDetails.lastSubmission?.stableIdentity,
+        )
         // The Kubernetes create is the authoritative uniqueness check; the
         // pre-validation can miss a taken name on a transient API error. If
         // creation failed, re-render the form instead of crashing on a null account.

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -144,7 +144,10 @@ export class KubeOIDCUserService {
         return {accounts, ownership, conflictedUsers}
     }
 
-    async createUser(id, email, githubEmails) {
+    async createUser(id, email, githubEmails, identity = {}) {
+        const identities = identity.providerKey && identity.subject ? {
+            [identity.providerKey]: {sub: identity.subject},
+        } : undefined
         const user = await this.adapter.createNamespacedCustomObject(
             OIDCUserCrd,
             this.adapter.namespace,
@@ -155,8 +158,10 @@ export class KubeOIDCUserService {
                     email
                 },
                 github: {
-                    emails: githubEmails
-                }
+                    emails: githubEmails,
+                    ...(identity.githubId !== undefined ? {id: identity.githubId} : {}),
+                },
+                ...(identities ? {identities} : {}),
             },
             (apiResponse) => (new Account()).fromKubernetes(apiResponse),
             undefined,

--- a/src/services/login/github-login.js
+++ b/src/services/login/github-login.js
@@ -5,6 +5,21 @@ import accessDenied from "../../utils/session/access-denied.js";
 import getLoginResult from "../../utils/user/get-login-result.js";
 import {GitHubGroupPrefix} from "../../utils/kubernetes/kube-constants.js";
 import {auditLog} from "../../utils/session/audit-log.js";
+import {isEmailEnabled} from '../../utils/email-configuration.js';
+
+export const getGitHubScopes = (env = process.env) => [
+    ...(isEmailEnabled(env) ? ['user:email'] : []),
+    ...(env.GITHUB_ORGANIZATION ? ['read:org'] : []),
+]
+
+export async function getGitHubEmails(token, fetchImpl = fetch, env = process.env) {
+    if (!isEmailEnabled(env)) return []
+    const response = await fetchImpl('https://api.github.com/user/emails', {
+        method: 'GET',
+        headers: {'Authorization': `Bearer ${token}`},
+    })
+    return (await response.json()).filter(email => email.verified)
+}
 
 export default async (ctx, provider) => {
     const ghOauth = new OAuth2(process.env.GH_CLIENT_ID,
@@ -29,7 +44,7 @@ export default async (ctx, provider) => {
         auditLog(ctx, {interactionDetails, state}, 'Redirecting user to GitHub')
         return ctx.redirect(ghOauth.getAuthorizeUrl({
             redirect_uri: `${process.env.ISSUER_URL}interaction/callback/gh`,
-            scope: process.env.GITHUB_ORGANIZATION ? ['user:email,read:org'] : ['user:email'],
+            scope: getGitHubScopes(),
             state,
         }));
     }
@@ -61,14 +76,9 @@ export default async (ctx, provider) => {
         })
     }
 
-    const emails = await fetch('https://api.github.com/user/emails', {
-        method: "GET",
-        headers: {
-            'Authorization': `Bearer ${token}`
-        },
-    }).then((r) => r.json()).then((r) => r.filter((r) => r.verified)).catch(error => {
-        auditLog(ctx,{error, interactionDetails}, 'Error getting emails from GitHub')
-    });
+    const emails = await getGitHubEmails(token).catch(error => {
+            auditLog(ctx,{error, interactionDetails}, 'Error getting emails from GitHub')
+        });
 
     if (!emails) {
         return accessDenied(ctx, provider, 'Error getting emails from GitHub')

--- a/src/services/login/github-login.js
+++ b/src/services/login/github-login.js
@@ -12,6 +12,15 @@ export const getGitHubScopes = (env = process.env) => [
     ...(env.GITHUB_ORGANIZATION ? ['read:org'] : []),
 ]
 
+export const getGitHubAuthorizeParams = (state, env = process.env) => {
+    const scopes = getGitHubScopes(env)
+    return {
+        redirect_uri: `${env.ISSUER_URL}interaction/callback/gh`,
+        ...(scopes.length ? {scope: scopes} : {}),
+        state,
+    }
+}
+
 export async function getGitHubEmails(token, fetchImpl = fetch, env = process.env) {
     if (!isEmailEnabled(env)) return []
     const response = await fetchImpl('https://api.github.com/user/emails', {
@@ -42,11 +51,7 @@ export default async (ctx, provider) => {
         })
         ctx.status = 302;
         auditLog(ctx, {interactionDetails, state}, 'Redirecting user to GitHub')
-        return ctx.redirect(ghOauth.getAuthorizeUrl({
-            redirect_uri: `${process.env.ISSUER_URL}interaction/callback/gh`,
-            scope: getGitHubScopes(),
-            state,
-        }));
+        return ctx.redirect(ghOauth.getAuthorizeUrl(getGitHubAuthorizeParams(state)));
     }
 
     if (!token) {

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -5,9 +5,10 @@ import getLoginResult from "../../utils/user/get-login-result.js";
 import { auditLog } from "../../utils/session/audit-log.js";
 import { getOidcClient, oidcRedirectUri } from "../../utils/oidc-providers.js";
 import ScimLinkService from "../scim-link-service.js";
+import {isEmailEnabled} from '../../utils/email-configuration.js';
 
 export const getOidcEmailError = (profile, env = process.env) => {
-    if (!profile.email && env.EMAIL_ENABLED !== 'false') return 'missing'
+    if (!profile.email && isEmailEnabled(env)) return 'missing'
     if (profile.email && profile.email_verified === false) return 'unverified'
     return null
 }

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -6,6 +6,12 @@ import { auditLog } from "../../utils/session/audit-log.js";
 import { getOidcClient, oidcRedirectUri } from "../../utils/oidc-providers.js";
 import ScimLinkService from "../scim-link-service.js";
 
+export const getOidcEmailError = (profile, env = process.env) => {
+    if (!profile.email && env.EMAIL_ENABLED !== 'false') return 'missing'
+    if (profile.email && profile.email_verified === false) return 'unverified'
+    return null
+}
+
 // Map the validated id_token / userinfo claims onto the structure we persist
 // under identities.<provider> and the values createOrUpdateByEmails expects.
 export const extractIdentity = (providerConfig, profile) => {
@@ -22,11 +28,11 @@ export const extractIdentity = (providerConfig, profile) => {
         name: profile.name ?? null,
         company: null,
         primaryEmail,
-        emails: [{
+        emails: primaryEmail ? [{
             email: primaryEmail,
             primary: true,
             verified: typeof profile.email_verified === 'boolean' ? profile.email_verified : undefined,
-        }],
+        }] : [],
         groups,
         preferredUsername: profile.preferred_username ?? profile.nickname,
         linkClaims: Object.fromEntries(providerConfig.linkingClaims
@@ -123,11 +129,12 @@ export default async (ctx, provider, providerConfig) => {
         }
         const profile = { ...claims, ...userinfo };
 
-        if (!profile.email) {
+        const emailError = getOidcEmailError(profile)
+        if (emailError === 'missing') {
             auditLog(ctx, { error: true, interactionDetails }, `No email returned from ${displayName}`);
             return accessDenied(ctx, provider, `No email returned from ${displayName}`);
         }
-        if (profile.email_verified === false) {
+        if (emailError === 'unverified') {
             auditLog(ctx, { error: true, interactionDetails }, `Email not verified by ${displayName}`);
             return accessDenied(ctx, provider, `Email not verified by ${displayName}`);
         }

--- a/src/utils/email-configuration.js
+++ b/src/utils/email-configuration.js
@@ -1,0 +1,17 @@
+export const isEmailEnabled = (env = process.env) => env.EMAIL_ENABLED !== 'false'
+
+const requiredEmailEnvironment = [
+    'EMAIL_HOST',
+    'EMAIL_PORT',
+    'EMAIL_SSL',
+    'EMAIL_USERNAME',
+    'EMAIL_PASSWORD',
+]
+
+export function validateEmailConfiguration(env = process.env) {
+    if (!isEmailEnabled(env)) return
+    const missing = requiredEmailEnvironment.filter(key => !env[key])
+    if (missing.length) {
+        throw new Error(`Email is enabled but required configuration is missing: ${missing.join(', ')}`)
+    }
+}

--- a/src/utils/oidc-providers.js
+++ b/src/utils/oidc-providers.js
@@ -20,7 +20,9 @@ import * as client from "openid-client";
 // where <KEY> is the provider key upper-cased with non-alphanumerics replaced
 // by underscores (e.g. key "google" -> GOOGLE_CLIENT_ID, key "entra-id" ->
 // ENTRA_ID_CLIENT_ID). A provider is only surfaced when both are present.
-const DEFAULT_SCOPES = ['openid', 'email', 'profile'];
+const defaultScopes = () => process.env.EMAIL_ENABLED === 'false'
+    ? ['openid', 'profile']
+    : ['openid', 'email', 'profile'];
 
 const envKey = (key) => key.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
 
@@ -71,7 +73,7 @@ const buildProvider = (def) => {
         issuer: def.issuer,
         clientId,
         clientSecret,
-        scopes: Array.isArray(def.scopes) && def.scopes.length ? def.scopes : DEFAULT_SCOPES,
+        scopes: Array.isArray(def.scopes) && def.scopes.length ? def.scopes : defaultScopes(),
         groupsClaim: def.groupsClaim || null,
         linkingClaims: Array.isArray(def.linkingClaims)
             ? [...new Set(def.linkingClaims.filter(claim => typeof claim === 'string' && /^[A-Za-z0-9_.:-]+$/.test(claim)))]

--- a/src/utils/oidc-providers.js
+++ b/src/utils/oidc-providers.js
@@ -1,4 +1,5 @@
 import * as client from "openid-client";
+import {isEmailEnabled} from './email-configuration.js';
 
 // Generic OIDC upstream providers. GitHub is intentionally NOT here — its API
 // is not standards-compliant OIDC and keeps its own handler (github-login.js).
@@ -20,9 +21,9 @@ import * as client from "openid-client";
 // where <KEY> is the provider key upper-cased with non-alphanumerics replaced
 // by underscores (e.g. key "google" -> GOOGLE_CLIENT_ID, key "entra-id" ->
 // ENTRA_ID_CLIENT_ID). A provider is only surfaced when both are present.
-const defaultScopes = () => process.env.EMAIL_ENABLED === 'false'
-    ? ['openid', 'profile']
-    : ['openid', 'email', 'profile'];
+const defaultScopes = () => isEmailEnabled()
+    ? ['openid', 'email', 'profile']
+    : ['openid', 'profile'];
 
 const envKey = (key) => key.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
 

--- a/src/utils/user/confirm-tos.js
+++ b/src/utils/user/confirm-tos.js
@@ -2,6 +2,8 @@ import Account from "../../models/account.js";
 import EmailAdapter from "../../adapters/email.js";
 import {getText, ToSTextName} from "../get-text.js";
 import {getEmailContent, getEmailSubject} from "../get-email-content.js";
+import {isEmailEnabled} from '../email-configuration.js';
+import {auditLog} from '../session/audit-log.js';
 
 export const confirmTos = async (ctx, accountId, contentHash) => {
     let account = await Account.findAccount(ctx, accountId)
@@ -11,17 +13,23 @@ export const confirmTos = async (ctx, accountId, contentHash) => {
         current => current.acceptTermsOfService(contentHash, acceptedAt),
     )
 
-    const content = await getEmailContent('emails/tos', {
-        name: account.profile.name,
-        timestamp: acceptedAt,
-        hash: contentHash,
-        content: getText(ToSTextName)
-    })
-    const adapter = new EmailAdapter()
-    await adapter.sendMail(
-        account.primaryEmail,
-        getEmailSubject('emails/tos'),
-        content.text,
-        content.html
-    )
+    if (!isEmailEnabled() || !account.primaryEmail) return
+    try {
+        const content = await getEmailContent('emails/tos', {
+            name: account.profile.name,
+            timestamp: acceptedAt,
+            hash: contentHash,
+            content: getText(ToSTextName)
+        })
+        const adapter = new EmailAdapter()
+        await adapter.sendMail(
+            account.primaryEmail,
+            getEmailSubject('emails/tos'),
+            content.text,
+            content.html
+        )
+    } catch (error) {
+        globalThis.logger?.error({error, accountId}, 'Failed to send Terms of Service receipt')
+        auditLog(ctx, {accountId, error: error.message}, 'Terms of Service receipt delivery failed')
+    }
 }

--- a/test/e2e/oidc-login.spec.js
+++ b/test/e2e/oidc-login.spec.js
@@ -9,7 +9,8 @@ test('logs in through the Dex upstream OIDC provider', async ({ page }) => {
     await page.goto('/')
 
     // 2. Choose the Dex upstream. Dex's mockCallback connector returns a fixed
-    //    identity (kilgore@kilgore.trout / "Kilgore Trout") with no login form.
+    //    identity ("Kilgore Trout") with no login form. EMAIL_ENABLED=false
+    //    means Passmower requests no upstream email scope.
     await page.getByRole('button', { name: /Sign in with Dex/i }).click()
 
     // 3. First-time login requires accepting the Terms of Service; a returning
@@ -29,5 +30,5 @@ test('logs in through the Dex upstream OIDC provider', async ({ page }) => {
             return res.ok() ? await res.text() : ''
         },
         { timeout: 20_000, message: 'waiting for an authenticated /api/me' },
-    ).toContain('kilgore@kilgore.trout')
+    ).toContain('Kilgore Trout')
 })

--- a/test/e2e/passmower.env
+++ b/test/e2e/passmower.env
@@ -21,7 +21,7 @@ WEBAUTHN_ENABLED=false
 # Generic upstream OIDC -> Dex (see test/e2e/dex/config.yaml).
 # Single-quoted: this file is sourced with `set -a; . passmower.env`, and bash
 # would otherwise strip the inner double quotes and corrupt the JSON.
-OIDC_PROVIDERS='{"dex":{"displayName":"Dex","issuer":"http://127.0.0.1:5556/dex","scopes":["openid","email","profile","groups"],"groupsClaim":"groups"}}'
+OIDC_PROVIDERS='{"dex":{"displayName":"Dex","issuer":"http://127.0.0.1:5556/dex","scopes":["openid","profile","groups"],"groupsClaim":"groups"}}'
 DEX_CLIENT_ID=passmower
 DEX_CLIENT_SECRET=passmower-dex-secret
 

--- a/test/integration/kube-user-service.test.js
+++ b/test/integration/kube-user-service.test.js
@@ -40,6 +40,19 @@ describe('KubeOIDCUserService over the fake Kubernetes adapter', () => {
         })
     })
 
+    it('creates an email-less user with its stable OIDC identity atomically', async () => {
+        const account = await service.createUser('subject-user', undefined, undefined, {
+            providerKey: 'dex', subject: 'subject-123',
+        })
+
+        expect(account.accountId).toBe('subject-user')
+        const stored = adapter.list('OIDCUser')[0]
+        expect(stored.passmower.email).toBeUndefined()
+        expect(stored.status.primaryEmail).toBeUndefined()
+        expect(stored.identities.dex).toEqual({sub: 'subject-123'})
+        expect((await service.findUserByIdentity('dex', 'subject-123')).accountId).toBe('subject-user')
+    })
+
     it('finds a user by id and by email', async () => {
         await service.createUser('bob', 'bob@example.com', [])
         expect((await service.findUser('bob')).accountId).toBe('bob')

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -158,6 +158,15 @@ describe('Account.claims', () => {
         expect(claims.email_verified).toBe(false)
     })
 
+    it('omits both email claims when an account has no primary email', async () => {
+        const claims = await account({
+            status: {primaryEmail: undefined, emails: [], groups: [], profile: {}},
+        }).claims('id_token', 'openid email', {}, [])
+
+        expect(claims.email).toBeUndefined()
+        expect(claims.email_verified).toBeUndefined()
+    })
+
     it('adds profile fields and emails for the profile scope', async () => {
         const a = account({
             status: {
@@ -288,5 +297,12 @@ describe('Account.getRemoteHeaders', () => {
         expect(headers['X-Name']).toBe('Jane')
         expect(headers['X-Email']).toBe('a@x.com')
         expect(headers['X-Groups'].split(',').sort()).toEqual(['gh:org', 'local:team'])
+    })
+
+    it('omits an email header when the account has no email', () => {
+        const headers = account({status: {profile: {name: 'Jane'}, groups: []}}).getRemoteHeaders({
+            user: 'X-User', name: 'X-Name', email: 'X-Email', groups: 'X-Groups',
+        })
+        expect(headers).not.toHaveProperty('X-Email')
     })
 })

--- a/test/unit/confirm-tos.test.js
+++ b/test/unit/confirm-tos.test.js
@@ -1,4 +1,4 @@
-import {afterEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 const mocks = vi.hoisted(() => ({sendMail: vi.fn()}))
 
@@ -23,7 +23,16 @@ vi.mock('../../src/utils/get-text.js', () => ({
 import Account from '../../src/models/account.js'
 import {confirmTos} from '../../src/utils/user/confirm-tos.js'
 
-afterEach(() => vi.restoreAllMocks())
+beforeEach(() => {
+    vi.stubEnv('EMAIL_ENABLED', 'true')
+    mocks.sendMail.mockReset().mockResolvedValue({})
+    globalThis.logger ??= {info() {}, error() {}}
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+})
 
 describe('confirmTos', () => {
     it('persists dedicated acceptance state before sending confirmation email', async () => {
@@ -35,12 +44,42 @@ describe('confirmTos', () => {
         vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
-        await confirmTos({kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
+        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
 
         expect(account.acceptTermsOfService).toHaveBeenCalledWith('content-hash', expect.any(Date))
         expect(mutateUserStatus).toHaveBeenCalledWith('alice', expect.any(Function))
         expect(mocks.sendMail).toHaveBeenCalledWith(
             'alice@example.com', 'Terms accepted', 'text', '<p>html</p>',
         )
+    })
+
+    it('persists acceptance without constructing a receipt when email is disabled', async () => {
+        vi.stubEnv('EMAIL_ENABLED', 'false')
+        const account = {
+            profile: {name: 'Alice'}, primaryEmail: undefined,
+            acceptTermsOfService: vi.fn(),
+        }
+        vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
+        const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
+
+        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
+
+        expect(account.acceptTermsOfService).toHaveBeenCalled()
+        expect(mocks.sendMail).not.toHaveBeenCalled()
+    })
+
+    it('does not roll back acceptance when receipt delivery fails', async () => {
+        const account = {
+            profile: {name: 'Alice'}, primaryEmail: 'alice@example.com',
+            acceptTermsOfService: vi.fn(),
+        }
+        vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
+        mocks.sendMail.mockRejectedValueOnce(new Error('SMTP unavailable'))
+        const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
+
+        await expect(confirmTos(
+            {headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash',
+        )).resolves.toBeUndefined()
+        expect(account.acceptTermsOfService).toHaveBeenCalled()
     })
 })

--- a/test/unit/email-adapter.test.js
+++ b/test/unit/email-adapter.test.js
@@ -1,0 +1,44 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    createTransport: vi.fn(),
+    sendMail: vi.fn(),
+}))
+
+vi.mock('nodemailer', () => ({
+    default: {
+        createTransport: mocks.createTransport,
+    },
+}))
+
+import EmailAdapter from '../../src/adapters/email.js'
+
+beforeEach(() => {
+    mocks.sendMail.mockReset().mockResolvedValue({messageId: 'sent'})
+    mocks.createTransport.mockReset().mockReturnValue({sendMail: mocks.sendMail})
+})
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('EmailAdapter', () => {
+    it('does not initialize Nodemailer when email is disabled', async () => {
+        vi.stubEnv('EMAIL_ENABLED', 'false')
+        await expect(new EmailAdapter().sendMail('a@example.com', 'subject', 'text', 'html'))
+            .rejects.toThrow('Email delivery is disabled')
+        expect(mocks.createTransport).not.toHaveBeenCalled()
+    })
+
+    it('initializes lazily and propagates transport failures when enabled', async () => {
+        for (const [key, value] of Object.entries({
+            EMAIL_ENABLED: 'true', EMAIL_HOST: 'smtp.example.com', EMAIL_PORT: '587',
+            EMAIL_SSL: 'false', EMAIL_USERNAME: 'passmower', EMAIL_PASSWORD: 'secret',
+        })) vi.stubEnv(key, value)
+        mocks.sendMail.mockRejectedValueOnce(new Error('SMTP unavailable'))
+        const adapter = new EmailAdapter()
+
+        expect(mocks.createTransport).not.toHaveBeenCalled()
+        await expect(adapter.sendMail('a@example.com', 'subject', 'text', 'html'))
+            .rejects.toThrow('SMTP unavailable')
+        expect(mocks.createTransport).toHaveBeenCalledOnce()
+    })
+})

--- a/test/unit/email-configuration.test.js
+++ b/test/unit/email-configuration.test.js
@@ -1,0 +1,25 @@
+import {describe, expect, it} from 'vitest'
+import {isEmailEnabled, validateEmailConfiguration} from '../../src/utils/email-configuration.js'
+
+const configured = {
+    EMAIL_ENABLED: 'true',
+    EMAIL_HOST: 'smtp.example.com',
+    EMAIL_PORT: '587',
+    EMAIL_SSL: 'false',
+    EMAIL_USERNAME: 'passmower',
+    EMAIL_PASSWORD: 'secret',
+}
+
+describe('email configuration', () => {
+    it('defaults to enabled and validates every documented SMTP setting', () => {
+        expect(isEmailEnabled({})).toBe(true)
+        expect(() => validateEmailConfiguration(configured)).not.toThrow()
+        expect(() => validateEmailConfiguration({...configured, EMAIL_HOST: ''}))
+            .toThrow(/EMAIL_HOST/)
+    })
+
+    it('has no SMTP configuration dependency when explicitly disabled', () => {
+        expect(isEmailEnabled({EMAIL_ENABLED: 'false'})).toBe(false)
+        expect(() => validateEmailConfiguration({EMAIL_ENABLED: 'false'})).not.toThrow()
+    })
+})

--- a/test/unit/github-login.test.js
+++ b/test/unit/github-login.test.js
@@ -1,0 +1,24 @@
+import {describe, expect, it, vi} from 'vitest'
+import {getGitHubEmails, getGitHubScopes} from '../../src/services/login/github-login.js'
+
+describe('email-free GitHub login', () => {
+    it('does not request email permission or call the email API when disabled', async () => {
+        const env = {EMAIL_ENABLED: 'false', GITHUB_ORGANIZATION: 'codemowers'}
+        const fetchImpl = vi.fn()
+
+        expect(getGitHubScopes(env)).toEqual(['read:org'])
+        await expect(getGitHubEmails('token', fetchImpl, env)).resolves.toEqual([])
+        expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    it('retains only verified GitHub addresses when enabled', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({json: async () => [
+            {email: 'verified@example.com', verified: true},
+            {email: 'unknown@example.com', verified: false},
+        ]})
+
+        expect(getGitHubScopes({EMAIL_ENABLED: 'true'})).toEqual(['user:email'])
+        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}))
+            .resolves.toEqual([{email: 'verified@example.com', verified: true}])
+    })
+})

--- a/test/unit/github-login.test.js
+++ b/test/unit/github-login.test.js
@@ -1,5 +1,9 @@
 import {describe, expect, it, vi} from 'vitest'
-import {getGitHubEmails, getGitHubScopes} from '../../src/services/login/github-login.js'
+import {
+    getGitHubAuthorizeParams,
+    getGitHubEmails,
+    getGitHubScopes,
+} from '../../src/services/login/github-login.js'
 
 describe('email-free GitHub login', () => {
     it('does not request email permission or call the email API when disabled', async () => {
@@ -9,6 +13,19 @@ describe('email-free GitHub login', () => {
         expect(getGitHubScopes(env)).toEqual(['read:org'])
         await expect(getGitHubEmails('token', fetchImpl, env)).resolves.toEqual([])
         expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    it('omits the scope parameter when no GitHub permissions are needed', () => {
+        const params = getGitHubAuthorizeParams('state', {
+            EMAIL_ENABLED: 'false',
+            ISSUER_URL: 'https://passmower.example/',
+        })
+
+        expect(params).toEqual({
+            redirect_uri: 'https://passmower.example/interaction/callback/gh',
+            state: 'state',
+        })
+        expect(params).not.toHaveProperty('scope')
     })
 
     it('retains only verified GitHub addresses when enabled', async () => {

--- a/test/unit/oidc-login.test.js
+++ b/test/unit/oidc-login.test.js
@@ -1,9 +1,24 @@
 import {describe, expect, it} from 'vitest'
-import {extractIdentity} from '../../src/services/login/oidc-login.js'
+import {extractIdentity, getOidcEmailError} from '../../src/services/login/oidc-login.js'
 
 const provider = {groupsClaim: null, linkingClaims: []}
 
 describe('generic OIDC email verification evidence', () => {
+    it('requires email only while email support is enabled', () => {
+        expect(getOidcEmailError({sub: 'subject'}, {EMAIL_ENABLED: 'true'})).toBe('missing')
+        expect(getOidcEmailError({sub: 'subject'}, {EMAIL_ENABLED: 'false'})).toBeNull()
+        expect(getOidcEmailError(
+            {sub: 'subject', email: 'a@example.com', email_verified: false},
+            {EMAIL_ENABLED: 'false'},
+        )).toBe('unverified')
+    })
+
+    it('represents an email-less stable identity without an invalid email entry', () => {
+        expect(extractIdentity(provider, {sub: 'subject', name: 'Email Free'})).toMatchObject({
+            sub: 'subject', primaryEmail: undefined, emails: [], name: 'Email Free',
+        })
+    })
+
     it.each([
         [true, true],
         [false, false],

--- a/test/unit/oidc-providers.test.js
+++ b/test/unit/oidc-providers.test.js
@@ -30,12 +30,26 @@ describe('getOidcProviders', () => {
     })
 
     it('defaults groupPrefix to the issuer host and scopes to openid/email/profile', () => {
+        vi.stubEnv('EMAIL_ENABLED', 'true')
         vi.stubEnv('OIDC_PROVIDERS', JSON.stringify({ gitlab: { issuer: 'https://gitlab.example.com' } }))
         vi.stubEnv('GITLAB_CLIENT_ID', 'id')
         vi.stubEnv('GITLAB_CLIENT_SECRET', 'secret')
         const [p] = getOidcProviders()
         expect(p.groupPrefix).toBe('gitlab.example.com')
         expect(p.scopes).toEqual(['openid', 'email', 'profile'])
+    })
+
+    it('does not request email by default when email is disabled but preserves explicit scopes', () => {
+        vi.stubEnv('EMAIL_ENABLED', 'false')
+        vi.stubEnv('GITLAB_CLIENT_ID', 'id')
+        vi.stubEnv('GITLAB_CLIENT_SECRET', 'secret')
+        vi.stubEnv('OIDC_PROVIDERS', JSON.stringify({gitlab: {issuer: 'https://gitlab.example.com'}}))
+        expect(getOidcProvider('gitlab').scopes).toEqual(['openid', 'profile'])
+
+        vi.stubEnv('OIDC_PROVIDERS', JSON.stringify({
+            gitlab: {issuer: 'https://gitlab.example.com', scopes: ['openid', 'email']},
+        }))
+        expect(getOidcProvider('gitlab').scopes).toEqual(['openid', 'email'])
     })
 
     it('defaults tokenEndpointAuthMethod to client_secret_post and only allows basic as the alternative', () => {


### PR DESCRIPTION
## Summary
- make EMAIL_ENABLED a global email capability switch covering SMTP, magic links, ToS receipts, and admin invites
- support email-less GitHub and generic OIDC enrollment using stable upstream identities
- omit unavailable email claims and UI fields, validate enabled SMTP configuration at startup, and avoid mounting email secrets when disabled
- document the email-free deployment mode and update the Dex E2E scenario to exercise it

## Verification
- npm test (202 passed)
- npm run test:integration (43 passed)
- npm run lint:check (frontend)
- npm run build (frontend)
- npm run sass-prod (styles)
- Helm enabled, disabled, and invalid configuration renders
- minikube rollout healthy with EMAIL_ENABLED=false, no SMTP secret mounted, OIDC discovery returns 200

The local E2E harness requires kind, which is not installed here; the updated browser scenario will run in CI.