### PR TITLE
Enforce OIDCUser account type login behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@ frontend/ styles/     # Vue frontend + SCSS (built into the image)
   `provider.interactionDetails`, `Interaction.find`, `provider.cookieName`. Policy
   prompts (`approval_required`, `tos`, `name`, `groups_required`) are defined in
   `src/providers/setup-policies.js` and gated by `src/conditions/*`.
+- **Account access is revalidated.** `getAccountAccessFailure()` centralizes account
+  type, approval, profile, current ToS, and client membership checks. Refresh tokens
+  and forward-auth re-evaluate it so post-login policy changes take effect.
 - **Adapters are injectable seams.** `KubeOIDCClientOperator`, `KubeOidcUserOperator`,
   and `KubeOIDCUserService` take an optional adapter:
   `constructor(provider, adapter = new KubernetesAdapter())`. Tests inject

--- a/README.md
+++ b/README.md
@@ -366,6 +366,9 @@ users are added, changed, or deleted. See
 [docs/oidc-user-event-hooks.md](docs/oidc-user-event-hooks.md) for the hook CRD,
 event metadata, idempotency, and security model.
 
+Login and admin-impersonation behavior for each `OIDCUser.spec.type` is described
+in [docs/account-types.md](docs/account-types.md).
+
 ## Traefik middleware
 
 For legacy applications `forwardAuth` based middleware option is supported.

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -587,6 +587,7 @@ spec:
                 type:
                   type: string
                   default: person
+                  description: Person and legacy unset accounts may sign in normally. Service accounts may only be used through admin impersonation. Organization, group, and banned accounts cannot sign in.
                   enum:
                     - person
                     - org

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -156,6 +156,8 @@ passmower:
     termsOfService:
         #configMapRef:
         #  name: ""
+        # Empty or whitespace-only content disables ToS prompting and receipts.
+        # Changing configured content requires people to accept the new version.
         content: ""
     disableFrontendEdit:
         #configMapRef:

--- a/docs/account-types.md
+++ b/docs/account-types.md
@@ -1,0 +1,30 @@
+# OIDCUser account types
+
+`OIDCUser.spec.type` controls whether an object represents a person who can
+authenticate or a non-login identity used for provisioning and administration.
+
+| Type | Ordinary login | Admin impersonation | Purpose |
+| --- | --- | --- | --- |
+| unset | Allowed | Allowed | Legacy users; treated as `person`. |
+| `person` | Allowed | Allowed | Human user account. |
+| `service` | Denied | Allowed | Non-interactive or application-local identity that an administrator may inspect through explicit impersonation. |
+| `org` | Denied | Denied | Organization identity and reserved name. |
+| `group` | Denied | Denied | Group identity used for provisioning and ownership. |
+| `banned` | Denied | Denied | Reserved account name whose owner must not authenticate. |
+
+Unknown values are denied even if they enter storage outside CRD validation.
+Changing an existing person to a non-login type terminates Passmower's live OIDC
+and admin sessions, prevents refresh-token use, rejects Passmower bearer APIs,
+and stops forward-auth from returning identity headers. All ordinary login
+methods share the same check, including GitHub, generic OIDC, email links, and
+passkeys.
+
+Service-account impersonation is the only type-specific exception. It still uses
+the ordinary client approval, group, and other access policies; it does not turn
+a service account into a generally login-capable identity. Impersonation of
+`banned`, `org`, and `group` accounts is refused.
+
+Self-contained JWT access tokens already issued to an account cannot be recalled
+from Passmower. Resource servers may continue accepting one until its normal
+expiry. Use short access-token lifetimes where rapid offboarding is required;
+Passmower rejects refresh and all server-side session paths immediately.

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -248,6 +248,11 @@ If a 1.x deployment assigned one of these types to a login-capable user, change
 it to `person` before upgrading. See [account-types.md](account-types.md) for the
 complete matrix and the expiry limitation for already-issued JWT access tokens.
 
+Forward-auth now rechecks the full account access policy on every request. A user
+whose approval, required profile name, current ToS acceptance, or client group/user
+membership is revoked receives 401 from legacy applications without waiting for the
+existing site session to expire.
+
 ---
 
 ## 5. RBAC change — automatic

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -237,6 +237,19 @@ condition should switch to `status.termsOfService.acceptedAt`.
 
 ---
 
+### Non-person account types no longer permit ordinary login
+
+Passmower 2.0 enforces `OIDCUser.spec.type` at every server-controlled access
+boundary. Only `person` and legacy unset types may log in normally. `service`
+accounts may only be entered through an explicit admin impersonation link;
+`org`, `group`, `banned`, and unknown types cannot be impersonated or log in.
+
+If a 1.x deployment assigned one of these types to a login-capable user, change
+it to `person` before upgrading. See [account-types.md](account-types.md) for the
+complete matrix and the expiry limitation for already-issued JWT access tokens.
+
+---
+
 ## 5. RBAC change — automatic
 
 The chart's `ClusterRole` now grants `create` on `batch/jobs` instead of core `pods`

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -225,10 +225,15 @@ non-breaking way:
 
 ToS acceptance is durable account state, not an observation about the current
 resource, so new acceptances are stored under `OIDCUser.status.termsOfService` with
-`acceptedAt` and `contentHash` fields. Passmower continues to recognize the legacy
+`acceptedAt` and `contentHash` fields. Empty or whitespace-only ToS content disables
+the acceptance prompt and receipt entirely. When configured content changes, its
+hash changes and people must accept the new version.
+
+Passmower continues to recognize the legacy
 `status.conditions[type=ToSv1]` entry and automatically replaces it on the next status
-write. No user action or renewed acceptance is required. External tooling that reads
-the old condition should switch to `status.termsOfService.acceptedAt`.
+write, using the currently configured content hash as its baseline. No user action or
+renewed acceptance is required during migration. External tooling that reads the old
+condition should switch to `status.termsOfService.acceptedAt`.
 
 ---
 

--- a/frontend/src/components/Admin/Accounts.vue
+++ b/frontend/src/components/Admin/Accounts.vue
@@ -20,6 +20,7 @@
         <div class="item" v-for="account in accounts" :key="account.accountId">
             <div class="item-details">
                 <h3>{{ account.accountId }}</h3>
+                <p>Type: {{ account.type || 'person (legacy)' }}</p>
                 <p>Name: {{ account.name }}</p>
                 <p v-if="account.email">Primary email: {{ account.email }}</p>
                 <p v-if="account.onboardedBy">Invited by: {{ account.onboardedBy }}</p>

--- a/frontend/src/components/User/Profile.vue
+++ b/frontend/src/components/User/Profile.vue
@@ -20,8 +20,10 @@
             <li v-for="group in account.groups" :key="group.displayName">{{ group.displayName }}</li>
         </ul>
         <br/>
