### PR TITLE
Bind site sessions to the issuing client address

### DIFF
--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
             {{- end }}
             - name: NORMALIZE_EMAIL_ADDRESSES
               value: {{ .Values.passmower.normalizeEmailAddresses | quote }}
+            - name: SITE_SESSION_IP_BINDING
+              value: {{ .Values.passmower.siteSessionIpBinding | quote }}
             - name: WEBAUTHN_ENABLED
               value: {{ .Values.passmower.webauthnEnabled | quote }}
             - name: GITHUB_ENABLED

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -46,6 +46,12 @@ passmower:
   # Changing this on an existing installation may expose previously hidden conflicts;
   # see docs/identity-integrity.md.
   normalizeEmailAddresses: true
+  # Bind forward-auth/dashboard site sessions to the client IP that they were
+  # issued to; a session presented from a different address is destroyed and the
+  # user re-authenticates. Increases session-theft resistance at the cost of
+  # re-authentication whenever the user's network changes (mobile roaming,
+  # VPN toggles, some CGNAT setups).
+  siteSessionIpBinding: false
   # Enable WebAuthn/Passkey authentication. Allows users to register passkeys for faster login.
   webauthnEnabled: true
   # Enable GitHub OAuth login. Requires githubClientSecretRef to be set.

--- a/src/utils/session/parse-request-headers.js
+++ b/src/utils/session/parse-request-headers.js
@@ -1,5 +1,10 @@
 import {UAParser} from "ua-parser-js";
 
