### PR TITLE
Notify users of sign-ins and impersonation

### DIFF
--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -116,6 +116,10 @@ spec:
               value: {{ .Values.passmower.incidents.enabled | quote }}
             - name: INCIDENT_TTL_SECONDS
               value: {{ .Values.passmower.incidents.ttlSeconds | quote }}
+            - name: NOTIFY_ON_LOGIN
+              value: {{ .Values.passmower.notifications.onLogin | quote }}
+            - name: NOTIFY_ON_IMPERSONATION
+              value: {{ .Values.passmower.notifications.onImpersonation | quote }}
             - name: OIDC_PROVIDERS
               value: {{ .Values.passmower.oidcProviders | default dict | toJson | quote }}
             - name: REDIS_IP_FAMILY

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -108,6 +108,18 @@ passmower:
     enabled: true
     ttlSeconds: 604800
 
+  # Security notifications broadcast to the affected user over every channel
+  # they have: email (when emailEnabled) and a Slack DM (when
+  # slackClientSecretRef is configured and the user is linked). Delivery is
+  # best-effort and never blocks the flow that triggered it.
+  notifications:
+    # Notify on every fresh interactive sign-in (method, source address,
+    # browser, OS). Off by default: noisy for active users.
+    onLogin: false
+    # Notify the user when an administrator activates an impersonation
+    # session for their account.
+    onImpersonation: true
+
   # Generic OIDC upstream login providers. Add a provider-keyed entry — any
   # standards-compliant OIDC provider works (Google, GitLab, EntraID, Keycloak,
   # Okta, Authentik, Zitadel, ...). Each entry:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,35 @@
+# User notifications
+
+Passmower can send short security notices to the affected user over every
+channel they have:
+
+- **Email** — the account's primary address, when email delivery is enabled
+  (`passmower.emailEnabled`).
+- **Slack DM** — when the Slack workspace integration is configured
+  (`slackClientSecretRef`) and the account is linked to a Slack user.
+
+Delivery is best-effort. A notification failure is logged and never affects
+the flow that triggered it. Accounts with neither channel simply receive
+nothing.
+
+## Events
+
+```yaml
+passmower:
+  notifications:
+    onLogin: false
+    onImpersonation: true
+```
+
+- `onLogin` (env `NOTIFY_ON_LOGIN`, default off): every fresh interactive
+  sign-in, with the login method, source address, browser, and OS as reported
+  by the proxy headers. Off by default because it is noisy for active users.
+  Impersonated sign-ins do not trigger it; they are covered by the dedicated
+  impersonation notification.
+- `onImpersonation` (env `NOTIFY_ON_IMPERSONATION`, default on): the moment an
+  administrator activates an impersonation link for the account, naming the
+  administrator. Complements the incognito one-time impersonation links — the
+  user is told who is acting as them and when.
+
+The audit log independently records the same events regardless of these
+settings; notifications are user-facing transparency, not the audit trail.

--- a/src/services/notification-service.js
+++ b/src/services/notification-service.js
@@ -1,0 +1,32 @@
+import EmailAdapter from "../adapters/email.js";
+import {SlackAdapter} from "../adapters/slack.js";
+import {isEmailEnabled} from "../utils/email-configuration.js";
+
+export const loginNotificationsEnabled = (env = process.env) => env.NOTIFY_ON_LOGIN === 'true'
+export const impersonationNotificationsEnabled = (env = process.env) => env.NOTIFY_ON_IMPERSONATION !== 'false'
+
+// Broadcast a short security notice to every channel the account has: email
+// (when delivery is enabled) and a Slack DM (when the workspace integration is
+// configured and the user is linked). Best-effort: a notification failure must
+// never affect the flow that triggered it.
+export const notifyAccount = async (account, subject, text, {
+    emailAdapter = new EmailAdapter(),
+    slackAdapter = new SlackAdapter(),
+    env = process.env,
+} = {}) => {
+    if (!account) return
+    const deliveries = []
+    if (isEmailEnabled(env) && account.primaryEmail) {
+        deliveries.push(emailAdapter.sendMail(account.primaryEmail, subject, text)
+            .catch(error => globalThis.logger?.warn(
+                {error: error.message, accountId: account.accountId},
+                'Failed to send notification email')))
+    }
+    if (env.SLACK_TOKEN && account.slackId) {
+        deliveries.push(slackAdapter.sendMessage(account.slackId, `*${subject}*\n${text}`)
+            .catch(error => globalThis.logger?.warn(
+                {error: error.message, accountId: account.accountId},
+                'Failed to send notification Slack message')))
+    }
+    await Promise.all(deliveries)
+}

--- a/src/services/session-service.js
+++ b/src/services/session-service.js
@@ -6,6 +6,7 @@ import instance from "oidc-provider/lib/helpers/weak_cache.js";
 import {parseRequestMetadata} from "../utils/session/parse-request-headers.js";
 import {canImpersonateAccount, getAccountTypeAccessFailure} from '../utils/user/account-type-access.js';
 import {auditLog} from '../utils/session/audit-log.js';