-        <p v-if="account.tos_accepted_at"><a target="_blank" href="/terms-of-service">Terms of Service</a> accepted at {{account.tos_accepted_at}}</p>
-        <p v-else>Terms of Service not accepted</p>
+        <template v-if="account.terms_of_service_configured">
+            <p v-if="account.tos_accepted_at"><a target="_blank" href="/terms-of-service">Terms of Service</a> accepted at {{account.tos_accepted_at}}</p>
+            <p v-else>Terms of Service not accepted</p>
+        </template>
     </div>
 </template>
 

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -7,6 +7,7 @@ import {getUsernameSource} from "../utils/username-source.js";
 import {sanitizeUsername, isUsernameValid, isUsernameAvailable} from "../utils/user/username.js";
 import {fetchExtraClaims} from "../utils/fetch-extra-claims.js";
 import {canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
+import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 
 export const AdminGroup = process.env.ADMIN_GROUP;
 export const GroupPrefix = process.env.GROUP_PREFIX;
@@ -142,7 +143,7 @@ class Account {
         return response
     }
 
-    getIntendedStatus() {
+    getIntendedStatus(termsOfService = getTermsOfServiceDocument()) {
         const identities = Object.values(this.#identities ?? {})
         const activeIdentities = identities.filter(identity => identity.active !== false)
         const identityEmails = identities.flatMap(i => i.emails ?? [])
@@ -181,7 +182,7 @@ class Account {
             slackId: this.#slack?.id ?? null,
             passkeyCount: this.#webauthn?.credentials?.length ?? 0,
             conditions: this.#conditions.filter(condition => condition.type !== 'ToSv1'),
-            termsOfService: this.getTermsOfServiceAcceptance(),
+            termsOfService: this.#getIntendedTermsOfServiceAcceptance(termsOfService),
             recentApplications: this.#recentApplications,
             emailVerifications: this.getEmailVerifications(),
         }
@@ -273,6 +274,12 @@ class Account {
             acceptedAt: legacy.lastTransitionTime ?? null,
             contentHash: null,
         } : undefined
+    }
+
+    #getIntendedTermsOfServiceAcceptance(document) {
+        const acceptance = this.getTermsOfServiceAcceptance()
+        if (!acceptance || acceptance.contentHash !== null) return acceptance
+        return document ? {...acceptance, contentHash: document.contentHash} : acceptance
     }
 
     acceptTermsOfService(contentHash, acceptedAt = new Date()) {

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -8,6 +8,7 @@ import {sanitizeUsername, isUsernameValid, isUsernameAvailable} from "../utils/u
 import {fetchExtraClaims} from "../utils/fetch-extra-claims.js";
 import {canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
 import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
+import {canImpersonateAccount} from '../utils/user/account-type-access.js';
 
 export const AdminGroup = process.env.ADMIN_GROUP;
 export const GroupPrefix = process.env.GROUP_PREFIX;
@@ -204,7 +205,8 @@ class Account {
             profile = {
                 ...profile,
                 accountId: this.accountId,
-                impersonationEnabled: requesterAccountId !== this.accountId,
+                type: this.type,
+                impersonationEnabled: requesterAccountId !== this.accountId && canImpersonateAccount(this),
                 approved: this.isAdmin || (new Approved()).check(this),
                 conditions: this.#conditions,
                 onboardedBy: this.#passmower?.onboardedBy ?? null,

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -188,7 +188,7 @@ class Account {
         }
     }
 
-    getProfileResponse(forAdmin = false, requesterAccountId = null) {
+    getProfileResponse(forAdmin = false, requesterAccountId = null, termsOfService = getTermsOfServiceDocument()) {
         let profile =  {
             emails: this.emails,
             email: this.primaryEmail,
@@ -197,6 +197,7 @@ class Account {
             phones: this.profile.phones,
             isAdmin: this.isAdmin,
             groups: this.#mapGroups(),
+            terms_of_service_configured: !!termsOfService,
             tos_accepted_at: this.getTermsOfServiceAcceptance()?.acceptedAt,
         }
         if (forAdmin) {

--- a/src/providers/setup-middlewares.js
+++ b/src/providers/setup-middlewares.js
@@ -10,6 +10,8 @@ import {OIDCMiddlewareClientCrd} from "../utils/kubernetes/kube-constants.js";
 import Account from "../models/account.js";
 import nanoid from "oidc-provider/lib/helpers/nanoid.js";
 import requestErrorHandler from "../utils/request-error-handler.js";
+import {getAccountTypeAccessFailure} from '../utils/user/account-type-access.js';
+import {auditLog} from '../utils/session/audit-log.js';
 
 export default async (provider) => {
     const sessionMetadataRedis = new RedisAdapter('SessionMetadata')
@@ -93,10 +95,18 @@ export default async (provider) => {
         ctx.currentSession = session.accountId ? session : undefined
         if (ctx.currentSession?.accountId) {
             ctx.currentAccount = await Account.findAccount(ctx, ctx.currentSession.accountId)
-            if (!ctx.currentAccount) {
+            const failure = getAccountTypeAccessFailure(ctx.currentAccount)
+            if (failure) {
+                auditLog(ctx, {
+                    accountId: ctx.currentSession.accountId,
+                    accountType: ctx.currentAccount?.type,
+                    failure,
+                }, 'Session terminated because account type is not allowed to log in')
                 await ctx.sessionService.endOIDCSession(ctx.currentSession.jti, {
                     redirect: () => {}
                 }, () => {})
+                ctx.currentSession = undefined
+                ctx.currentAccount = undefined
             }
         }
         return next();

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -15,6 +15,7 @@ import {UsernameCommitted} from "../conditions/username-committed.js";
 import {getText} from "../utils/get-text.js";
 import {getUsernameSource} from "../utils/username-source.js";
 import {isEmailEnabled} from '../utils/email-configuration.js';
+import {getAccountTypeAccessFailure} from '../utils/user/account-type-access.js';
 
 export default (provider) => {
     const router = new Router();
@@ -23,6 +24,14 @@ export default (provider) => {
     router.use(async (ctx, next) => {
         let session = await ctx.sessionService.getAdminSession(ctx)
         if (session) {
+            const account = await Account.findAccount(ctx, session.accountId)
+            const failure = getAccountTypeAccessFailure(account)
+            if (failure) {
+                await ctx.sessionService.endAdminSession(ctx, session)
+                auditLog(ctx, {accountId: session.accountId, accountType: account?.type, failure},
+                    'Admin session terminated because account type is not allowed to log in')
+                return
+            }
             ctx.adminSession = session
             return next()
         } else {
@@ -99,7 +108,7 @@ export default (provider) => {
         }
         const accountId = ctx.request.body.accountId
         const impersonation = await ctx.sessionService.createImpersonation(ctx, accountId)
-        auditLog(ctx, {accountId}, 'Admin created impersonation link')
+        if (impersonation) auditLog(ctx, {accountId}, 'Admin created impersonation link')
         ctx.body = {
             impersonation
         }

--- a/src/routes/forwardAuthRoutes.js
+++ b/src/routes/forwardAuthRoutes.js
@@ -6,6 +6,8 @@ import {isHostInProviderBaseDomain} from "../utils/session/base-domain.js";
 import RedisAdapter from "../adapters/redis.js";
 import {enableAndGetRedirectUri} from "../utils/session/enable-and-get-redirect-uri.js";
 import {responseType, scope} from "../models/oidc-middleware-client.js";
+import {getAccountAccessFailure} from '../utils/user/check-account-access.js';
+import {auditLog} from '../utils/session/audit-log.js';
 
 export default (provider) => {
     const router = new Router();
@@ -48,12 +50,16 @@ export default (provider) => {
                 ctx.body = cookie.result.error
             } else {
                 const account = await Account.findAccount(ctx, cookie.accountId)
-                if (account) {
+                const failure = getAccountAccessFailure(client, account)
+                if (!failure) {
                     const remoteHeaders = account.getRemoteHeaders(client.headerMapping)
                     Object.keys(remoteHeaders).map(k => {
                         ctx.set(k, remoteHeaders[k])
                     })
                     ctx.status = 200
+                } else {
+                    auditLog(ctx, {accountId: cookie.accountId, clientId, failure},
+                        'Forward-auth account no longer satisfies access policy')
                 }
             }
         } else {

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -314,7 +314,9 @@ export default (provider) => {
         const impersonation = await ctx.sessionService.getImpersonation(ctx)
         const account = await Account.findAccount(ctx, impersonation.accountId)
         auditLog(ctx, {impersonation, account}, 'Impersonation used to log in')
-        return provider.interactionFinished(ctx.req, ctx.res, await getLoginResult(ctx, provider, account, 'Impersonation'), {
+        return provider.interactionFinished(ctx.req, ctx.res, await getLoginResult(
+            ctx, provider, account, 'Impersonation', {impersonation: true},
+        ), {
             mergeWithLastSubmission: true,
         });
     });

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -17,7 +17,7 @@ import Account from "../models/account.js";
 import {WebAuthnService} from "../services/webauthn/index.js";
 import crypto from "node:crypto";
 import {Approved} from "../conditions/approved.js";
-import {ApprovalTextName, getText, ToSTextName} from "../utils/get-text.js";
+import {ApprovalTextName, getText, getTermsOfService} from "../utils/get-text.js";
 import {OIDCProviderError} from "oidc-provider/lib/helpers/errors.js";
 import renderError from "../utils/render-error.js";
 import {addGrant} from "../utils/session/add-grants.js";
@@ -124,8 +124,8 @@ export default (provider) => {
     router.get(['/', '/profile', '/privileges', '/privileges/:group', '/terms-of-service'], async (ctx, next) => {
         if (await signedInToSelf(ctx, provider)) {
             if (ctx.path === '/terms-of-service') {
-                // TODO: proper implementation
-                const text = getText(ToSTextName)
+                const text = getTermsOfService()
+                if (text === null) ctx.throw(404, 'Terms of Service are not configured')
                 return render(provider, ctx, 'tos', 'Terms of Service', {text, save: false}, true)
             } else {
                 return ctx.render('frontend', { layout: false, title: 'Passmower' })
@@ -215,7 +215,12 @@ export default (provider) => {
                 });
             }
             case 'tos': {
-                const text = getText(ToSTextName)
+                const text = getTermsOfService()
+                if (text === null) {
+                    return provider.interactionFinished(ctx.req, ctx.res, {}, {
+                        mergeWithLastSubmission: true,
+                    })
+                }
                 await provider.interactionResult(ctx.req, ctx.res, {
                     tosTextChecksum: crypto.createHash('sha256').update(text, 'utf8').digest('hex'),
                 })
@@ -447,8 +452,8 @@ export default (provider) => {
     router.post('/interaction/:uid/confirm-tos', async (ctx) => {
         const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
         assert.equal(interactionDetails.prompt.name, 'tos');
-        await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
-        auditLog(ctx, {interactionDetails}, 'ToS approved')
+        const accepted = await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
+        auditLog(ctx, {interactionDetails}, accepted ? 'ToS approved' : 'ToS no longer configured')
         return provider.interactionFinished(ctx.req, ctx.res, {}, {
             mergeWithLastSubmission: true,
         });

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -15,7 +15,6 @@ import accessDenied from "../utils/session/access-denied.js";
 import getLoginResult from "../utils/user/get-login-result.js";
 import Account from "../models/account.js";
 import {WebAuthnService} from "../services/webauthn/index.js";
-import crypto from "node:crypto";
 import {Approved} from "../conditions/approved.js";
 import {ApprovalTextName, getText, getTermsOfService} from "../utils/get-text.js";
 import {OIDCProviderError} from "oidc-provider/lib/helpers/errors.js";
@@ -31,6 +30,7 @@ import {auditLog} from "../utils/session/audit-log.js";
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import validator, {checkEmail, checkRealName, checkUsername} from "../utils/session/validator.js";
 import {isEmailEnabled} from '../utils/email-configuration.js';
+import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 
 // Which login methods are surfaced on the sign-in page. Each is enabled
 // unless explicitly disabled via env var, preserving previous behaviour.
@@ -215,16 +215,16 @@ export default (provider) => {
                 });
             }
             case 'tos': {
-                const text = getTermsOfService()
-                if (text === null) {
+                const document = getTermsOfServiceDocument()
+                if (!document) {
                     return provider.interactionFinished(ctx.req, ctx.res, {}, {
                         mergeWithLastSubmission: true,
                     })
                 }
                 await provider.interactionResult(ctx.req, ctx.res, {
-                    tosTextChecksum: crypto.createHash('sha256').update(text, 'utf8').digest('hex'),
+                    tosTextChecksum: document.contentHash,
                 })
-                return render(provider, ctx, 'tos', 'Terms of Service', {text, save: true}, true)
+                return render(provider, ctx, 'tos', 'Terms of Service', {text: document.text, save: true}, true)
             }
             case 'approval_required': {
                 // Check again so when user gets approved and refreshes the interaction page, flow can continue.
@@ -452,7 +452,22 @@ export default (provider) => {
     router.post('/interaction/:uid/confirm-tos', async (ctx) => {
         const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
         assert.equal(interactionDetails.prompt.name, 'tos');
-        const accepted = await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
+        let accepted
+        try {
+            accepted = await confirmTos(ctx, interactionDetails.session.accountId, interactionDetails.result.tosTextChecksum)
+        } catch (error) {
+            if (error.status !== 409) throw error
+            const document = getTermsOfServiceDocument()
+            if (document) {
+                await provider.interactionResult(ctx.req, ctx.res, {
+                    tosTextChecksum: document.contentHash,
+                })
+                return render(provider, ctx, 'tos', 'Terms of Service', {
+                    text: document.text, save: true,
+                }, true)
+            }
+            accepted = false
+        }
         auditLog(ctx, {interactionDetails}, accepted ? 'ToS approved' : 'ToS no longer configured')
         return provider.interactionFinished(ctx.req, ctx.res, {}, {
             mergeWithLastSubmission: true,

--- a/src/services/session-service.js
+++ b/src/services/session-service.js
@@ -4,6 +4,8 @@ import Account from "../models/account.js";
 import {confirm as providerEndSession} from "oidc-provider/lib/actions/end_session.js";
 import instance from "oidc-provider/lib/helpers/weak_cache.js";
 import {parseRequestMetadata} from "../utils/session/parse-request-headers.js";
+import {canImpersonateAccount, getAccountTypeAccessFailure} from '../utils/user/account-type-access.js';
+import {auditLog} from '../utils/session/audit-log.js';
 
 export class SessionService {
     constructor(provider) {
@@ -156,6 +158,14 @@ export class SessionService {
         return true
     }
 
+    async endAdminSession(ctx, session) {
+        if (session?.jti) await this.adminSessionRedis.destroy(session.jti)
+        ctx.cookies.set(this.provider.cookieName('admin_session'), null, {
+            ...instance(this.provider).configuration.cookies.long,
+            maxAge: 0,
+        })
+    }
+
     // Create a one-time impersonation link instead of activating impersonation
     // in the admin's own browser. The admin opens the link in a private/incognito
     // window (or another device) so their own and downstream apps' cookies never
@@ -163,7 +173,14 @@ export class SessionService {
     async createImpersonation(ctx, accountId) {
         const account = await Account.findAccount(ctx, accountId)
         if (!account) {
-            ctx.statusCode = 404
+            ctx.status = 404
+            return null
+        }
+        if (!canImpersonateAccount(account)) {
+            ctx.status = 403
+            auditLog(ctx, {accountId, accountType: account.type,
+                failure: getAccountTypeAccessFailure(account, {impersonation: true})},
+            'Admin impersonation link rejected for account type')
             return null
         }
         const impersonation = {

--- a/src/utils/get-text.js
+++ b/src/utils/get-text.js
@@ -5,8 +5,8 @@ import { Marked } from 'marked';
 export const ApprovalTextName = 'approval'
 export const ToSTextName = 'tos'
 
-export function getText(name) {
-    let text = `Please add /app/${name}/${name}.{md|txt} using ConfigMap.`
+export function getConfiguredText(name) {
+    let text
     if (existsSync(`/app/${name}/${name}.md`)) {
         const marked = new Marked({
             mangle: false,
@@ -23,11 +23,27 @@ export function getText(name) {
         text = marked.parse(text)
     } else if (existsSync(`/app/${name}/${name}.txt`)) {
         text = readFileSync(`/app/${name}/${name}.txt`, 'utf8');
+        if (!text.trim()) return null
         text = htmlSafe(text)
-        text.replace(/\n/g, '<br/>')
+        text = text.replace(/\n/g, '<br/>')
+    } else {
+        return null
     }
 
-    return text
+    return text?.trim() ? text : null
+}
+
+export function getText(name) {
+    const text = getConfiguredText(name)
+    if (text !== null) return text
+    // Preserve the existing behavior for optional non-ToS text mounts: an
+    // explicitly empty file renders as empty rather than as setup guidance.
+    if (existsSync(`/app/${name}/${name}.md`) || existsSync(`/app/${name}/${name}.txt`)) return ''
+    return `Please add /app/${name}/${name}.{md|txt} using ConfigMap.`
+}
+
+export function getTermsOfService() {
+    return getConfiguredText(ToSTextName)
 }
 
 const renderer = {

--- a/src/utils/get-text.js
+++ b/src/utils/get-text.js
@@ -1,13 +1,26 @@
-import {existsSync, readFileSync} from 'fs';
+import {existsSync, readFileSync, statSync} from 'fs';
 import htmlSafe from "oidc-provider/lib/helpers/html_safe.js";
 import { Marked } from 'marked';
 
 export const ApprovalTextName = 'approval'
 export const ToSTextName = 'tos'
 
+const configuredTextCache = new Map()
+
+export const clearConfiguredTextCache = () => configuredTextCache.clear()
+
 export function getConfiguredText(name) {
+    const markdownPath = `/app/${name}/${name}.md`
+    const textPath = `/app/${name}/${name}.txt`
+    const path = existsSync(markdownPath) ? markdownPath : existsSync(textPath) ? textPath : null
+    if (!path) return null
+    const stat = statSync(path)
+    const cacheKey = `${path}:${stat.mtimeMs}:${stat.size}`
+    const cached = configuredTextCache.get(name)
+    if (cached?.key === cacheKey) return cached.text
+
     let text
-    if (existsSync(`/app/${name}/${name}.md`)) {
+    if (path === markdownPath) {
         const marked = new Marked({
             mangle: false,
             headerIds: false,
@@ -16,21 +29,24 @@ export function getConfiguredText(name) {
             // breaks: true, // Doesn't work: https://github.com/markedjs/marked/issues/2842
         })
         marked.use({ renderer });
-        text = readFileSync(`/app/${name}/${name}.md`, {
+        text = readFileSync(path, {
             encoding: 'utf-8'
         })
         text = text.replace(/\n(?=\n)/g, "\n<br><br>");
         text = marked.parse(text)
-    } else if (existsSync(`/app/${name}/${name}.txt`)) {
-        text = readFileSync(`/app/${name}/${name}.txt`, 'utf8');
-        if (!text.trim()) return null
+    } else {
+        text = readFileSync(path, 'utf8');
+        if (!text.trim()) {
+            configuredTextCache.set(name, {key: cacheKey, text: null})
+            return null
+        }
         text = htmlSafe(text)
         text = text.replace(/\n/g, '<br/>')
-    } else {
-        return null
     }
 
-    return text?.trim() ? text : null
+    text = text?.trim() ? text : null
+    configuredTextCache.set(name, {key: cacheKey, text})
+    return text
 }
 
 export function getText(name) {

--- a/src/utils/session/bearer-account.js
+++ b/src/utils/session/bearer-account.js
@@ -1,5 +1,6 @@
 import * as jose from "jose";
 import Account from "../../models/account.js";
+import {getAccountTypeAccessFailure} from '../user/account-type-access.js';
 
 // Resource-bound (RFC 8707) access tokens use the self-contained JWT format
 // and are never persisted, so provider.AccessToken.find() cannot resolve
@@ -56,7 +57,7 @@ export const accountFromBearer = async (ctx, provider, requiredScope = null) => 
         return {status: 403}
     }
     const account = await Account.findAccount(ctx, accessToken.accountId)
-    if (!account) {
+    if (getAccountTypeAccessFailure(account)) {
         return {status: 401}
     }
     return {account, scopes}

--- a/src/utils/user/account-type-access.js
+++ b/src/utils/user/account-type-access.js
@@ -1,0 +1,13 @@
+const ordinaryLoginTypes = new Set([null, 'person'])
+const impersonationTypes = new Set([null, 'person', 'service'])
+
+export const getAccountTypeAccessFailure = (account, {impersonation = false} = {}) => {
+    if (!account) return 'account_missing'
+    const type = account.type ?? null
+    if (type === 'banned') return 'account_banned'
+    const allowedTypes = impersonation ? impersonationTypes : ordinaryLoginTypes
+    return allowedTypes.has(type) ? null : 'account_type_not_login_capable'
+}
+
+export const canImpersonateAccount = account =>
+    getAccountTypeAccessFailure(account, {impersonation: true}) === null

--- a/src/utils/user/check-account-access.js
+++ b/src/utils/user/check-account-access.js
@@ -2,11 +2,11 @@ import {Approved} from '../../conditions/approved.js'
 import {checkAccountGroups} from './check-account-groups.js'
 import {tosRequired} from './tos-required.js'
 
-export const getAccountAccessFailure = (client, account) => {
+export const getAccountAccessFailure = (client, account, termsOfService) => {
     if (!account) return 'account_missing'
     if (!account.isAdmin && !(new Approved()).check(account)) return 'approval_required'
     if (!account.profile?.name) return 'name_required'
-    if (tosRequired(account)) return 'tos_required'
+    if (tosRequired(account, termsOfService)) return 'tos_required'
     if (!checkAccountGroups(client, account)) return 'client_access_required'
     return null
 }

--- a/src/utils/user/check-account-access.js
+++ b/src/utils/user/check-account-access.js
@@ -1,9 +1,11 @@
 import {Approved} from '../../conditions/approved.js'
 import {checkAccountGroups} from './check-account-groups.js'
 import {tosRequired} from './tos-required.js'
+import {getAccountTypeAccessFailure} from './account-type-access.js'
 
 export const getAccountAccessFailure = (client, account, termsOfService) => {
-    if (!account) return 'account_missing'
+    const typeFailure = getAccountTypeAccessFailure(account)
+    if (typeFailure) return typeFailure
     if (!account.isAdmin && !(new Approved()).check(account)) return 'approval_required'
     if (!account.profile?.name) return 'name_required'
     if (tosRequired(account, termsOfService)) return 'tos_required'

--- a/src/utils/user/check-account-groups.js
+++ b/src/utils/user/check-account-groups.js
@@ -3,6 +3,6 @@ export const checkAccountGroups = (client, account) => {
     const allowedGroups = client?.allowedGroups ?? []
     if (!allowedUsers.length && !allowedGroups.length) return true
     if (allowedUsers.includes(account.accountId)) return true
-    const accountGroups = account.getProfileResponse().groups.map(g => g.displayName)
+    const accountGroups = (account.groups ?? []).map(g => `${g.prefix}:${g.name}`)
     return allowedGroups.some(group => accountGroups.includes(group))
 }

--- a/src/utils/user/confirm-tos.js
+++ b/src/utils/user/confirm-tos.js
@@ -1,11 +1,19 @@
 import Account from "../../models/account.js";
 import EmailAdapter from "../../adapters/email.js";
-import {getText, ToSTextName} from "../get-text.js";
 import {getEmailContent, getEmailSubject} from "../get-email-content.js";
 import {isEmailEnabled} from '../email-configuration.js';
 import {auditLog} from '../session/audit-log.js';
+import {getTermsOfServiceDocument} from './tos-required.js';
 
 export const confirmTos = async (ctx, accountId, contentHash) => {
+    const document = getTermsOfServiceDocument()
+    if (!document) return false
+    if (document.contentHash !== contentHash) {
+        const error = new Error('Terms of Service changed during acceptance')
+        error.status = 409
+        error.expose = true
+        throw error
+    }
     let account = await Account.findAccount(ctx, accountId)
     const acceptedAt = new Date()
     await ctx.kubeOIDCUserService.mutateUserStatus(
@@ -19,7 +27,7 @@ export const confirmTos = async (ctx, accountId, contentHash) => {
             name: account.profile.name,
             timestamp: acceptedAt,
             hash: contentHash,
-            content: getText(ToSTextName)
+            content: document.text
         })
         const adapter = new EmailAdapter()
         await adapter.sendMail(
@@ -32,4 +40,5 @@ export const confirmTos = async (ctx, accountId, contentHash) => {
         globalThis.logger?.error({error, accountId}, 'Failed to send Terms of Service receipt')
         auditLog(ctx, {accountId, error: error.message}, 'Terms of Service receipt delivery failed')
     }
+    return true
 }

--- a/src/utils/user/get-login-result.js
+++ b/src/utils/user/get-login-result.js
@@ -1,6 +1,7 @@
 import {auditLog} from "../session/audit-log.js";
+import {getAccountTypeAccessFailure} from './account-type-access.js';
 
-export default async (ctx, provider, account, method) => {
+export default async (ctx, provider, account, method, {impersonation = false} = {}) => {
     const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res)
     if (!account) {
         if (interactionDetails?.result?.requireCustomUsername) {
@@ -12,6 +13,15 @@ export default async (ctx, provider, account, method) => {
             error_description: 'Account doesn\'t exist',
         };
     } else {
+        const failure = getAccountTypeAccessFailure(account, {impersonation})
+        if (failure) {
+            auditLog(ctx, {interactionDetails, method, accountId: account.accountId,
+                accountType: account.type, failure}, 'Account type is not allowed to log in')
+            return {
+                error: 'access_denied',
+                error_description: 'This account cannot sign in',
+            }
+        }
         auditLog(ctx, {interactionDetails, method, account}, 'User logged in')
         return {
             login: {

--- a/src/utils/user/tos-required.js
+++ b/src/utils/user/tos-required.js
@@ -1,10 +1,23 @@
+import crypto from 'node:crypto'
+import {getTermsOfService} from '../get-text.js'
+
+export const getTermsOfServiceDocument = () => {
+    const text = getTermsOfService()
+    return text === null ? null : {
+        text,
+        contentHash: crypto.createHash('sha256').update(text, 'utf8').digest('hex'),
+    }
+}
+
 // Whether the account must accept the Terms of Service before continuing.
 // ToS only applies to people — service accounts, orgs and groups skip it
 // (#62). An account with no type set is treated as a person.
-export const tosRequired = (account) => {
+export const tosRequired = (account, document = getTermsOfServiceDocument()) => {
     const type = account?.type
-    if (type && type !== 'person') {
-        return false
-    }
-    return !account?.getTermsOfServiceAcceptance()
+    if ((type && type !== 'person') || !document) return false
+    const acceptance = account?.getTermsOfServiceAcceptance()
+    // A null hash comes from the legacy ToSv1 condition. Reconciliation records
+    // the current hash as its baseline without forcing an upgrade-time prompt.
+    return !acceptance || (acceptance.contentHash !== null
+        && acceptance.contentHash !== document.contentHash)
 }

--- a/test/integration/apps-api.test.js
+++ b/test/integration/apps-api.test.js
@@ -23,10 +23,10 @@ process.env.ADMIN_GROUP = 'github.com:testorg:admins'
 const ISSUER = process.env.ISSUER_URL
 const ADMIN_GROUP = { prefix: 'github.com', name: 'testorg:admins' }
 
-const seedUser = (name, groups = []) => {
+const seedUser = (name, groups = [], type = 'person') => {
     fakeKube.seed('OIDCUser', {
         metadata: { name, labels: {} },
-        spec: { email: `${name}@example.com`, name },
+        spec: { email: `${name}@example.com`, name, type },
         passmower: { email: `${name}@example.com` },
         status: {
             primaryEmail: `${name}@example.com`,
@@ -105,6 +105,7 @@ describe('apps list API over bearer access tokens (HTTP)', () => {
 
         seedUser('plain-user')
         seedUser('admin-user', [ADMIN_GROUP])
+        seedUser('banned-user', [], 'banned')
     })
 
     afterAll(async () => {
@@ -131,6 +132,11 @@ describe('apps list API over bearer access tokens (HTTP)', () => {
         it('rejects tokens without the `applications` scope', async () => {
             const token = await mint({ sub: 'plain-user', scope: 'openid profile groups' })
             await agent.get('/api/apps').set(bearer(token)).expect(403)
+        })
+
+        it('rejects an otherwise valid token after the account is banned', async () => {
+            const token = await mint({sub: 'banned-user', scope: 'openid applications'})
+            await agent.get('/api/apps').set(bearer(token)).expect(401)
         })
 
         it('lists the apps the caller can access, without session metadata', async () => {

--- a/test/integration/impersonation.test.js
+++ b/test/integration/impersonation.test.js
@@ -68,4 +68,25 @@ describe('impersonation links', () => {
         expect(result.accountId).toBe('target-user')
         expect(result.link).toMatch(/\/impersonate\/[\w-]+$/)
     })
+
+    it('allows service impersonation but rejects non-login identities', async () => {
+        const { SessionService } = await import('../../src/services/session-service.js')
+        const service = new SessionService(provider)
+        const ctx = type => ({
+            headers: {},
+            adminSession: {accountId: 'admin'},
+            kubeOIDCUserService: {
+                async findUser() { return {accountId: `${type}-target`, type} },
+            },
+        })
+
+        await expect(service.createImpersonation(ctx('service'), 'service-target'))
+            .resolves.toMatchObject({accountId: 'service-target'})
+        for (const type of ['banned', 'org', 'group']) {
+            const requestContext = ctx(type)
+            await expect(service.createImpersonation(requestContext, `${type}-target`))
+                .resolves.toBeNull()
+            expect(requestContext.status).toBe(403)
+        }
+    })
 })

--- a/test/unit/account-type-access.test.js
+++ b/test/unit/account-type-access.test.js
@@ -1,0 +1,38 @@
+import {describe, expect, it} from 'vitest'
+import {
+    canImpersonateAccount,
+    getAccountTypeAccessFailure,
+} from '../../src/utils/user/account-type-access.js'
+
+const account = type => ({type})
+
+describe('account type access', () => {
+    it.each([undefined, null, 'person'])('allows %s accounts to log in normally', type => {
+        expect(getAccountTypeAccessFailure(account(type))).toBeNull()
+    })
+
+    it.each(['service', 'org', 'group', 'unexpected'])(
+        'rejects %s accounts from ordinary login', type => {
+            expect(getAccountTypeAccessFailure(account(type)))
+                .toBe('account_type_not_login_capable')
+        },
+    )
+
+    it('reports banned accounts distinctly without allowing impersonation', () => {
+        expect(getAccountTypeAccessFailure(account('banned'))).toBe('account_banned')
+        expect(canImpersonateAccount(account('banned'))).toBe(false)
+    })
+
+    it('allows only people, legacy accounts, and services to be impersonated', () => {
+        for (const type of [undefined, null, 'person', 'service']) {
+            expect(canImpersonateAccount(account(type))).toBe(true)
+        }
+        for (const type of ['banned', 'org', 'group', 'unexpected']) {
+            expect(canImpersonateAccount(account(type))).toBe(false)
+        }
+    })
+
+    it('treats a missing account as unavailable', () => {
+        expect(getAccountTypeAccessFailure(null)).toBe('account_missing')
+    })
+})

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -139,6 +139,19 @@ describe('Account.getProfileResponse', () => {
         expect(account().getProfileResponse(true).onboardedBy).toBeNull()
     })
 
+    it('projects account type and impersonation eligibility only to admins', () => {
+        const service = account({spec: {type: 'service'}})
+        expect(service.getProfileResponse()).not.toHaveProperty('type')
+        expect(service.getProfileResponse(true, 'admin')).toMatchObject({
+            type: 'service', impersonationEnabled: true,
+        })
+
+        const banned = account({spec: {type: 'banned'}})
+        expect(banned.getProfileResponse(true, 'admin')).toMatchObject({
+            type: 'banned', impersonationEnabled: false,
+        })
+    })
+
     it('projects the dedicated ToS acceptance timestamp without exposing its content hash', () => {
         const response = account({status: {termsOfService: {
             acceptedAt: '2026-08-06T12:00:00.000Z',

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -82,15 +82,22 @@ describe('Account.getIntendedStatus', () => {
     })
 
     it('migrates legacy ToSv1 acceptance on the next status projection', () => {
-        const status = account({status: {conditions: [{
+        const legacy = account({status: {conditions: [{
             type: 'ToSv1', status: 'True', lastTransitionTime: '2025-01-01T00:00:00.000Z',
-        }, {type: 'Ready', status: 'True'}]}}).getIntendedStatus()
+        }, {type: 'Ready', status: 'True'}]}})
+        const status = legacy.getIntendedStatus()
 
         expect(status.termsOfService).toEqual({
             acceptedAt: '2025-01-01T00:00:00.000Z',
             contentHash: null,
         })
         expect(status.conditions).toEqual([{type: 'Ready', status: 'True'}])
+
+        expect(legacy.getIntendedStatus({text: 'Terms', contentHash: 'current-hash'}).termsOfService)
+            .toEqual({
+                acceptedAt: '2025-01-01T00:00:00.000Z',
+                contentHash: 'current-hash',
+            })
     })
 })
 

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -143,10 +143,15 @@ describe('Account.getProfileResponse', () => {
         const response = account({status: {termsOfService: {
             acceptedAt: '2026-08-06T12:00:00.000Z',
             contentHash: 'content-hash',
-        }}}).getProfileResponse()
+        }}}).getProfileResponse(false, null, {text: 'Terms', contentHash: 'content-hash'})
 
         expect(response.tos_accepted_at).toBe('2026-08-06T12:00:00.000Z')
+        expect(response.terms_of_service_configured).toBe(true)
         expect(response.termsOfService).toBeUndefined()
+    })
+
+    it('reports when ToS is not configured so the profile does not link to a missing page', () => {
+        expect(account().getProfileResponse(false, null, null).terms_of_service_configured).toBe(false)
     })
 })
 

--- a/test/unit/check-account-access.test.js
+++ b/test/unit/check-account-access.test.js
@@ -2,9 +2,9 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 import Account from '../../src/models/account.js'
 import {getAccountAccessFailure} from '../../src/utils/user/check-account-access.js'
 
-const account = ({name = 'Alice', groups = [], terms = true} = {}) => new Account().fromKubernetes({
+const account = ({name = 'Alice', groups = [], terms = true, type} = {}) => new Account().fromKubernetes({
     metadata: {name: 'alice', labels: {}},
-    spec: {},
+    spec: type ? {type} : {},
     status: {
         profile: {name},
         groups: groups.map(displayName => {
@@ -49,5 +49,14 @@ describe('current account access policy', () => {
         expect(getAccountAccessFailure({}, account(), {
             text: 'Updated terms', contentHash: 'updated-hash',
         })).toBe('tos_required')
+    })
+
+    it.each([
+        ['banned', 'account_banned'],
+        ['service', 'account_type_not_login_capable'],
+        ['org', 'account_type_not_login_capable'],
+        ['group', 'account_type_not_login_capable'],
+    ])('rejects %s accounts before other policy checks', (type, failure) => {
+        expect(getAccountAccessFailure({}, account({type}), termsOfService)).toBe(failure)
     })
 })

--- a/test/unit/check-account-access.test.js
+++ b/test/unit/check-account-access.test.js
@@ -21,14 +21,16 @@ const account = ({name = 'Alice', groups = [], terms = true} = {}) => new Accoun
 afterEach(() => vi.unstubAllEnvs())
 
 describe('current account access policy', () => {
+    const termsOfService = {text: 'Terms', contentHash: 'hash'}
+
     it('accepts an unchanged eligible account', () => {
-        expect(getAccountAccessFailure({}, account())).toBeNull()
+        expect(getAccountAccessFailure({}, account(), termsOfService)).toBeNull()
     })
 
     it('rejects missing accounts, profile data, ToS, and client membership', () => {
         expect(getAccountAccessFailure({}, null)).toBe('account_missing')
         expect(getAccountAccessFailure({}, account({name: null}))).toBe('name_required')
-        expect(getAccountAccessFailure({}, account({terms: false}))).toBe('tos_required')
+        expect(getAccountAccessFailure({}, account({terms: false}), termsOfService)).toBe('tos_required')
         expect(getAccountAccessFailure({allowedGroups: ['local:staff']}, account()))
             .toBe('client_access_required')
     })
@@ -41,5 +43,11 @@ describe('current account access policy', () => {
         const admin = account()
         admin.isAdmin = true
         expect(getAccountAccessFailure({}, admin)).toBeNull()
+    })
+
+    it('rejects an account that accepted a different ToS version', () => {
+        expect(getAccountAccessFailure({}, account(), {
+            text: 'Updated terms', contentHash: 'updated-hash',
+        })).toBe('tos_required')
     })
 })

--- a/test/unit/confirm-tos.test.js
+++ b/test/unit/confirm-tos.test.js
@@ -1,6 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import crypto from 'node:crypto'
 
-const mocks = vi.hoisted(() => ({sendMail: vi.fn()}))
+const contentHash = crypto.createHash('sha256').update('Terms', 'utf8').digest('hex')
+
+const mocks = vi.hoisted(() => ({sendMail: vi.fn(), terms: 'Terms'}))
 
 vi.mock('../../src/adapters/email.js', () => ({
     default: class EmailAdapter {
@@ -15,16 +18,14 @@ vi.mock('../../src/utils/get-email-content.js', () => ({
     getEmailSubject: vi.fn().mockReturnValue('Terms accepted'),
 }))
 
-vi.mock('../../src/utils/get-text.js', () => ({
-    getText: vi.fn().mockReturnValue('Terms'),
-    ToSTextName: 'termsOfService',
-}))
+vi.mock('../../src/utils/get-text.js', () => ({getTermsOfService: () => mocks.terms}))
 
 import Account from '../../src/models/account.js'
 import {confirmTos} from '../../src/utils/user/confirm-tos.js'
 
 beforeEach(() => {
     vi.stubEnv('EMAIL_ENABLED', 'true')
+    mocks.terms = 'Terms'
     mocks.sendMail.mockReset().mockResolvedValue({})
     globalThis.logger ??= {info() {}, error() {}}
 })
@@ -44,9 +45,9 @@ describe('confirmTos', () => {
         vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
-        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
+        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', contentHash)
 
-        expect(account.acceptTermsOfService).toHaveBeenCalledWith('content-hash', expect.any(Date))
+        expect(account.acceptTermsOfService).toHaveBeenCalledWith(contentHash, expect.any(Date))
         expect(mutateUserStatus).toHaveBeenCalledWith('alice', expect.any(Function))
         expect(mocks.sendMail).toHaveBeenCalledWith(
             'alice@example.com', 'Terms accepted', 'text', '<p>html</p>',
@@ -62,7 +63,7 @@ describe('confirmTos', () => {
         vi.spyOn(Account, 'findAccount').mockResolvedValue(account)
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
-        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash')
+        await confirmTos({headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', contentHash)
 
         expect(account.acceptTermsOfService).toHaveBeenCalled()
         expect(mocks.sendMail).not.toHaveBeenCalled()
@@ -78,8 +79,26 @@ describe('confirmTos', () => {
         const mutateUserStatus = vi.fn(async (_accountId, mutation) => mutation(account))
 
         await expect(confirmTos(
-            {headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', 'content-hash',
-        )).resolves.toBeUndefined()
+            {headers: {}, kubeOIDCUserService: {mutateUserStatus}}, 'alice', contentHash,
+        )).resolves.toBe(true)
         expect(account.acceptTermsOfService).toHaveBeenCalled()
+    })
+
+    it('rejects acceptance when the document changed after the prompt was rendered', async () => {
+        await expect(confirmTos(
+            {headers: {}, kubeOIDCUserService: {}}, 'alice', 'stale-hash',
+        )).rejects.toThrow('Terms of Service changed during acceptance')
+        expect(mocks.sendMail).not.toHaveBeenCalled()
+    })
+
+    it('does not record acceptance or send a receipt when ToS is unconfigured', async () => {
+        mocks.terms = null
+        const findAccount = vi.spyOn(Account, 'findAccount')
+
+        await expect(confirmTos(
+            {headers: {}, kubeOIDCUserService: {}}, 'alice', contentHash,
+        )).resolves.toBe(false)
+        expect(findAccount).not.toHaveBeenCalled()
+        expect(mocks.sendMail).not.toHaveBeenCalled()
     })
 })

--- a/test/unit/forward-auth-access.test.js
+++ b/test/unit/forward-auth-access.test.js
@@ -1,0 +1,60 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import Koa from 'koa'
+import request from 'supertest'
+
+const mocks = vi.hoisted(() => ({failure: null, auditLog: vi.fn()}))
+
+vi.mock('../../src/utils/session/site-session.js', () => ({
+    validateSiteSession: vi.fn().mockResolvedValue({accountId: 'alice'}),
+}))
+vi.mock('../../src/adapters/redis.js', () => ({
+    default: class RedisAdapter {
+        async find() {
+            return {headerMapping: {user: 'Remote-User'}}
+        }
+    },
+}))
+vi.mock('../../src/models/account.js', () => ({
+    default: {findAccount: vi.fn().mockResolvedValue({
+        getRemoteHeaders: () => ({'Remote-User': 'alice'}),
+    })},
+}))
+vi.mock('../../src/utils/session/base-domain.js', () => ({
+    isHostInProviderBaseDomain: () => true,
+}))
+vi.mock('../../src/utils/user/check-account-access.js', () => ({
+    getAccountAccessFailure: () => mocks.failure,
+}))
+vi.mock('../../src/utils/session/audit-log.js', () => ({auditLog: mocks.auditLog}))
+
+import forwardAuthRoutes from '../../src/routes/forwardAuthRoutes.js'
+
+const app = new Koa()
+app.use(forwardAuthRoutes({}).routes())
+
+const callForwardAuth = () => request(app.callback())
+    .get('/forward-auth?client=apps.webmail')
+    .set('x-forwarded-host', 'webmail.example.com')
+    .set('x-forwarded-proto', 'https')
+    .set('x-forwarded-uri', '/')
+
+beforeEach(() => {
+    mocks.failure = null
+    mocks.auditLog.mockReset()
+})
+
+describe('forward-auth live access policy', () => {
+    it('returns identity headers while the account remains eligible', async () => {
+        const response = await callForwardAuth().expect(200)
+        expect(response.headers['remote-user']).toBe('alice')
+    })
+
+    it('returns 401 without identity headers after policy state changes', async () => {
+        mocks.failure = 'client_access_required'
+        const response = await callForwardAuth().expect(401)
+        expect(response.headers['remote-user']).toBeUndefined()
+        expect(mocks.auditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+            accountId: 'alice', failure: 'client_access_required',
+        }), 'Forward-auth account no longer satisfies access policy')
+    })
+})

--- a/test/unit/get-login-result.test.js
+++ b/test/unit/get-login-result.test.js
@@ -1,0 +1,35 @@
+import {describe, expect, it, vi} from 'vitest'
+
+vi.mock('../../src/utils/session/audit-log.js', () => ({auditLog: vi.fn()}))
+
+import getLoginResult from '../../src/utils/user/get-login-result.js'
+
+const provider = {interactionDetails: vi.fn().mockResolvedValue({uid: 'interaction'})}
+const ctx = {req: {}, res: {}}
+const account = type => ({accountId: 'subject', type})
+
+describe('login result account-type enforcement', () => {
+    it('allows people and legacy accounts', async () => {
+        await expect(getLoginResult(ctx, provider, account('person'), 'OIDC')).resolves.toEqual({
+            login: {accountId: 'subject'},
+        })
+        await expect(getLoginResult(ctx, provider, account(null), 'OIDC')).resolves.toEqual({
+            login: {accountId: 'subject'},
+        })
+    })
+
+    it.each(['service', 'org', 'group', 'banned'])(
+        'returns a neutral access denial for an ordinary %s login', async type => {
+            await expect(getLoginResult(ctx, provider, account(type), 'OIDC')).resolves.toEqual({
+                error: 'access_denied',
+                error_description: 'This account cannot sign in',
+            })
+        },
+    )
+
+    it('permits service accounts only through explicit impersonation', async () => {
+        await expect(getLoginResult(
+            ctx, provider, account('service'), 'Impersonation', {impersonation: true},
+        )).resolves.toEqual({login: {accountId: 'subject'}})
+    })
+})

--- a/test/unit/get-text.test.js
+++ b/test/unit/get-text.test.js
@@ -1,0 +1,30 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const fs = vi.hoisted(() => ({existsSync: vi.fn(), readFileSync: vi.fn()}))
+
+vi.mock('fs', () => fs)
+
+import {getTermsOfService} from '../../src/utils/get-text.js'
+import {getTermsOfServiceDocument} from '../../src/utils/user/tos-required.js'
+
+beforeEach(() => {
+    fs.existsSync.mockReset().mockImplementation(path => path.endsWith('/tos.md'))
+    fs.readFileSync.mockReset()
+})
+
+describe('Terms of Service configuration', () => {
+    it('treats an empty or whitespace-only document as unconfigured', () => {
+        fs.readFileSync.mockReturnValue('  \n')
+
+        expect(getTermsOfService()).toBeNull()
+        expect(getTermsOfServiceDocument()).toBeNull()
+    })
+
+    it('renders and hashes a configured document', () => {
+        fs.readFileSync.mockReturnValue('# Terms')
+
+        const document = getTermsOfServiceDocument()
+        expect(document.text).toContain('<h1>Terms</h1>')
+        expect(document.contentHash).toMatch(/^[a-f0-9]{64}$/)
+    })
+})

--- a/test/unit/get-text.test.js
+++ b/test/unit/get-text.test.js
@@ -1,15 +1,17 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-const fs = vi.hoisted(() => ({existsSync: vi.fn(), readFileSync: vi.fn()}))
+const fs = vi.hoisted(() => ({existsSync: vi.fn(), readFileSync: vi.fn(), statSync: vi.fn()}))
 
 vi.mock('fs', () => fs)
 
-import {getTermsOfService} from '../../src/utils/get-text.js'
+import {clearConfiguredTextCache, getTermsOfService} from '../../src/utils/get-text.js'
 import {getTermsOfServiceDocument} from '../../src/utils/user/tos-required.js'
 
 beforeEach(() => {
+    clearConfiguredTextCache()
     fs.existsSync.mockReset().mockImplementation(path => path.endsWith('/tos.md'))
     fs.readFileSync.mockReset()
+    fs.statSync.mockReset().mockReturnValue({mtimeMs: 1, size: 10})
 })
 
 describe('Terms of Service configuration', () => {
@@ -26,5 +28,17 @@ describe('Terms of Service configuration', () => {
         const document = getTermsOfServiceDocument()
         expect(document.text).toContain('<h1>Terms</h1>')
         expect(document.contentHash).toMatch(/^[a-f0-9]{64}$/)
+    })
+
+    it('reuses rendered content until the projected file changes', () => {
+        fs.readFileSync.mockReturnValue('# Terms')
+        expect(getTermsOfService()).toContain('<h1>Terms</h1>')
+        expect(getTermsOfService()).toContain('<h1>Terms</h1>')
+        expect(fs.readFileSync).toHaveBeenCalledOnce()
+
+        fs.statSync.mockReturnValue({mtimeMs: 2, size: 18})
+        fs.readFileSync.mockReturnValue('# Updated terms')
+        expect(getTermsOfService()).toContain('Updated terms')
+        expect(fs.readFileSync).toHaveBeenCalledTimes(2)
     })
 })

--- a/test/unit/tos-required.test.js
+++ b/test/unit/tos-required.test.js
@@ -18,27 +18,39 @@ function account({ type, tosAccepted = false, legacyAccepted = false } = {}) {
     })
 }
 
+const document = {text: 'Terms', contentHash: 'sha256'}
+
 describe('tosRequired (#62: ToS only applies to people)', () => {
     it('requires ToS for a person who has not accepted it', () => {
-        expect(tosRequired(account({ type: 'person' }))).toBe(true)
+        expect(tosRequired(account({ type: 'person' }), document)).toBe(true)
     })
 
     it('does not require ToS once a person has accepted it', () => {
-        expect(tosRequired(account({ type: 'person', tosAccepted: true }))).toBe(false)
+        expect(tosRequired(account({ type: 'person', tosAccepted: true }), document)).toBe(false)
     })
 
     it('accepts the legacy ToSv1 condition during migration', () => {
-        expect(tosRequired(account({type: 'person', legacyAccepted: true}))).toBe(false)
+        expect(tosRequired(account({type: 'person', legacyAccepted: true}), document)).toBe(false)
     })
 
     it('treats an account with no type as a person', () => {
-        expect(tosRequired(account({}))).toBe(true)
+        expect(tosRequired(account({}), document)).toBe(true)
     })
 
     it('skips ToS for non-person accounts regardless of acceptance', () => {
         for (const type of ['service', 'org', 'group']) {
-            expect(tosRequired(account({ type }))).toBe(false)
+            expect(tosRequired(account({ type }), document)).toBe(false)
         }
+    })
+
+    it('skips acceptance entirely when no ToS document is configured', () => {
+        expect(tosRequired(account({type: 'person'}), null)).toBe(false)
+    })
+
+    it('requires renewed acceptance when the configured document changes', () => {
+        expect(tosRequired(account({type: 'person', tosAccepted: true}), {
+            text: 'Updated terms', contentHash: 'updated-sha256',
+        })).toBe(true)
     })
 
     it('exposes spec.type via Account.type', () => {


### PR DESCRIPTION
## Summary
- centralize login eligibility for person, service, org, group, banned, legacy, and unknown account types
- enforce it across upstream/email/passkey login, active OIDC and admin sessions, refresh tokens, forward-auth, and Passmower bearer APIs
- preserve explicit admin impersonation for service accounts while rejecting banned/org/group targets
- expose type and valid impersonation actions in the admin UI, document semantics and the JWT expiry limitation

## Verification
- npm test (232 passed)
- npm run test:integration (45 passed)
- frontend lint and production build
- helm template passmower charts/passmower
- minikube rollout healthy on the feature image; OIDC discovery returned 200

Closes #38

## Dependency
This branch is stacked on PR #202 because both update the centralized account-access policy. Merge #202 first; once it lands, this PR's diff against develop collapses to the isolated account-type commit.