### PR TITLE
Define upstream verified-email trust behavior

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -418,6 +418,9 @@ spec:
                         default: false
                       verified:
                         type: boolean
+                      observedAt:
+                        type: string
+                        format: date-time
                 groups:
                   type: array
                   items:
@@ -460,6 +463,9 @@ spec:
                           default: false
                         verified:
                           type: boolean
+                        observedAt:
+                          type: string
+                          format: date-time
                   groups:
                     type: array
                     items:
@@ -625,6 +631,9 @@ spec:
                       provider:
                         type: string
                       verifiedAt:
+                        type: string
+                        format: date-time
+                      observedAt:
                         type: string
                         format: date-time
                 passkeyCount:

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -94,6 +94,8 @@ spec:
               value: {{ .Values.passmower.githubEnabled | quote }}
             - name: EMAIL_ENABLED
               value: {{ .Values.passmower.emailEnabled | quote }}
+            - name: PASSMOWER_VERIFIED_EMAIL_OVERRIDE
+              value: {{ .Values.passmower.passmowerVerifiedEmailOverride | quote }}
             - name: AUDIT_ENABLED
               value: {{ .Values.passmower.audit.enabled | quote }}
             - name: AUDIT_INCLUDE_SOURCE_ADDRESS

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -54,6 +54,12 @@ passmower:
   # When false, no SMTP credentials are mounted and upstream users may enroll
   # using their stable provider identity without an email address.
   emailEnabled: true
+  # Accept upstream OIDC logins carrying an explicit email_verified: false when
+  # the upstream identity is already linked to an account holding Passmower
+  # magic-link verification for that exact address. Returning users are not
+  # locked out by an upstream flipping to unverified; first-time email-based
+  # linking still requires the upstream signal. See docs/email-verification.md.
+  passmowerVerifiedEmailOverride: false
   # Email credentials secret name. Secret must contain EMAIL_HOST, EMAIL_PASSWORD, EMAIL_PORT, EMAIL_SSL and EMAIL_USERNAME
   emailCredentialsSecretRef: "email-credentials"
   # GitHub OAuth client secret name. Secret must contain GH_CLIENT_ID and GH_CLIENT_SECRET

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -100,6 +100,10 @@ passmower:
   #   groupPrefix     (optional) prefix for synced groups; defaults to issuer host
   #   linkingClaims   (optional) stable verified claims retained for SCIM subject
   #                   linking, e.g. [tid, oid] for Entra. Never use email here.
+  #   emailVerification (optional) oidc-claim or none. Google and GitLab.com
+  #                   default to oidc-claim; all other issuers default to none.
+  #                   Opt in only when the issuer documents email_verified as
+  #                   proof of control for the exact email claim.
   #   icon            (optional) custom sign-in button icon: inline SVG markup or
   #                   a data: URI. External image URLs are blocked by CSP. Falls
   #                   back to a built-in logo for well-known keys, else a generic icon.

--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -50,7 +50,22 @@ passmower:
 Use `emailVerification: none` to override an automatic Google or GitLab.com
 default. Passmower accepts provider login when the signal is missing, but stores
 unknown evidence and emits downstream `email_verified: false`. An explicit
-upstream `false` remains a login error. ID-token evidence is used for a UserInfo
+upstream `false` remains a login error from every issuer, trusted or not. The
+asymmetry is deliberate: a negative signal can only deny email-based account
+linking, never grant it, so heeding it is always safe, while `emailVerification`
+governs only whether a positive claim is trusted. The login error directs the
+user to verify the address upstream or, when Passmower email support is enabled,
+through Passmower's own email login.
+
+The `passmowerVerifiedEmailOverride` chart value (env
+`PASSMOWER_VERIFIED_EMAIL_OVERRIDE`) relaxes this error for returning users
+only: the login proceeds when the upstream identity is already linked to an
+account holding Passmower magic-link verification for the exact upstream
+address. The provider observation is still recorded as `unverified`; downstream
+`email_verified` stays `true` through the durable magic-link evidence. The
+override never applies to a first login from an upstream identity, so an
+attacker holding the address unverified at a configured provider cannot use the
+victim's own Passmower verification to get linked into their account. ID-token evidence is used for a UserInfo
 email only when both responses contain the same normalized address; disagreement
 cannot transfer verification to a replacement primary address.
 