+import {impersonationNotificationsEnabled, notifyAccount} from './notification-service.js';
 
 export class SessionService {
     constructor(provider) {
@@ -206,6 +207,12 @@ export class SessionService {
         }
         impersonation.activated = true
         await this.impersonationRedis.upsert(jti, impersonation, instance(this.provider).configuration.ttl.Impersonation)
+        if (impersonationNotificationsEnabled()) {
+            const account = await Account.findAccount(ctx, impersonation.accountId)
+            // Fire-and-forget: notifyAccount never rejects.
+            void notifyAccount(account, 'Your Passmower account is being impersonated',
+                `Administrator ${impersonation.actor} activated an impersonation session for your account ${impersonation.accountId} on ${new URL(process.env.ISSUER_URL).host}. Contact an administrator if this is unexpected.`)
+        }
         ctx.cookies.set(
             this.provider.cookieName('impersonation'),
             jti,

--- a/src/utils/user/get-login-result.js
+++ b/src/utils/user/get-login-result.js
@@ -1,5 +1,7 @@
 import {auditLog} from "../session/audit-log.js";
 import {getAccountTypeAccessFailure} from './account-type-access.js';
+import {parseRequestMetadata} from '../session/parse-request-headers.js';
+import {loginNotificationsEnabled, notifyAccount} from '../../services/notification-service.js';
 
 export default async (ctx, provider, account, method, {impersonation = false} = {}) => {
     const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res)
@@ -23,6 +25,18 @@ export default async (ctx, provider, account, method, {impersonation = false} = 
             }
         }
         auditLog(ctx, {interactionDetails, method, account}, 'User logged in')
+        // Impersonated sign-ins are announced by the dedicated impersonation
+        // notification instead. Fire-and-forget: notifyAccount never rejects.
+        if (!impersonation && loginNotificationsEnabled()) {
+            const request = parseRequestMetadata(ctx.headers)
+            const os = request.os?.startsWith('undefined') ? undefined : request.os
+            const location = [request.ip && `from ${request.ip}`,
+                request.browser && `using ${request.browser}`,
+                os && `on ${os}`].filter(Boolean).join(' ')
+            void notifyAccount(account,
+                `New sign-in to ${new URL(process.env.ISSUER_URL).host}`,
+                `Your account ${account.accountId} signed in via ${method}${location ? ' ' + location : ''}. If this was not you, end your sessions on your profile page and contact an administrator.`)
+        }
         return {
             login: {
                 accountId: account.accountId,

--- a/test/unit/notification-service.test.js
+++ b/test/unit/notification-service.test.js
@@ -1,0 +1,57 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+    impersonationNotificationsEnabled,
+    loginNotificationsEnabled,
+    notifyAccount,
+} from '../../src/services/notification-service.js'
+
+const account = {accountId: 'alice', primaryEmail: 'alice@example.com', slackId: 'U123'}
+
+describe('notification service', () => {
+    let emailAdapter, slackAdapter
+
+    beforeEach(() => {
+        globalThis.logger = {info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+        emailAdapter = {sendMail: vi.fn().mockResolvedValue({})}
+        slackAdapter = {sendMessage: vi.fn().mockResolvedValue({})}
+    })
+
+    it('gates each event on its own flag with the intended defaults', () => {
+        expect(loginNotificationsEnabled({})).toBe(false)
+        expect(loginNotificationsEnabled({NOTIFY_ON_LOGIN: 'true'})).toBe(true)
+        expect(impersonationNotificationsEnabled({})).toBe(true)
+        expect(impersonationNotificationsEnabled({NOTIFY_ON_IMPERSONATION: 'false'})).toBe(false)
+    })
+
+    it('broadcasts to every channel the account has', async () => {
+        await notifyAccount(account, 'Subject', 'Body',
+            {emailAdapter, slackAdapter, env: {SLACK_TOKEN: 'token'}})
+
+        expect(emailAdapter.sendMail).toHaveBeenCalledWith('alice@example.com', 'Subject', 'Body')
+        expect(slackAdapter.sendMessage).toHaveBeenCalledWith('U123', '*Subject*\nBody')
+    })
+
+    it('skips channels the account or deployment does not have', async () => {
+        await notifyAccount({accountId: 'bob', slackId: 'U9'}, 'S', 'B',
+            {emailAdapter, slackAdapter, env: {SLACK_TOKEN: 'token'}})
+        expect(emailAdapter.sendMail).not.toHaveBeenCalled()
+        expect(slackAdapter.sendMessage).toHaveBeenCalled()
+
+        slackAdapter.sendMessage.mockClear()
+        await notifyAccount(account, 'S', 'B',
+            {emailAdapter, slackAdapter, env: {EMAIL_ENABLED: 'false'}})
+        expect(slackAdapter.sendMessage).not.toHaveBeenCalled()
+
+        await expect(notifyAccount(undefined, 'S', 'B', {emailAdapter, slackAdapter, env: {}}))
+            .resolves.toBeUndefined()
+    })
+
+    it('never rejects when a channel fails, only logs', async () => {
+        emailAdapter.sendMail.mockRejectedValue(new Error('smtp down'))
+        slackAdapter.sendMessage.mockRejectedValue(new Error('slack down'))
+
+        await expect(notifyAccount(account, 'S', 'B',
+            {emailAdapter, slackAdapter, env: {SLACK_TOKEN: 'token'}})).resolves.toBeUndefined()
+        expect(globalThis.logger.warn).toHaveBeenCalledTimes(2)
+    })
+})


### PR DESCRIPTION
Implements #48, scoped to the two listed events:

- New notification service broadcasting a short security notice to every channel the account has: primary email (when `emailEnabled`) and a Slack DM (when `slackClientSecretRef` is configured and the user is linked). Best-effort — a delivery failure is logged and never affects the triggering flow.
- `passmower.notifications.onLogin` (env `NOTIFY_ON_LOGIN`, default **off**): every fresh interactive sign-in with method, source address, browser, and OS. Impersonated sign-ins are excluded (covered by the next event).
- `passmower.notifications.onImpersonation` (env `NOTIFY_ON_IMPERSONATION`, default **on**): fires when an administrator activates an impersonation link, naming the administrator — complements the incognito one-time impersonation links with user-facing transparency.
- Documented in `docs/notifications.md`; the audit log independently records the same events regardless of these settings.

262 unit tests pass (4 new); helm template renders.

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)