+// The client address as seen by the edge proxy: first hop of x-forwarded-for,
+// falling back to the socket address for direct connections.
+export const requestIp = (ctx) =>
+    ctx.headers?.['x-forwarded-for']?.split(',')[0]?.trim() || ctx.request?.ip || ctx.ip
+
 export const parseRequestMetadata = (metadata, sessionId, currentSession) => {
     const ua = UAParser(metadata).withClientHints()
     return {

--- a/src/utils/session/site-session.js
+++ b/src/utils/session/site-session.js
@@ -4,6 +4,8 @@ import nanoid from "oidc-provider/lib/helpers/nanoid.js";
 import {providerBaseDomain} from "./base-domain.js";
 import configuration from "../../configuration.js";
 import {clientId as selfClientId} from "./self-oidc-client.js";
+import {requestIp} from "./parse-request-headers.js";
+import {auditLog} from "./audit-log.js";
 
 const providerHostname = new URL(process.env.ISSUER_URL).hostname
 
@@ -54,6 +56,7 @@ export const addSiteSession = async (ctx, provider, sessionId, accountId, client
         sessionId,
         accountId,
         domain: getSiteSessionScope(client.clientId),
+        ip: requestIp(ctx),
     }
     await redis.upsert(siteWideCookie.jti, siteWideCookie, instance(provider).configuration.ttl.SiteSession);
     return siteWideCookie
@@ -64,11 +67,25 @@ export const updateSiteSession = async (siteSession) => {
     await siteSessionRedis.upsert(siteSession.jti, siteSession, configuration.ttl.SiteSession)
 }
 
+// Opt-in binding of the site session to the requesting client address (#21).
+// Records created before the flag was enabled carry no ip and fail closed the
+// same way: one fresh authentication rebinds them.
+export const siteSessionIpMismatch = (siteSession, ip, env = process.env) => {
+    if (env.SITE_SESSION_IP_BINDING !== 'true') return false
+    return siteSession?.ip !== ip
+}
+
 export const validateSiteSession = async (ctx, clientId) => {
     const sessionRedis = new RedisAdapter('Session')
     const siteSessionRedis = new RedisAdapter('SiteSession')
     let siteSession = ctx.cookies.get(getFullSiteSessionCookieName(clientId))
     siteSession = await siteSessionRedis.find(siteSession)
+    if (siteSession && siteSessionIpMismatch(siteSession, requestIp(ctx))) {
+        auditLog(ctx, {accountId: siteSession.accountId, clientId},
+            'Site session rejected and destroyed: requesting address differs from the issuing address')
+        await siteSessionRedis.destroy(siteSession.jti)
+        return undefined
+    }
     let baseSession = siteSession?.sessionId ? await sessionRedis.find(siteSession?.sessionId) : true // Handle situation when siteSession does not yet have sessionId
     if (baseSession?.authorizations) {
         baseSession = baseSession?.authorizations?.[clientId]

--- a/test/unit/site-session.test.js
+++ b/test/unit/site-session.test.js
@@ -1,7 +1,9 @@
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 const mocks = vi.hoisted(() => ({
     upsert: vi.fn(),
+    find: vi.fn(),
+    destroy: vi.fn(),
     providerConfiguration: {
         cookies: {long: {httpOnly: true, secure: true}},
         ttl: {SiteSession: 3600},
@@ -10,8 +12,17 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../src/adapters/redis.js', () => ({
     default: class RedisAdapter {
+        constructor(name) {
+            this.name = name
+        }
         upsert(...args) {
             return mocks.upsert(...args)
+        }
+        find(...args) {
+            return mocks.find(this.name, ...args)
+        }
+        destroy(...args) {
+            return mocks.destroy(this.name, ...args)
         }
     },
 }))
@@ -28,6 +39,8 @@ import {
     addSiteSession,
     getLegacySiteSessionCookieDomain,
     getSiteSessionCookieDomain,
+    siteSessionIpMismatch,
+    validateSiteSession,
 } from '../../src/utils/session/site-session.js'
 import {providerBaseDomain} from '../../src/utils/session/base-domain.js'
 
@@ -62,5 +75,78 @@ describe('site session cookie scope', () => {
             secure: true,
             maxAge: 3600000,
         })
+    })
+})
+
+describe('site session IP binding', () => {
+    const clientId = 'apps.webmail'
+    const record = (ip) => ({
+        jti: 'jti-1', sessionId: 'sess-1', accountId: 'acc',
+        domain: providerBaseDomain,
+        ...(ip ? {ip} : {}),
+    })
+    const ctx = (ip) => ({cookies: {get: () => 'jti-1'}, headers: {'x-forwarded-for': ip}})
+
+    const stubStores = (siteSession) => {
+        mocks.find.mockImplementation(async (name, id) => {
+            if (name === 'SiteSession' && id === 'jti-1') return siteSession
+            if (name === 'Session' && id === 'sess-1') return {authorizations: {[clientId]: {grantId: 'g'}}}
+            return undefined
+        })
+    }
+
+    beforeEach(() => {
+        globalThis.logger = {info: vi.fn(), error: vi.fn(), warn: vi.fn()}
+        mocks.find.mockReset()
+        mocks.destroy.mockReset()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('is inert unless SITE_SESSION_IP_BINDING is enabled', () => {
+        expect(siteSessionIpMismatch(record('1.1.1.1'), '2.2.2.2', {})).toBe(false)
+        expect(siteSessionIpMismatch(record('1.1.1.1'), '2.2.2.2', {SITE_SESSION_IP_BINDING: 'true'})).toBe(true)
+        expect(siteSessionIpMismatch(record('1.1.1.1'), '1.1.1.1', {SITE_SESSION_IP_BINDING: 'true'})).toBe(false)
+        // records issued before the flag was enabled carry no ip and fail closed
+        expect(siteSessionIpMismatch(record(undefined), '1.1.1.1', {SITE_SESSION_IP_BINDING: 'true'})).toBe(true)
+    })
+
+    it('stamps the issuing address on new site sessions', async () => {
+        await addSiteSession(
+            {cookies: {set: vi.fn()}, headers: {'x-forwarded-for': '1.1.1.1, 10.0.0.1'}},
+            {},
+            'session-id',
+            'account-id',
+            {clientId},
+        )
+        expect(mocks.upsert).toHaveBeenCalledWith(
+            'new-site-session-jti',
+            expect.objectContaining({ip: '1.1.1.1'}),
+            3600,
+        )
+    })
+
+    it('accepts a session presented from its issuing address', async () => {
+        vi.stubEnv('SITE_SESSION_IP_BINDING', 'true')
+        stubStores(record('1.1.1.1'))
+        await expect(validateSiteSession(ctx('1.1.1.1'), clientId))
+            .resolves.toMatchObject({jti: 'jti-1', ip: '1.1.1.1'})
+        expect(mocks.destroy).not.toHaveBeenCalled()
+    })
+
+    it('destroys a session presented from a different address', async () => {
+        vi.stubEnv('SITE_SESSION_IP_BINDING', 'true')
+        stubStores(record('1.1.1.1'))
+        await expect(validateSiteSession(ctx('2.2.2.2'), clientId)).resolves.toBeUndefined()
+        expect(mocks.destroy).toHaveBeenCalledWith('SiteSession', 'jti-1')
+    })
+
+    it('keeps prior behavior while the flag is off', async () => {
+        stubStores(record('1.1.1.1'))
+        await expect(validateSiteSession(ctx('2.2.2.2'), clientId))
+            .resolves.toMatchObject({jti: 'jti-1'})
+        expect(mocks.destroy).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
Implements the remaining hardening idea from #21 (idea 1, the issuer-host-scoped dashboard cookie, already shipped in c60f6aa).

- Every site session now records the client address (first x-forwarded-for hop) that it was issued to.
- Behind the new opt-in chart value `passmower.siteSessionIpBinding` (env `SITE_SESSION_IP_BINDING`, default off), `validateSiteSession` destroys a session presented from a different address and forces re-authentication, with an audit log entry.
- Legacy records without a stored address fail closed the same way once the flag is on; one fresh login rebinds them.
- Default-off because binding breaks legitimate network changes (mobile roaming, VPN toggles, CGNAT).

Unit tests cover the mismatch helper, address stamping, and all four validate paths. 253 unit tests pass; helm template renders.

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)