### PR TITLE
Disable unconfigured ToS and enforce document versions

### DIFF
--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -156,6 +156,8 @@ passmower:
     termsOfService:
         #configMapRef:
         #  name: ""
+        # Empty or whitespace-only content disables ToS prompting and receipts.
+        # Changing configured content requires people to accept the new version.
         content: ""
     disableFrontendEdit:
         #configMapRef:

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -225,10 +225,15 @@ non-breaking way:
 
 ToS acceptance is durable account state, not an observation about the current
 resource, so new acceptances are stored under `OIDCUser.status.termsOfService` with
-`acceptedAt` and `contentHash` fields. Passmower continues to recognize the legacy
+`acceptedAt` and `contentHash` fields. Empty or whitespace-only ToS content disables
+the acceptance prompt and receipt entirely. When configured content changes, its
+hash changes and people must accept the new version.
+
+Passmower continues to recognize the legacy
 `status.conditions[type=ToSv1]` entry and automatically replaces it on the next status
-write. No user action or renewed acceptance is required. External tooling that reads
-the old condition should switch to `status.termsOfService.acceptedAt`.
+write, using the currently configured content hash as its baseline. No user action or
+renewed acceptance is required during migration. External tooling that reads the old
+condition should switch to `status.termsOfService.acceptedAt`.
 
 ---
 

--- a/frontend/src/components/User/Profile.vue
+++ b/frontend/src/components/User/Profile.vue
@@ -20,8 +20,10 @@
             <li v-for="group in account.groups" :key="group.displayName">{{ group.displayName }}</li>
         </ul>
         <br/>
