### PR TITLE
Surface recent access incidents to admins

### DIFF
--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
               value: {{ .Values.passmower.activityTracking.recentApplicationLimit | quote }}
             - name: CLIENT_INACTIVE_AFTER_DAYS
               value: {{ .Values.passmower.activityTracking.inactiveAfterDays | quote }}
+            - name: INCIDENTS_ENABLED
+              value: {{ .Values.passmower.incidents.enabled | quote }}
+            - name: INCIDENT_TTL_SECONDS
+              value: {{ .Values.passmower.incidents.ttlSeconds | quote }}
             - name: OIDC_PROVIDERS
               value: {{ .Values.passmower.oidcProviders | default dict | toJson | quote }}
             - name: REDIS_IP_FAMILY

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -93,6 +93,15 @@ passmower:
     recentApplicationLimit: 20
     inactiveAfterDays: 90
 
+  # Record denied-access events (a signed-in user tried to open an application
+  # their groups or account state do not allow) to Redis with a TTL and show
+  # them in the admin panel with a suggested fix. One record is kept per
+  # account/client/failure combination; repeats bump its counter and refresh
+  # the TTL.
+  incidents:
+    enabled: true
+    ttlSeconds: 604800
+
   # Generic OIDC upstream login providers. Add a provider-keyed entry — any
   # standards-compliant OIDC provider works (Google, GitLab, EntraID, Keycloak,
   # Okta, Authentik, Zitadel, ...). Each entry:

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -84,3 +84,27 @@ configuration. Passmower retains the resource and generated Secret, so setting
 it back to `false` restores the same client ID and credentials. Passmower does
 not automatically disable or delete inactive clients; use the condition or
 metric to drive an administrator-reviewed policy.
+
+## Recent access incidents
+
+When a signed-in user is denied access to an application — their groups do not
+satisfy the client's access policy, or their account state (approval, ToS,
+name, type) blocks the login — Passmower records the event to Redis and shows
+it in the admin panel under "Recent access incidents", together with a
+suggested fix (for group-policy denials, the client's allowed groups).
+
+Records are deduplicated per account/client/failure combination: repeats bump
+a counter and refresh the TTL. Recording is best-effort and never blocks the
+login flow. Nothing is written for anonymous traffic; incidents describe
+authenticated users hitting an access policy.
+
+```yaml
+passmower:
+  incidents:
+    enabled: true
+    # Seconds a record is retained after the last occurrence.
+    ttlSeconds: 604800
+```
+
+Incidents are an ephemeral admin convenience view. The audit log remains the
+durable record of the same denials.

--- a/frontend/src/Admin.vue
+++ b/frontend/src/Admin.vue
@@ -3,6 +3,7 @@
         <div class="card card-wide">
             <h1>Passmower admin</h1>
             <InviteUser />
+            <Incidents />
             <Accounts />
         </div>
     </main>
@@ -15,10 +16,12 @@ import Accounts from "@/components/Admin/Accounts.vue";
 import {mapActions} from "pinia";
 import {userAdminStore} from "./stores/admin";
 import InviteUser from "./components/Admin/InviteUser.vue";
+import Incidents from "./components/Admin/Incidents.vue";
 
 export default {
     components: {
       InviteUser,
+        Incidents,
         Accounts,
         WidgetContainerModal: container,
     },

--- a/frontend/src/components/Admin/Incidents.vue
+++ b/frontend/src/components/Admin/Incidents.vue
@@ -1,0 +1,65 @@
+<template>
+    <div class="profile-section" v-if="incidents.length">
+        <div class="profile-section-header">
+            <h2>Recent access incidents</h2>
+        </div>
+        <div class="item" v-for="incident in incidents" :key="incident.id">
+            <div class="item-details">
+                <h3>{{ incident.accountId || 'anonymous' }} → {{ incident.clientId }}</h3>
+                <p>
+                    {{ describeFailure(incident.failure) }}
+                    via {{ incident.source === 'forward-auth' ? 'forward auth' : 'OIDC login' }}
+                </p>
+                <p>
+                    Last seen <time :datetime="incident.lastSeenAt">{{ formatDate(incident.lastSeenAt) }}</time>
+                    <span v-if="incident.count > 1"> — {{ incident.count }} attempts since {{ formatDate(incident.firstSeenAt) }}</span>
+                    <span v-if="incident.sourceIp"> from {{ incident.sourceIp }}</span>
+                </p>
+                <p v-if="incident.failure === 'client_access_required' && incident.allowedGroups.length">
+                    Suggested fix: add the user to one of the allowed groups:
+                    <strong>{{ incident.allowedGroups.join(', ') }}</strong>
+                </p>
+                <p v-else-if="incident.failure === 'client_access_required' && incident.allowedUsers.length">
+                    Suggested fix: add the user to the client's allowed users list.
+                </p>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "Incidents",
+    data() {
+        return {
+            incidents: [],
+        }
+    },
+    created() {
+        fetch('/admin/api/incidents').then((r) => r.json()).then((r) => {
+            this.incidents = r.incidents ?? []
+        })
+    },
+    methods: {
+        formatDate(value) {
+            if (!value) return 'Never'
+            return new Intl.DateTimeFormat(undefined, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+            }).format(new Date(value))
+        },
+        describeFailure(failure) {
+            const descriptions = {
+                client_access_required: 'Not a member of an allowed group',
+                approval_required: 'Account is not approved',
+                name_required: 'Account has no name set',
+                tos_required: 'Terms of Service not accepted',
+                account_banned: 'Account is banned',
+                account_missing: 'Account no longer exists',
+                account_type_not_login_capable: 'Account type cannot sign in',
+            }
+            return descriptions[failure] ?? failure
+        },
+    },
+}
+</script>

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -16,6 +16,7 @@ import {getText} from "../utils/get-text.js";
 import {getUsernameSource} from "../utils/username-source.js";
 import {isEmailEnabled} from '../utils/email-configuration.js';
 import {getAccountTypeAccessFailure} from '../utils/user/account-type-access.js';