@@ -59,7 +74,9 @@ cannot transfer verification to a replacement primary address.
 - Reauthenticate with GitHub or the OIDC provider to replace legacy or stale
   provider observations.
 - Use Passmower magic-link login when the provider has no trustworthy signal or
-  when recent mailbox control matters.
+  when recent mailbox control matters. With `passmowerVerifiedEmailOverride`
+  enabled, that same magic-link evidence also keeps an already-linked upstream
+  identity signed in after its issuer starts reporting `email_verified: false`.
 - Deactivate or remove a linked identity to stop its provider evidence from
   affecting downstream claims. Durable magic-link evidence is retained, but is
   effective only while its exact address remains the selected primary email.

--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -9,30 +9,62 @@ primary address omit both downstream email claims; see
 [email-configuration.md](email-configuration.md).
 
 Evidence is projected into `OIDCUser.status.emailVerifications` with its status,
-method, provider, and an optional verification timestamp. Provider-backed
+method, provider, and an optional verification or observation timestamp. Provider-backed
 evidence is recomputed from the provider data stored on the user; magic-link
 evidence is durable status maintained by Passmower. Magic-link evidence remains
 stored if its address is temporarily unlinked, but it can only affect claims
 when that exact address is selected as the current primary email.
 
-The current evidence rules are:
+Provider evidence is an observation, not an indefinite guarantee. Passmower
+replaces it at the next login and ignores it while an identity is inactive or
+after it is removed. It cannot immediately observe upstream revocation or later
+address reassignment. `observedAt` records when Passmower last saw the provider
+signal; applications needing fresh mailbox control should require a magic link.
 