-        <p v-if="account.tos_accepted_at"><a target="_blank" href="/terms-of-service">Terms of Service</a> accepted at {{account.tos_accepted_at}}</p>
-        <p v-else>Terms of Service not accepted</p>
+        <template v-if="account.terms_of_service_configured">
+            <p v-if="account.tos_accepted_at"><a target="_blank" href="/terms-of-service">Terms of Service</a> accepted at {{account.tos_accepted_at}}</p>
+            <p v-else>Terms of Service not accepted</p>
+        </template>
     </div>
 </template>
 

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -7,6 +7,7 @@ import {getUsernameSource} from "../utils/username-source.js";
 import {sanitizeUsername, isUsernameValid, isUsernameAvailable} from "../utils/user/username.js";
 import {fetchExtraClaims} from "../utils/fetch-extra-claims.js";
 import {canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
+import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 
 export const AdminGroup = process.env.ADMIN_GROUP;
 export const GroupPrefix = process.env.GROUP_PREFIX;
@@ -142,7 +143,7 @@ class Account {
         return response
     }
 
-    getIntendedStatus() {
+    getIntendedStatus(termsOfService = getTermsOfServiceDocument()) {
         const identities = Object.values(this.#identities ?? {})
         const activeIdentities = identities.filter(identity => identity.active !== false)
         const identityEmails = identities.flatMap(i => i.emails ?? [])
@@ -181,7 +182,7 @@ class Account {
             slackId: this.#slack?.id ?? null,
             passkeyCount: this.#webauthn?.credentials?.length ?? 0,
             conditions: this.#conditions.filter(condition => condition.type !== 'ToSv1'),
-            termsOfService: this.getTermsOfServiceAcceptance(),
+            termsOfService: this.#getIntendedTermsOfServiceAcceptance(termsOfService),
             recentApplications: this.#recentApplications,
             emailVerifications: this.getEmailVerifications(),
         }
@@ -273,6 +274,12 @@ class Account {
             acceptedAt: legacy.lastTransitionTime ?? null,
             contentHash: null,
         } : undefined
+    }
+
+    #getIntendedTermsOfServiceAcceptance(document) {
+        const acceptance = this.getTermsOfServiceAcceptance()
+        if (!acceptance || acceptance.contentHash !== null) return acceptance
+        return document ? {...acceptance, contentHash: document.contentHash} : acceptance
     }
 
     acceptTermsOfService(contentHash, acceptedAt = new Date()) {

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -188,7 +188,7 @@ class Account {
         }
     }
 
-    getProfileResponse(forAdmin = false, requesterAccountId = null) {
+    getProfileResponse(forAdmin = false, requesterAccountId = null, termsOfService = getTermsOfServiceDocument()) {
         let profile =  {
             emails: this.emails,
             email: this.primaryEmail,
@@ -197,6 +197,7 @@ class Account {
             phones: this.profile.phones,
             isAdmin: this.isAdmin,
             groups: this.#mapGroups(),
+            terms_of_service_configured: !!termsOfService,
             tos_accepted_at: this.getTermsOfServiceAcceptance()?.acceptedAt,
         }
         if (forAdmin) {

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -17,7 +17,7 @@ import Account from "../models/account.js";
 import {WebAuthnService} from "../services/webauthn/index.js";
 import crypto from "node:crypto";
 import {Approved} from "../conditions/approved.js";
-import {ApprovalTextName, getText, ToSTextName} from "../utils/get-text.js";
+import {ApprovalTextName, getText, getTermsOfService} from "../utils/get-text.js";
 import {OIDCProviderError} from "oidc-provider/lib/helpers/errors.js";
 import renderError from "../utils/render-error.js";
 import {addGrant} from "../utils/session/add-grants.js";
@@ -124,8 +124,8 @@ export default (provider) => {
     router.get(['/', '/profile', '/privileges', '/privileges/:group', '/terms-of-service'], async (ctx, next) => {
         if (await signedInToSelf(ctx, provider)) {
             if (ctx.path === '/terms-of-service') {
-                // TODO: proper implementation
-                const text = getText(ToSTextName)
+                const text = getTermsOfService()
+                if (text === null) ctx.throw(404, 'Terms of Service are not configured')
                 return render(provider, ctx, 'tos', 'Terms of Service', {text, save: false}, true)
             } else {
                 return ctx.render('frontend', { layout: false, title: 'Passmower' })
@@ -215,7 +215,12 @@ export default (provider) => {
                 });
             }
             case 'tos': {
-                const text = getText(ToSTextName)
+                const text = getTermsOfService()
+                if (text === null) {
+                    return provider.interactionFinished(ctx.req, ctx.res, {}, {
+                        mergeWithLastSubmission: true,
+                    })
+                }
                 await provider.interactionResult(ctx.req, ctx.res, {
                     tosTextChecksum: crypto.createHash('sha256').update(text, 'utf8').digest('hex'),
                 })
@@ -447,8 +452,8 @@ export default (provider) => {
     router.post('/interaction/:uid/confirm-tos', async (ctx) => {
         const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
         assert.equal(interactionDetails.prompt.name, 'tos');
-        await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
-        auditLog(ctx, {interactionDetails}, 'ToS approved')
+        const accepted = await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
+        auditLog(ctx, {interactionDetails}, accepted ? 'ToS approved' : 'ToS no longer configured')
         return provider.interactionFinished(ctx.req, ctx.res, {}, {
             mergeWithLastSubmission: true,
         });

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -15,7 +15,6 @@ import accessDenied from "../utils/session/access-denied.js";
 import getLoginResult from "../utils/user/get-login-result.js";
 import Account from "../models/account.js";
 import {WebAuthnService} from "../services/webauthn/index.js";
-import crypto from "node:crypto";
 import {Approved} from "../conditions/approved.js";
 import {ApprovalTextName, getText, getTermsOfService} from "../utils/get-text.js";
 import {OIDCProviderError} from "oidc-provider/lib/helpers/errors.js";
@@ -31,6 +30,7 @@ import {auditLog} from "../utils/session/audit-log.js";
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import validator, {checkEmail, checkRealName, checkUsername} from "../utils/session/validator.js";
 import {isEmailEnabled} from '../utils/email-configuration.js';
+import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 
 // Which login methods are surfaced on the sign-in page. Each is enabled
 // unless explicitly disabled via env var, preserving previous behaviour.
@@ -215,16 +215,16 @@ export default (provider) => {
                 });
             }
             case 'tos': {
-                const text = getTermsOfService()
-                if (text === null) {
+                const document = getTermsOfServiceDocument()
+                if (!document) {
                     return provider.interactionFinished(ctx.req, ctx.res, {}, {
                         mergeWithLastSubmission: true,
                     })
                 }
                 await provider.interactionResult(ctx.req, ctx.res, {
-                    tosTextChecksum: crypto.createHash('sha256').update(text, 'utf8').digest('hex'),
+                    tosTextChecksum: document.contentHash,
                 })
-                return render(provider, ctx, 'tos', 'Terms of Service', {text, save: true}, true)
+                return render(provider, ctx, 'tos', 'Terms of Service', {text: document.text, save: true}, true)
             }
             case 'approval_required': {
                 // Check again so when user gets approved and refreshes the interaction page, flow can continue.
@@ -452,7 +452,22 @@ export default (provider) => {
     router.post('/interaction/:uid/confirm-tos', async (ctx) => {
         const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
         assert.equal(interactionDetails.prompt.name, 'tos');
-        const accepted = await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
+        let accepted
+        try {
+            accepted = await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
+        } catch (error) {
+            if (error.status !== 409) throw error
+            const document = getTermsOfServiceDocument()
+            if (document) {
+                await provider.interactionResult(ctx.req, ctx.res, {
+                    tosTextChecksum: document.contentHash,
+                })
+                return render(provider, ctx, 'tos', 'Terms of Service', {
+                    text: document.text, save: true,
+                }, true)
+            }
+            accepted = false
+        }
         auditLog(ctx, {interactionDetails}, accepted ? 'ToS approved' : 'ToS no longer configured')
         return provider.interactionFinished(ctx.req, ctx.res, {}, {
             mergeWithLastSubmission: true,

--- a/src/utils/get-text.js
+++ b/src/utils/get-text.js
@@ -5,8 +5,8 @@ import { Marked } from 'marked';
 export const ApprovalTextName = 'approval'
 export const ToSTextName = 'tos'
 
-export function getText(name) {
-    let text = `Please add /app/${name}/${name}.{md|txt} using ConfigMap.`
+export function getConfiguredText(name) {
+    let text
     if (existsSync(`/app/${name}/${name}.md`)) {
         const marked = new Marked({
             mangle: false,
@@ -23,11 +23,27 @@ export function getText(name) {
         text = marked.parse(text)
     } else if (existsSync(`/app/${name}/${name}.txt`)) {
         text = readFileSync(`/app/${name}/${name}.txt`, 'utf8');
+        if (!text.trim()) return null
         text = htmlSafe(text)
-        text.replace(/\n/g, '<br/>')
+        text = text.replace(/\n/g, '<br/>')
+    } else {
+        return null
     }
 
-    return text
+    return text?.trim() ? text : null
+}
+
+export function getText(name) {
+    const text = getConfiguredText(name)
+    if (text !== null) return text
+    // Preserve the existing behavior for optional non-ToS text mounts: an
+    // explicitly empty file renders as empty rather than as setup guidance.
+    if (existsSync(`/app/${name}/${name}.md`) || existsSync(`/app/${name}/${name}.txt`)) return ''
+    return `Please add /app/${name}/${name}.{md|txt} using ConfigMap.`
+}
+
+export function getTermsOfService() {
+    return getConfiguredText(ToSTextName)
 }
 
 const renderer = {

--- a/src/utils/user/check-account-access.js
+++ b/src/utils/user/check-account-access.js
@@ -2,11 +2,11 @@ import {Approved} from '../../conditions/approved.js'
 import {checkAccountGroups} from './check-account-groups.js'
 import {tosRequired} from './tos-required.js'
 
-export const getAccountAccessFailure = (client, account) => {
+export const getAccountAccessFailure = (client, account, termsOfService) => {
     if (!account) return 'account_missing'
     if (!account.isAdmin && !(new Approved()).check(account)) return 'approval_required'
     if (!account.profile?.name) return 'name_required'
-    if (tosRequired(account)) return 'tos_required'
+    if (tosRequired(account, termsOfService)) return 'tos_required'
     if (!checkAccountGroups(client, account)) return 'client_access_required'
     return null
 }

--- a/src/utils/user/confirm-tos.js
+++ b/src/utils/user/confirm-tos.js
@@ -1,11 +1,19 @@
 import Account from "../../models/account.js";
 import EmailAdapter from "../../adapters/email.js";
-import {getText, ToSTextName} from "../get-text.js";
 import {getEmailContent, getEmailSubject} from "../get-email-content.js";
 import {isEmailEnabled} from '../email-configuration.js';
 import {auditLog} from '../session/audit-log.js';
+import {getTermsOfServiceDocument} from './tos-required.js';
 
 export const confirmTos = async (ctx, accountId, contentHash) => {
+    const document = getTermsOfServiceDocument()
+    if (!document) return false
+    if (document.contentHash !== contentHash) {
+        const error = new Error('Terms of Service changed during acceptance')
+        error.status = 409
+        error.expose = true
+        throw error
+    }
     let account = await Account.findAccount(ctx, accountId)
     const acceptedAt = new Date()
     await ctx.kubeOIDCUserService.mutateUserStatus(
@@ -19,7 +27,7 @@ export const confirmTos = async (ctx, accountId, contentHash) => {
             name: account.profile.name,
             timestamp: acceptedAt,
             hash: contentHash,
-            content: getText(ToSTextName)
+            content: document.text
         })
         const adapter = new EmailAdapter()
         await adapter.sendMail(
@@ -32,4 +40,5 @@ export const confirmTos = async (ctx, accountId, contentHash) => {
         globalThis.logger?.error({error, accountId}, 'Failed to send Terms of Service receipt')
         auditLog(ctx, {accountId, error: error.message}, 'Terms of Service receipt delivery failed')
     }
+    return true
 }

--- a/src/utils/user/tos-required.js
+++ b/src/utils/user/tos-required.js
@@ -1,10 +1,23 @@
+import crypto from 'node:crypto'
+import {getTermsOfService} from '../get-text.js'
+
+export const getTermsOfServiceDocument = () => {
+    const text = getTermsOfService()
+    return text === null ? null : {
+        text,
+        contentHash: crypto.createHash('sha256').update(text, 'utf8').digest('hex'),
+    }
+}
+
 // Whether the account must accept the Terms of Service before continuing.
 // ToS only applies to people — service accounts, orgs and groups skip it
 // (#62). An account with no type set is treated as a person.
-export const tosRequired = (account) => {
+export const tosRequired = (account, document = getTermsOfServiceDocument()) => {
     const type = account?.type
-    if (type && type !== 'person') {
-        return false
-    }
-    return !account?.getTermsOfServiceAcceptance()
+    if ((type && type !== 'person') || !document) return false
+    const acceptance = account?.getTermsOfServiceAcceptance()
+    // A null hash comes from the legacy ToSv1 condition. Reconciliation records
+    // the current hash as its baseline without forcing an upgrade-time prompt.
+    return !acceptance || (acceptance.contentHash !== null
+        && acceptance.contentHash !== document.contentHash)
 }

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -82,15 +82,22 @@ describe('Account.getIntendedStatus', () => {
     })
 
     it('migrates legacy ToSv1 acceptance on the next status projection', () => {
-        const status = account({status: {conditions: [{
+        const legacy = account({status: {conditions: [{
             type: 'ToSv1', status: 'True', lastTransitionTime: '2025-01-01T00:00:00.000Z',
-        }, {type: 'Ready', status: 'True'}]}}).getIntendedStatus()
+        }, {type: 'Ready', status: 'True'}]}})
+        const status = legacy.getIntendedStatus()
 
         expect(status.termsOfService).toEqual({
             acceptedAt: '2025-01-01T00:00:00.000Z',
             contentHash: null,
         })
         expect(status.conditions).toEqual([{type: 'Ready', status: 'True'}])
+
+        expect(legacy.getIntendedStatus({text: 'Terms', contentHash: 'current-hash'}).termsOfService)
+            .toEqual({
+                acceptedAt: '2025-01-01T00:00:00.000Z',
+                contentHash: 'current-hash',
+            })
     })
 })
 

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -143,10 +143,15 @@ describe('Account.getProfileResponse', () => {
         const response = account({status: {termsOfService: {
             acceptedAt: '2026-08-06T12:00:00.000Z',
             contentHash: 'content-hash',
-        }}}).getProfileResponse()
+        }}}).getProfileResponse(false, null, {text: 'Terms', contentHash: 'content-hash'})
 
         expect(response.tos_accepted_at).toBe('2026-08-06T12:00:00.000Z')
+        expect(response.terms_of_service_configured).toBe(true)
         expect(response.termsOfService).toBeUndefined()
+    })
+
+    it('reports when ToS is not configured so the profile does not link to a missing page', () => {
+        expect(account().getProfileResponse(false, null, null).terms_of_service_configured).toBe(false)
     })
 })
 

--- a/test/unit/check-account-access.test.js
+++ b/test/unit/check-account-access.test.js
@@ -21,14 +21,16 @@ const account = ({name = 'Alice', groups = [], terms = true} = {}) => new Accoun
 afterEach(() => vi.unstubAllEnvs())
 
 describe('current account access policy', () => {
+    const termsOfService = {text: 'Terms', contentHash: 'hash'}
+
     it('accepts an unchanged eligible account', () => {
-        expect(getAccountAccessFailure({}, account())).toBeNull()
+        expect(getAccountAccessFailure({}, account(), termsOfService)).toBeNull()
     })
 
     it('rejects missing accounts, profile data, ToS, and client membership', () => {
         expect(getAccountAccessFailure({}, null)).toBe('account_missing')
         expect(getAccountAccessFailure({}, account({name: null}))).toBe('name_required')
-        expect(getAccountAccessFailure({}, account({terms: false}))).toBe('tos_required')
+        expect(getAccountAccessFailure({}, account({terms: false}), termsOfService)).toBe('tos_required')
         expect(getAccountAccessFailure({allowedGroups: ['local:staff']}, account()))
             .toBe('client_access_required')
     })
@@ -41,5 +43,11 @@ describe('current account access policy', () => {
         const admin = account()
         admin.isAdmin = true
         expect(getAccountAccessFailure({}, admin)).toBeNull()
+    })
+
+    it('rejects an account that accepted a different ToS version', () => {
+        expect(getAccountAccessFailure({}, account(), {
+            text: 'Updated terms', contentHash: 'updated-hash',
+        })).toBe('tos_required')
     })
 })

--- a/test/unit/confirm-tos.test.js
+++ b/test/unit/confirm-tos.test.js
@@ -1,6 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import crypto from 'node:crypto'
 
-const mocks = vi.hoisted(() => ({sendMail: vi.fn()}))
+const contentHash = crypto.createHash('sha256').update('Terms', 'utf8').digest('hex')
+
+const mocks = vi.hoisted(() => ({sendMail: vi.fn(), terms: 'Terms'}))
 
 vi.mock('../../src/adapters/email.js', () => ({
     default: class EmailAdapter {
@@ -15,16 +18,14 @@ vi.mock('../../src/utils/get-email-content.js', () => ({
     getEmailSubject: vi.fn().mockReturnValue('Terms accepted'),
 }))
 
-vi.mock('../../src/utils/get-text.js', () => ({
-    getText: vi.fn().mockReturnValue('Terms'),
-    ToSTextName: 'termsOfService',
-}))
+vi.mock('../../src/utils/get-text.js', () => ({getTermsOfService: () => mocks.terms}))
 
 import Account from '../../src/models/account.js'
 import {confirmTos} from '../../src/utils/user/confirm-tos.js'
 
 beforeEach(() => {
     vi.stubEnv('EMAIL_ENABLED', 'true')
+    mocks.terms = 'Terms'
     mocks.sendMail.mockReset().mockResolvedValue({})
     globalThis.logger ??= {info() {}, error() {}}
 })
@@ -44,9 +45,9 @@ describe('confirmTos', () => {
         vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
-        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
+        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', contentHash)
 
-        expect(account.acceptTermsOfService).toHaveBeenCalledWith('content-hash', expect.any(Date))
+        expect(account.acceptTermsOfService).toHaveBeenCalledWith(contentHash, expect.any(Date))
         expect(mutateUserStatus).toHaveBeenCalledWith('alice', expect.any(Function))
         expect(mocks.sendMail).toHaveBeenCalledWith(
             'alice@example.com', 'Terms accepted', 'text', '<p>html</p>',
@@ -62,7 +63,7 @@ describe('confirmTos', () => {
         vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
-        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
+        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', contentHash)
 
         expect(account.acceptTermsOfService).toHaveBeenCalled()
         expect(mocks.sendMail).not.toHaveBeenCalled()
@@ -78,8 +79,26 @@ describe('confirmTos', () => {
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
         await expect(confirmTos(
-            {headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash',
-        )).resolves.toBeUndefined()
+            {headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', contentHash,
+        )).resolves.toBe(true)
         expect(account.acceptTermsOfService).toHaveBeenCalled()
+    })
+
+    it('rejects acceptance when the document changed after the prompt was rendered', async () => {
+        await expect(confirmTos(
+            {headers: {}, kubeOIDCUserService: {}}, 'alice', 'stale-hash',
+        )).rejects.toThrow('Terms of Service changed during acceptance')
+        expect(mocks.sendMail).not.toHaveBeenCalled()
+    })
+
+    it('does not record acceptance or send a receipt when ToS is unconfigured', async () => {
+        mocks.terms = null
+        const findAccount = vi.spyOn(Account, 'findAccount')
+
+        await expect(confirmTos(
+            {headers: {}, kubeOIDCUserService: {}}, 'alice', contentHash,
+        )).resolves.toBe(false)
+        expect(findAccount).not.toHaveBeenCalled()
+        expect(mocks.sendMail).not.toHaveBeenCalled()
     })
 })

--- a/test/unit/get-text.test.js
+++ b/test/unit/get-text.test.js
@@ -1,0 +1,30 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const fs = vi.hoisted(() => ({existsSync: vi.fn(), readFileSync: vi.fn()}))
+
+vi.mock('fs', () => fs)
+
+import {getTermsOfService} from '../../src/utils/get-text.js'
+import {getTermsOfServiceDocument} from '../../src/utils/user/tos-required.js'
+
+beforeEach(() => {
+    fs.existsSync.mockReset().mockImplementation(path => path.endsWith('/tos.md'))
+    fs.readFileSync.mockReset()
+})
+
+describe('Terms of Service configuration', () => {
+    it('treats an empty or whitespace-only document as unconfigured', () => {
+        fs.readFileSync.mockReturnValue('  \n')
+
+        expect(getTermsOfService()).toBeNull()
+        expect(getTermsOfServiceDocument()).toBeNull()
+    })
+
+    it('renders and hashes a configured document', () => {
+        fs.readFileSync.mockReturnValue('# Terms')
+
+        const document = getTermsOfServiceDocument()
+        expect(document.text).toContain('<h1>Terms</h1>')
+        expect(document.contentHash).toMatch(/^[a-f0-9]{64}$/)
+    })
+})

--- a/test/unit/tos-required.test.js
+++ b/test/unit/tos-required.test.js
@@ -18,27 +18,39 @@ function account({ type, tosAccepted = false, legacyAccepted = false } = {}) {
     })
 }
 
+const document = {text: 'Terms', contentHash: 'sha256'}
+
 describe('tosRequired (#62: ToS only applies to people)', () => {
     it('requires ToS for a person who has not accepted it', () => {
-        expect(tosRequired(account({ type: 'person' }))).toBe(true)
+        expect(tosRequired(account({ type: 'person' }), document)).toBe(true)
     })
 
     it('does not require ToS once a person has accepted it', () => {
-        expect(tosRequired(account({ type: 'person', tosAccepted: true }))).toBe(false)
+        expect(tosRequired(account({ type: 'person', tosAccepted: true }), document)).toBe(false)
     })
 
     it('accepts the legacy ToSv1 condition during migration', () => {
-        expect(tosRequired(account({type: 'person', legacyAccepted: true}))).toBe(false)
+        expect(tosRequired(account({type: 'person', legacyAccepted: true}), document)).toBe(false)
     })
 
     it('treats an account with no type as a person', () => {
-        expect(tosRequired(account({}))).toBe(true)
+        expect(tosRequired(account({}), document)).toBe(true)
     })
 
     it('skips ToS for non-person accounts regardless of acceptance', () => {
         for (const type of ['service', 'org', 'group']) {
-            expect(tosRequired(account({ type }))).toBe(false)
+            expect(tosRequired(account({ type }), document)).toBe(false)
         }
+    })
+
+    it('skips acceptance entirely when no ToS document is configured', () => {
+        expect(tosRequired(account({type: 'person'}), null)).toBe(false)
+    })
+
+    it('requires renewed acceptance when the configured document changes', () => {
+        expect(tosRequired(account({type: 'person', tosAccepted: true}), {
+            text: 'Updated terms', contentHash: 'updated-sha256',
+        })).toBe(true)
     })
 
     it('exposes spec.type via Account.type', () => {


### PR DESCRIPTION
## Summary
- treat missing, empty, or whitespace-only ToS content as disabled: no prompt, acceptance write, receipt, or empty standalone page
- compare durable acceptance hashes with the current rendered document so changed terms require renewed acceptance, including refresh-token access checks
- reject stale acceptance forms with HTTP 409 if the document changes while an interaction is open
- baseline legacy ToSv1 acceptance to the current content hash during reconciliation without forcing an upgrade-time reacceptance
- document the behavior in chart values and the 2.0 migration guide

## Verification
- npm test (210 passed)
- npm run test:integration (43 passed)
- helm template passmower charts/passmower
- git diff --check