+import {listIncidents} from '../utils/session/incident-log.js';
 
 export default (provider) => {
     const router = new Router();
@@ -65,6 +66,12 @@ export default (provider) => {
         let accounts = await ctx.kubeOIDCUserService.listUsers()
         ctx.body = {
             accounts: accounts.map((acc) => acc.getProfileResponse(true, ctx.adminSession.accountId))
+        }
+    })
+
+    router.get('/admin/api/incidents', async (ctx, next) => {
+        ctx.body = {
+            incidents: await listIncidents(),
         }
     })
 

--- a/src/routes/forwardAuthRoutes.js
+++ b/src/routes/forwardAuthRoutes.js
@@ -8,6 +8,7 @@ import {enableAndGetRedirectUri} from "../utils/session/enable-and-get-redirect-
 import {responseType, scope} from "../models/oidc-middleware-client.js";
 import {getAccountAccessFailure} from '../utils/user/check-account-access.js';
 import {auditLog} from '../utils/session/audit-log.js';
+import {recordIncident} from '../utils/session/incident-log.js';
 
 export default (provider) => {
     const router = new Router();
@@ -60,6 +61,14 @@ export default (provider) => {
                 } else {
                     auditLog(ctx, {accountId: cookie.accountId, clientId, failure},
                         'Forward-auth account no longer satisfies access policy')
+                    await recordIncident(ctx, {
+                        source: 'forward-auth',
+                        accountId: cookie.accountId,
+                        clientId,
+                        failure,
+                        allowedGroups: client.allowedGroups,
+                        allowedUsers: client.allowedUsers,
+                    })
                 }
             }
         } else {

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -27,6 +27,7 @@ import {checkAccountGroups} from "../utils/user/check-account-groups.js";
 import {enableAndGetRedirectUri} from "../utils/session/enable-and-get-redirect-uri.js";
 import {clientId, responseType, scope} from "../utils/session/self-oidc-client.js";
 import {auditLog} from "../utils/session/audit-log.js";
+import {recordIncident} from "../utils/session/incident-log.js";
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import validator, {checkEmail, checkRealName, checkUsername} from "../utils/session/validator.js";
 import {isEmailEnabled} from '../utils/email-configuration.js';
@@ -247,6 +248,14 @@ export default (provider) => {
                     });
                 }
                 auditLog(ctx, {interactionDetails}, 'User does not satisfy client access policy')