-- GitHub is verified only when the matching `/user/emails` result explicitly
-  has `verified: true`. GitHub entries stored before this field was added remain
-  `unknown` until the user signs in with GitHub again or completes a magic-link
-  challenge.
-- Generic OIDC providers, including Google, are verified only when the validated
-  ID token or UserInfo response explicitly contains `email_verified: true`.
-  Explicit `false` is unverified and an omitted claim is unknown.
-- Entra ID email, `preferred_username`, tenant membership, and domain names do
-  not imply verification. Without an explicit trustworthy claim, use the
-  Passmower magic-link login to prove control.
-- Passmower currently has no dedicated Discord adapter. A future adapter must
-  retain Discord's explicit per-address `verified` result rather than infer it.
-- Providers such as Codeberg or Forgejo follow the same rule: use explicit
-  per-address evidence when available; otherwise use a Passmower magic link.
-- Successfully opening a Passmower magic link verifies exactly the challenged
-  destination address with method `magic-link` and provider `passmower`.
+## Provider trust matrix
+
+| Upstream | Evidence source | `true` / `false` / missing | Trusted for mailbox control | Passmower rule |
+|---|---|---|---|---|
+| GitHub | [`GET /user/emails`](https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user) `verified` for each exact address | verified / unverified / unknown on legacy records | Yes | Dedicated adapter retains only explicit `verified: true`, including Primary/Verified/Private addresses, as `github-api` evidence. A legacy record must reauthenticate or use a magic link. |
+| Google | Validated [ID token or UserInfo `email_verified`](https://developers.google.com/identity/openid-connect/reference) | verified / unverified / unknown | Yes | `https://accounts.google.com` automatically enables `oidc-claim` evidence. Email domain and `hd` never verify an address. |
+| GitLab.com | Validated [`email_verified`](https://docs.gitlab.com/integration/openid_connect_provider/) with the `email` scope | verified / unverified / unknown | Yes | `https://gitlab.com` automatically enables `oidc-claim` evidence. Self-hosted GitLab requires the explicit configuration below. |
+| Microsoft Entra ID | `email`, `preferred_username`, tenant and domain claims | unknown | No | Always defaults to `none`. Microsoft documents `email` as mutable and not guaranteed correct; none of these values proves mailbox control. |
+| Dex | Validated [`email_verified`](https://dexidp.io/docs/configuration/custom-scopes-claims-clients/) relayed from its connector | verified / unverified / unknown | Configuration-dependent | Defaults to `none`. Opt in only after auditing every connector and ensuring options such as `insecureSkipEmailVerified` are disabled. |
+| Discord | [`GET /users/@me`](https://docs.discord.com/developers/resources/user) `verified` with the `email` scope | verified / unverified / unknown | Yes | Not currently implemented: Discord is OAuth2, not an OIDC issuer. A dedicated adapter is useful if Discord login is added and must store `discord-api` evidence for the exact returned address. |
+| Codeberg / Forgejo | OAuth2 user profile email; no documented OIDC per-address verification contract | unknown | No | Defaults to `none`; use a magic link. Do not infer verification from account presence or Forgejo email-confirmation settings. |
+| Other generic OIDC | Provider-specific | unknown by default | No by default | A claim named `email_verified` is not silently trusted. Explicitly opt in only after auditing the issuer's contract. |
+| Passmower email | Successfully opened challenge sent to the exact address | verified | Yes | Stored durably as `magic-link` / `passmower` evidence with `verifiedAt`. |
+
+For a self-hosted provider whose documented semantics are equivalent to Google
+or GitLab, enable the capability explicitly:
+
+```yaml
+passmower:
+  oidcProviders:
+    gitlab:
+      issuer: https://gitlab.example.com
+      emailVerification: oidc-claim
+      clientSecretRef: gitlab-client
+```
+
+Use `emailVerification: none` to override an automatic Google or GitLab.com
+default. Passmower accepts provider login when the signal is missing, but stores
+unknown evidence and emits downstream `email_verified: false`. An explicit
+upstream `false` remains a login error. ID-token evidence is used for a UserInfo
+email only when both responses contain the same normalized address; disagreement
+cannot transfer verification to a replacement primary address.
+
+## Remediation and lifecycle
+
+- Reauthenticate with GitHub or the OIDC provider to replace legacy or stale
+  provider observations.
+- Use Passmower magic-link login when the provider has no trustworthy signal or
+  when recent mailbox control matters.
+- Deactivate or remove a linked identity to stop its provider evidence from
+  affecting downstream claims. Durable magic-link evidence is retained, but is
+  effective only while its exact address remains the selected primary email.
+- Changing the primary address always re-evaluates evidence by normalized exact
+  address; verification is never copied from the previous primary address.
 
 ## Downstream OIDC clients
 

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -339,9 +339,11 @@ class Account {
                 status: item.verified === true ? 'verified' : item.verified === false ? 'unverified' : 'unknown',
                 method: 'github-api',
                 provider: 'github',
+                ...(item.observedAt ? {observedAt: item.observedAt} : {}),
             })
         }
         for (const [provider, identity] of Object.entries(this.#identities ?? {})) {
+            if (identity.active === false) continue
             for (const item of identity.emails ?? []) {
                 const email = canonicalizeEmail(item.email)
                 if (!email) continue
@@ -350,6 +352,7 @@ class Account {
                     status: item.verified === true ? 'verified' : item.verified === false ? 'unverified' : 'unknown',
                     method: 'oidc-claim',
                     provider,
+                    ...(item.observedAt ? {observedAt: item.observedAt} : {}),
                 })
             }
         }
@@ -437,6 +440,7 @@ class Account {
                     email: ghEmail,
                     primary: e.primary,
                     verified: typeof e.verified === 'boolean' ? e.verified : undefined,
+                    observedAt: e.observedAt,
                 }
             })
             githubEmails = [...new Map(githubEmails.map(v => [v.email, v])).values()]