+                await recordIncident(ctx, {
+                    source: 'oidc-login',
+                    accountId: ctx.currentAccount?.accountId,
+                    clientId: params.client_id,
+                    failure: 'client_access_required',
+                    allowedGroups: client?.allowedGroups,
+                    allowedUsers: client?.allowedUsers,
+                })
                 return render(provider, ctx, 'message', 'Access denied', {
                     message: 'Your account is not permitted to access this resource'
                 }, true)

--- a/src/utils/session/incident-log.js
+++ b/src/utils/session/incident-log.js
@@ -1,0 +1,63 @@
+import RedisAdapter from "../../adapters/redis.js";
+
+const INDEX = 'index'
+const DEFAULT_TTL_SECONDS = 7 * 24 * 3600
+const LIST_LIMIT = 100
+
+export const incidentsEnabled = (env = process.env) => env.INCIDENTS_ENABLED !== 'false'
+
+export const incidentTtlSeconds = (env = process.env) => {
+    const value = Number.parseInt(env.INCIDENT_TTL_SECONDS ?? '', 10)
+    return Number.isFinite(value) && value > 0 ? value : DEFAULT_TTL_SECONDS
+}
+
+const clientIp = (ctx) =>
+    ctx.headers?.['x-forwarded-for']?.split(',')[0]?.trim() || ctx.request?.ip || ctx.ip
+
+// Denied-access events surfaced to admins (#63). One record per
+// account/client/failure combination: repeats bump the counter and refresh the
+// TTL instead of growing the store. Recording is best-effort and must never
+// break the login flow itself.
+export const recordIncident = async (ctx, {source, accountId, clientId, failure, allowedGroups, allowedUsers}) => {
+    if (!incidentsEnabled()) return
+    try {
+        const redis = new RedisAdapter('Incident')
+        const id = [source, accountId ?? 'anonymous', clientId, failure].join(':')
+        const existing = await redis.find(id)
+        const now = new Date().toISOString()
+        await redis.upsert(id, {
+            id,
+            source,
+            accountId,
+            clientId,
+            failure,
+            allowedGroups: allowedGroups ?? [],
+            allowedUsers: allowedUsers ?? [],
+            sourceIp: clientIp(ctx),
+            count: (existing?.count ?? 0) + 1,
+            firstSeenAt: existing?.firstSeenAt ?? now,
+            lastSeenAt: now,
+        }, incidentTtlSeconds())
+        await redis.appendToSet(INDEX, id)
+    } catch (error) {
+        globalThis.logger?.warn({error: error.message}, 'Failed to record access incident')
+    }
+}
+
+export const listIncidents = async () => {
+    const redis = new RedisAdapter('Incident')
+    const ids = await redis.getSetMembers(INDEX) ?? []
+    const incidents = []
+    await Promise.all(ids.map(async (id) => {
+        const incident = await redis.find(id)
+        if (incident) {
+            incidents.push(incident)
+        } else {
+            // The record expired; drop the dangling index entry.
+            await redis.removeFromSet(INDEX, id)
+        }
+    }))
+    return incidents
+        .sort((a, b) => new Date(b.lastSeenAt) - new Date(a.lastSeenAt))
+        .slice(0, LIST_LIMIT)
+}