--- a/src/services/login/github-login.js
+++ b/src/services/login/github-login.js
@@ -21,13 +21,13 @@ export const getGitHubAuthorizeParams = (state, env = process.env) => {
     }
 }
 
-export async function getGitHubEmails(token, fetchImpl = fetch, env = process.env) {
+export async function getGitHubEmails(token, fetchImpl = fetch, env = process.env, observedAt = new Date().toISOString()) {
     if (!isEmailEnabled(env)) return []
     const response = await fetchImpl('https://api.github.com/user/emails', {
         method: 'GET',
         headers: {'Authorization': `Bearer ${token}`},
     })
-    return (await response.json()).filter(email => email.verified)
+    return (await response.json()).filter(email => email.verified).map(email => ({...email, observedAt}))
 }
 
 export default async (ctx, provider) => {

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -8,6 +8,10 @@ import ScimLinkService from "../scim-link-service.js";
 import {isEmailEnabled} from '../../utils/email-configuration.js';
 import {canonicalizeEmail} from '../../utils/user/identity-integrity.js';
 
+// An explicit upstream `email_verified: false` is heeded from every issuer,
+// trusted or not: a negative signal can only deny email-based account linking,
+// never grant it, so acting on it is always safe. The per-provider
+// emailVerification setting governs only whether `true` is trusted.
 export const getOidcEmailError = (profile, env = process.env) => {
     if (!profile.email && isEmailEnabled(env)) return 'missing'
     if (profile.email && profile.email_verified === false) return 'unverified'
@@ -44,6 +48,29 @@ export const extractIdentity = (providerConfig, profile, observedAt = new Date()
             .map(claim => [claim, String(profile[claim])])),
     };
 };
+
+// PASSMOWER_VERIFIED_EMAIL_OVERRIDE relaxes the explicit-false login error for
+// returning users only: the upstream identity (provider + sub) must already be
+// linked to an account, and that account must hold durable magic-link evidence
+// for the exact address. First-time email-based linking still requires the
+// upstream signal, so a stranger holding the address unverified upstream cannot
+// ride the victim's own Passmower verification into their account.
+export const shouldOverrideUnverifiedEmail = async (ctx, providerKey, sub, email, env = process.env) => {
+    if (env.PASSMOWER_VERIFIED_EMAIL_OVERRIDE !== 'true') return false
+    const address = canonicalizeEmail(email)
+    if (!address || !sub) return false
+    let account
+    try {
+        account = await ctx.kubeOIDCUserService.findUserByIdentity(providerKey, sub)
+    } catch {
+        // Identity conflicts and lookup failures fail closed; phase 3 linking
+        // surfaces and audits the underlying integrity problem.
+        return false
+    }
+    if (!account) return false
+    return account.getEmailVerifications().some(item =>
+        item.email === address && item.method === 'magic-link' && item.status === 'verified')
+}
 
 // UserInfo may replace the ID-token email. Only carry ID-token verification
 // across when both responses identify the same normalized address. When the
@@ -155,8 +182,15 @@ export default async (ctx, provider, providerConfig) => {
             return accessDenied(ctx, provider, `No email returned from ${displayName}`);
         }
         if (emailError === 'unverified') {
-            auditLog(ctx, { error: true, interactionDetails }, `Email not verified by ${displayName}`);
-            return accessDenied(ctx, provider, `Email not verified by ${displayName}`);
+            if (await shouldOverrideUnverifiedEmail(ctx, key, profile.sub, profile.email)) {
+                auditLog(ctx, { interactionDetails }, `Accepting upstream-unverified email from ${displayName}: address is Passmower-verified for the already-linked account`);
+            } else {
+                auditLog(ctx, { error: true, interactionDetails }, `Email not verified by ${displayName}`);
+                const remediation = isEmailEnabled()
+                    ? `Verify ${profile.email} at ${displayName} and sign in again, or use email login to verify it with Passmower.`
+                    : `Verify ${profile.email} at ${displayName} and sign in again.`;
+                return accessDenied(ctx, provider, `Email not verified by ${displayName}. ${remediation}`);
+            }
         }
 
         identity = extractIdentity(providerConfig, profile);

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -6,6 +6,7 @@ import { auditLog } from "../../utils/session/audit-log.js";
 import { getOidcClient, oidcRedirectUri } from "../../utils/oidc-providers.js";
 import ScimLinkService from "../scim-link-service.js";
 import {isEmailEnabled} from '../../utils/email-configuration.js';
+import {canonicalizeEmail} from '../../utils/user/identity-integrity.js';
 
 export const getOidcEmailError = (profile, env = process.env) => {
     if (!profile.email && isEmailEnabled(env)) return 'missing'
@@ -15,7 +16,7 @@ export const getOidcEmailError = (profile, env = process.env) => {
 
 // Map the validated id_token / userinfo claims onto the structure we persist
 // under identities.<provider> and the values createOrUpdateByEmails expects.
-export const extractIdentity = (providerConfig, profile) => {
+export const extractIdentity = (providerConfig, profile, observedAt = new Date().toISOString()) => {
     const primaryEmail = profile.email;
     let groups = [];
     if (providerConfig.groupsClaim && Array.isArray(profile[providerConfig.groupsClaim])) {
@@ -32,7 +33,9 @@ export const extractIdentity = (providerConfig, profile) => {
         emails: primaryEmail ? [{
             email: primaryEmail,
             primary: true,
-            verified: typeof profile.email_verified === 'boolean' ? profile.email_verified : undefined,
+            verified: providerConfig.emailVerification === 'oidc-claim'
+                && typeof profile.email_verified === 'boolean' ? profile.email_verified : undefined,
+            observedAt,
         }] : [],
         groups,
         preferredUsername: profile.preferred_username ?? profile.nickname,
@@ -40,6 +43,22 @@ export const extractIdentity = (providerConfig, profile) => {
             .filter(claim => ['string', 'number'].includes(typeof profile[claim]))
             .map(claim => [claim, String(profile[claim])])),
     };
+};
+
+// UserInfo may replace the ID-token email. Only carry ID-token verification
+// across when both responses identify the same normalized address. When the
+// two validated responses disagree about verification, fail closed.
+export const mergeOidcProfile = (claims = {}, userinfo = {}) => {
+    const profile = {...claims, ...userinfo};
+    const selectedEmail = canonicalizeEmail(profile.email);
+    const matchingSignals = [claims, userinfo]
+        .filter(source => canonicalizeEmail(source.email) === selectedEmail)
+        .map(source => source.email_verified)
+        .filter(value => typeof value === 'boolean');
+    if (matchingSignals.includes(false)) profile.email_verified = false;
+    else if (matchingSignals.includes(true)) profile.email_verified = true;
+    else delete profile.email_verified;
+    return profile;
 };
 
 // Generic OpenID Connect upstream login. Handles any standards-compliant
@@ -128,7 +147,7 @@ export default async (ctx, provider, providerConfig) => {
             // userinfo is best-effort — the id_token already carries sub/email.
             auditLog(ctx, { error: error.message, interactionDetails }, `Error getting userinfo from ${displayName}`);
         }
-        const profile = { ...claims, ...userinfo };
+        const profile = mergeOidcProfile(claims, userinfo);
 
         const emailError = getOidcEmailError(profile)
         if (emailError === 'missing') {

--- a/src/utils/oidc-providers.js
+++ b/src/utils/oidc-providers.js
@@ -12,6 +12,7 @@ import {isEmailEnabled} from './email-configuration.js';
 //      "groupsClaim": "groups",                    // optional
 //      "groupPrefix": "google.com",                // optional, defaults to issuer host
 //      "linkingClaims": ["tid", "oid"],             // optional stable claims retained for SCIM linking
+//      "emailVerification": "oidc-claim",             // optional explicit trust opt-in
 //      "tokenEndpointAuthMethod": "client_secret_post", // optional, or client_secret_basic
 //      "enabled": true }}                          // optional, defaults to true
 //
@@ -26,6 +27,18 @@ const defaultScopes = () => isEmailEnabled()
     : ['openid', 'profile'];
 
 const envKey = (key) => key.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
+
+const defaultEmailVerification = (issuer) => {
+    try {
+        const url = new URL(issuer);
+        if (url.protocol === 'https:' && ['accounts.google.com', 'gitlab.com'].includes(url.hostname)) {
+            return 'oidc-claim';
+        }
+    } catch {
+        // Invalid issuers are rejected by buildProvider below.
+    }
+    return 'none';
+};
 
 const parseProviderDefinitions = () => {
     if (!process.env.OIDC_PROVIDERS) {
@@ -79,6 +92,12 @@ const buildProvider = (def) => {
         linkingClaims: Array.isArray(def.linkingClaims)
             ? [...new Set(def.linkingClaims.filter(claim => typeof claim === 'string' && /^[A-Za-z0-9_.:-]+$/.test(claim)))]
             : [],
+        // Trust is a provider capability, not a generic consequence of a claim
+        // named email_verified. Only issuers whose semantics we know are enabled
+        // automatically; other providers require an administrator to opt in.
+        emailVerification: ['oidc-claim', 'none'].includes(def.emailVerification)
+            ? def.emailVerification
+            : defaultEmailVerification(def.issuer),
         groupPrefix,
         // client_secret_post is the default: oauth4webapi's client_secret_basic
         // form-urlencodes credentials per RFC 6749 §2.3.1, which several major

--- a/test/unit/account.test.js
+++ b/test/unit/account.test.js
@@ -236,13 +236,23 @@ describe('Account.claims', () => {
         })
 
         expect((await verified.claims('id_token', 'openid email', {}, [])).email_verified).toBe(true)
+        expect((await verified.claims('userinfo', 'openid email', {}, [])).email_verified).toBe(true)
         expect(unverified.getIntendedStatus().emailVerifications).toContainEqual({
             email: 'a@x.com', status: 'unverified', method: 'oidc-claim', provider: 'google',
         })
         expect((await unspecified.claims('id_token', 'openid email', {}, [])).email_verified).toBe(false)
+        expect((await unverified.claims('userinfo', 'openid email', {}, [])).email_verified).toBe(false)
         expect(unspecified.getIntendedStatus().emailVerifications).toContainEqual({
             email: 'a@x.com', status: 'unknown', method: 'oidc-claim', provider: 'google',
         })
+    })
+
+    it('ignores provider evidence after an identity is deactivated', async () => {
+        const a = account({
+            identities: {google: {active: false, emails: [{email: 'a@x.com', primary: true, verified: true}]}},
+            status: {primaryEmail: 'a@x.com', emails: ['a@x.com']},
+        })
+        expect((await a.claims('id_token', 'openid email', {}, [])).email_verified).toBe(false)
     })
 
     it('does not transfer verification when the emitted primary email changes', async () => {

--- a/test/unit/github-login.test.js
+++ b/test/unit/github-login.test.js
@@ -35,7 +35,20 @@ describe('email-free GitHub login', () => {
         ]})
 
         expect(getGitHubScopes({EMAIL_ENABLED: 'true'})).toEqual(['user:email'])
-        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}))
-            .resolves.toEqual([{email: 'verified@example.com', verified: true}])
+        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}, '2026-08-22T10:00:00.000Z'))
+            .resolves.toEqual([{
+                email: 'verified@example.com', verified: true,
+                observedAt: '2026-08-22T10:00:00.000Z',
+            }])
+    })
+
+    it('preserves GitHub primary/verified/private metadata as exact-address evidence', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({json: async () => [{
+            email: 'private@example.com', primary: true, verified: true, visibility: null,
+        }]})
+        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}, '2026-08-22T10:00:00.000Z'))
+            .resolves.toMatchObject([{
+                email: 'private@example.com', primary: true, verified: true, visibility: null,
+            }])
     })
 })

--- a/test/unit/oidc-login.test.js
+++ b/test/unit/oidc-login.test.js
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {extractIdentity, getOidcEmailError, mergeOidcProfile} from '../../src/services/login/oidc-login.js'
+import {extractIdentity, getOidcEmailError, mergeOidcProfile, shouldOverrideUnverifiedEmail} from '../../src/services/login/oidc-login.js'
 
 const provider = {groupsClaim: null, linkingClaims: [], emailVerification: 'oidc-claim'}
 
@@ -55,6 +55,34 @@ describe('generic OIDC email verification evidence', () => {
             {email: 'old@example.com', email_verified: true},
             {email: 'new@example.com'},
         )).toEqual({email: 'new@example.com'})
+    })
+
+    it('overrides an upstream-unverified email only for an already-linked, Passmower-verified identity', async () => {
+        const flag = {PASSMOWER_VERIFIED_EMAIL_OVERRIDE: 'true'}
+        const ctx = (account) => ({kubeOIDCUserService: {findUserByIdentity: async () => account}})
+        const linked = (evidence) => ({getEmailVerifications: () => evidence})
+        const magicLink = [{email: 'person@example.com', method: 'magic-link', status: 'verified'}]
+
+        await expect(shouldOverrideUnverifiedEmail(ctx(linked(magicLink)), 'dex', 'sub', 'Person@EXAMPLE.com', flag))
+            .resolves.toBe(true)
+        // flag off
+        await expect(shouldOverrideUnverifiedEmail(ctx(linked(magicLink)), 'dex', 'sub', 'person@example.com', {}))
+            .resolves.toBe(false)
+        // first login: identity not linked to any account yet
+        await expect(shouldOverrideUnverifiedEmail(ctx(undefined), 'dex', 'sub', 'person@example.com', flag))
+            .resolves.toBe(false)
+        // provider evidence alone is not Passmower verification
+        await expect(shouldOverrideUnverifiedEmail(
+            ctx(linked([{email: 'person@example.com', method: 'oidc-claim', status: 'verified'}])),
+            'dex', 'sub', 'person@example.com', flag)).resolves.toBe(false)
+        // evidence covers a different address
+        await expect(shouldOverrideUnverifiedEmail(
+            ctx(linked([{email: 'other@example.com', method: 'magic-link', status: 'verified'}])),
+            'dex', 'sub', 'person@example.com', flag)).resolves.toBe(false)
+        // identity conflicts fail closed
+        const conflicted = {kubeOIDCUserService: {findUserByIdentity: async () => { throw new Error('conflict') }}}
+        await expect(shouldOverrideUnverifiedEmail(conflicted, 'dex', 'sub', 'person@example.com', flag))
+            .resolves.toBe(false)
     })
 
     it('uses exact-address evidence from either response and fails closed on conflict', () => {

--- a/test/unit/oidc-login.test.js
+++ b/test/unit/oidc-login.test.js
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
-import {extractIdentity, getOidcEmailError} from '../../src/services/login/oidc-login.js'
+import {extractIdentity, getOidcEmailError, mergeOidcProfile} from '../../src/services/login/oidc-login.js'
 
-const provider = {groupsClaim: null, linkingClaims: []}
+const provider = {groupsClaim: null, linkingClaims: [], emailVerification: 'oidc-claim'}
 
 describe('generic OIDC email verification evidence', () => {
     it('requires email only while email support is enabled', () => {
@@ -27,10 +27,44 @@ describe('generic OIDC email verification evidence', () => {
         const profile = {sub: 'subject', email: 'Person@Example.COM'}
         if (emailVerified !== undefined) profile.email_verified = emailVerified
 
-        const identity = extractIdentity(provider, profile)
+        const identity = extractIdentity(provider, profile, '2026-08-22T10:00:00.000Z')
 
         expect(identity.emails).toEqual([{
             email: 'Person@Example.COM', primary: true, verified: expected,
+            observedAt: '2026-08-22T10:00:00.000Z',
         }])
+    })
+
+    it.each([
+        ['google', 'oidc-claim', true, true],
+        ['gitlab', 'oidc-claim', false, false],
+        ['dex', 'oidc-claim', undefined, undefined],
+        ['entra', 'none', true, undefined],
+        ['codeberg', 'none', true, undefined],
+        ['forgejo', 'none', true, undefined],
+        ['unknown', 'none', true, undefined],
+    ])('%s maps only explicitly trusted verification signals', (_name, capability, signal, expected) => {
+        const profile = {sub: 'subject', email: 'person@example.com'}
+        if (signal !== undefined) profile.email_verified = signal
+        const identity = extractIdentity({...provider, emailVerification: capability}, profile, '2026-08-22T10:00:00.000Z')
+        expect(identity.emails[0].verified).toBe(expected)
+    })
+
+    it('does not transfer ID-token verification when UserInfo changes the email', () => {
+        expect(mergeOidcProfile(
+            {email: 'old@example.com', email_verified: true},
+            {email: 'new@example.com'},
+        )).toEqual({email: 'new@example.com'})
+    })
+
+    it('uses exact-address evidence from either response and fails closed on conflict', () => {
+        expect(mergeOidcProfile(
+            {email: 'Person@example.com', email_verified: true},
+            {email: 'person@EXAMPLE.com'},
+        ).email_verified).toBe(true)
+        expect(mergeOidcProfile(
+            {email: 'person@example.com', email_verified: true},
+            {email: 'person@example.com', email_verified: false},
+        ).email_verified).toBe(false)
     })
 })

--- a/test/unit/oidc-providers.test.js
+++ b/test/unit/oidc-providers.test.js
@@ -37,6 +37,24 @@ describe('getOidcProviders', () => {
         const [p] = getOidcProviders()
         expect(p.groupPrefix).toBe('gitlab.example.com')
         expect(p.scopes).toEqual(['openid', 'email', 'profile'])
+        expect(p.emailVerification).toBe('none')
+    })
+
+    it('only auto-trusts audited issuers and allows an explicit override', () => {
+        vi.stubEnv('OIDC_PROVIDERS', JSON.stringify({
+            google: {issuer: 'https://accounts.google.com'},
+            gitlab: {issuer: 'https://gitlab.com', emailVerification: 'none'},
+            dex: {issuer: 'https://dex.example.com', emailVerification: 'oidc-claim'},
+            unknown: {issuer: 'https://unknown.example.com'},
+        }))
+        for (const key of ['google', 'gitlab', 'dex', 'unknown']) {
+            vi.stubEnv(`${key.toUpperCase()}_CLIENT_ID`, 'id')
+            vi.stubEnv(`${key.toUpperCase()}_CLIENT_SECRET`, 'secret')
+        }
+
+        expect(Object.fromEntries(getOidcProviders().map(p => [p.key, p.emailVerification]))).toEqual({
+            dex: 'oidc-claim', gitlab: 'none', google: 'oidc-claim', unknown: 'none',
+        })
     })
 
     it('does not request email by default when email is disabled but preserves explicit scopes', () => {


### PR DESCRIPTION
Closes #196

## Summary
- allowlist automatic OIDC email-verification trust for Google and GitLab.com, with explicit per-provider opt-in/disable controls
- keep Entra, Dex, Codeberg/Forgejo, and unknown generic issuers untrusted by default
- prevent ID-token verification evidence from transferring to a different UserInfo email
- timestamp provider observations and ignore evidence from inactive identities
- document the audited provider matrix, lifecycle limits, Discord adapter decision, and remediation paths
- add regression coverage for true, false, and missing signals, GitHub private primary email, inactive identities, and ID token/UserInfo behavior

## Validation
- npm test (247 passed)
- focused verification tests (56 passed)
- helm template passmower charts/passmower
- git diff --check
- integration suite attempted; Redis-dependent setup could not run because no Redis was available at 127.0.0.1:6379 (12 tests completed before the dependent suites timed out/skipped)