--- a/test/unit/incident-log.test.js
+++ b/test/unit/incident-log.test.js
@@ -1,0 +1,104 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const store = vi.hoisted(() => ({
+    records: new Map(),
+    index: new Set(),
+}))
+
+vi.mock('../../src/adapters/redis.js', () => ({
+    default: class RedisAdapter {
+        constructor(name) {
+            this.name = name
+        }
+        async upsert(id, payload, ttl) {
+            store.records.set(id, {payload, ttl})
+        }
+        async find(id) {
+            return store.records.get(id)?.payload
+        }
+        async appendToSet(id, item) {
+            store.index.add(item)
+        }
+        async removeFromSet(id, item) {
+            store.index.delete(item)
+        }
+        async getSetMembers() {
+            return [...store.index]
+        }
+    },
+}))
+
+import {incidentTtlSeconds, listIncidents, recordIncident} from '../../src/utils/session/incident-log.js'
+
+const ctx = {headers: {'x-forwarded-for': '1.1.1.1, 10.0.0.1'}}
+const incident = {
+    source: 'oidc-login',
+    accountId: 'alice',
+    clientId: 'grafana',
+    failure: 'client_access_required',
+    allowedGroups: ['passmower:grafana-users'],
+}
+
+describe('incident log', () => {
+    beforeEach(() => {
+        globalThis.logger = {info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+        store.records.clear()
+        store.index.clear()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('honors the TTL configuration and its default', () => {
+        expect(incidentTtlSeconds({})).toBe(604800)
+        expect(incidentTtlSeconds({INCIDENT_TTL_SECONDS: '3600'})).toBe(3600)
+        expect(incidentTtlSeconds({INCIDENT_TTL_SECONDS: 'bogus'})).toBe(604800)
+    })
+
+    it('records a denied access with the proposed-fix context', async () => {
+        await recordIncident(ctx, incident)
+
+        const [listed] = await listIncidents()
+        expect(listed).toMatchObject({
+            source: 'oidc-login',
+            accountId: 'alice',
+            clientId: 'grafana',
+            failure: 'client_access_required',
+            allowedGroups: ['passmower:grafana-users'],
+            sourceIp: '1.1.1.1',
+            count: 1,
+        })
+        expect(listed.firstSeenAt).toBe(listed.lastSeenAt)
+    })
+
+    it('deduplicates repeats into a counter instead of new records', async () => {
+        await recordIncident(ctx, incident)
+        await recordIncident(ctx, incident)
+        await recordIncident(ctx, {...incident, clientId: 'harbor'})
+
+        const listed = await listIncidents()
+        expect(listed).toHaveLength(2)
+        expect(listed.find(i => i.clientId === 'grafana').count).toBe(2)
+        expect(listed.find(i => i.clientId === 'harbor').count).toBe(1)
+    })
+
+    it('drops dangling index entries for expired records', async () => {
+        await recordIncident(ctx, incident)
+        store.records.clear() // simulate TTL expiry
+
+        await expect(listIncidents()).resolves.toEqual([])
+        expect(store.index.size).toBe(0)
+    })
+
+    it('can be disabled and never throws into the login flow', async () => {
+        vi.stubEnv('INCIDENTS_ENABLED', 'false')
+        await recordIncident(ctx, incident)
+        expect(store.records.size).toBe(0)
+
+        vi.unstubAllEnvs()
+        store.records.set = () => { throw new Error('redis down') }
+        await expect(recordIncident(ctx, incident)).resolves.toBeUndefined()
+        expect(globalThis.logger.warn).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Implements #63: when a signed-in user is denied access to an application, the event is saved to Redis with a TTL and shown in the admin panel with a proposed fix.

- New `incident-log` utility: one record per account/client/failure combination — repeats bump a counter and refresh the TTL (default 7 days, `passmower.incidents.ttlSeconds`). Recording is best-effort and never blocks the login flow; `passmower.incidents.enabled: false` turns it off.
- Recorded at both denial points: the OIDC interaction `groups_required` denial and the forward-auth access-policy recheck. Records carry source, account, client, failure reason, source IP, and the client's allowed groups/users.
- `GET /admin/api/incidents` (admin session required) and a "Recent access incidents" section in the admin panel, suggesting the group to add the user to for group-policy denials.
- Documented in docs/audit-logging.md — incidents are the ephemeral convenience view; the audit log stays the durable record.

253 unit tests pass (5 new); frontend eslint clean; helm template renders.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)