### PR TITLE
Expose usage metrics

### DIFF
--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -116,6 +116,8 @@ spec:
               value: {{ .Values.passmower.incidents.enabled | quote }}
             - name: INCIDENT_TTL_SECONDS
               value: {{ .Values.passmower.incidents.ttlSeconds | quote }}
+            - name: METRICS_GROUP_MEMBERSHIP
+              value: {{ .Values.passmower.metrics.groupMembershipCounts | quote }}
             - name: OIDC_PROVIDERS
               value: {{ .Values.passmower.oidcProviders | default dict | toJson | quote }}
             - name: REDIS_IP_FAMILY

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -108,6 +108,12 @@ passmower:
     enabled: true
     ttlSeconds: 604800
 
+  # Prometheus metrics served on :9090/metrics; see docs/metrics.md.
+  metrics:
+    # Per-group member-count gauge (passmower_group_members). Off by default:
+    # group memberships can leak sensitive information into Prometheus.
+    groupMembershipCounts: false
+
   # Generic OIDC upstream login providers. Add a provider-keyed entry — any
   # standards-compliant OIDC provider works (Google, GitLab, EntraID, Keycloak,
   # Okta, Authentik, Zitadel, ...). Each entry:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,34 @@
+# Prometheus metrics
+
+Passmower serves Prometheus metrics on port `9090` at `/metrics` (the same
+listener also serves `/health`). Default Node.js process metrics are included;
+every series carries `instance` (the issuer URL) and `deployment` labels.
+
+## Usage metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `passmower_authorization_success_count` | counter | `client_id`, `kind` | Successful application authorizations since process start. |
+| `passmower_active_sessions` | gauge | — | Stored OIDC provider sessions, computed from Redis at scrape time. |
+| `passmower_active_users` | gauge | — | Unique accounts with at least one active session. Anonymous/pre-login sessions count toward sessions but not users. |
+| `passmower_group_members` | gauge | `group` | Accounts per group, updated on user reconciliation. **Disabled by default** — enable with `passmower.metrics.groupMembershipCounts` only when your monitoring stack may hold group-membership information. |
+
+Request-rate style metrics deliberately stay with the ingress/proxy layer
+(e.g. Traefik service metrics) instead of being duplicated here.
+
+## Health and error metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `passmower_oidc_client_last_used_timestamp_seconds` | gauge | `kind`, `namespace`, `client` | Latest successful OIDC activity per client, zero if never used. |
+| `passmower_oidc_user_email_conflicts` | gauge | — | OIDCUser resources rejected because an older user owns a claimed email. |
+| `passmower_non_existent_client_request_count` | counter | `in_cluster` | Authentication requests naming an unknown client ID. |
+| `passmower_invalid_client_request_count` | counter | `client_id`, `reason`, `in_cluster` | Invalid authentication requests. |
+| `passmower_invalid_userinfo_request_count` | counter | `reason`, `in_cluster` | Invalid userinfo endpoint requests. |
+| `passmower_invalid_token_request_count` | counter | `reason`, `in_cluster` | Invalid token endpoint requests. |
+
+```yaml
+passmower:
+  metrics:
+    groupMembershipCounts: false
+```

--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -251,6 +251,24 @@ function uidKeyFor(uid) {
     return `uid:${uid}`;
 }
 
+// Read the raw values of every key matching `pattern` (full key names,
+// including the "oidc:" prefix). SCAN's MATCH argument is not affected by the
+// ioredis keyPrefix, but MGET arguments are, so the prefix is stripped before
+// reading.
+export async function scanKeyValues(pattern, {batch = 500} = {}) {
+    const c = getClient();
+    const keys = [];
+    let cursor = '0';
+    do {
+        const [next, found] = await c.scan(cursor, 'MATCH', pattern, 'COUNT', batch);
+        cursor = next;
+        keys.push(...found);
+    } while (cursor !== '0');
+    if (!keys.length) return [];
+    const prefix = getRedisOptions().keyPrefix;
+    return await c.mget(keys.map(key => key.startsWith(prefix) ? key.slice(prefix.length) : key));
+}
+
 class RedisAdapter {
     constructor(name) {
         this.name = name;

--- a/src/providers/setup-event-listeners.js
+++ b/src/providers/setup-event-listeners.js
@@ -82,6 +82,7 @@ export default (provider) => {
         const activity = activityFromContext(ctx)
         if (activity) {
             activityTracker.record(activity)
+            globalThis.metrics?.authorizationSuccess?.inc({client_id: activity.clientId, kind: activity.clientKind})
             audit.write({
                 event: 'application.login.succeeded',
                 result: 'success',

--- a/src/routes/metrics-server.js
+++ b/src/routes/metrics-server.js
@@ -2,6 +2,7 @@ import {collectDefaultMetrics, Gauge, register} from "prom-client";
 import Koa from 'koa';
 import Router from "@koa/router";
 import { setupOidcMetrics } from "../utils/session/handle-oidc-flow-metrics.js";
+import { setupUsageMetrics } from "../utils/usage-metrics.js";
 import {KubeOIDCUserService} from "../services/kube-oidc-user-service.js";
 import RedisAdapter from "../adapters/redis.js";
 
@@ -37,6 +38,7 @@ export default async () => {
         help: 'Number of OIDCUser resources rejected because an older user owns one or more claimed emails',
     })
     setupOidcMetrics()
+    setupUsageMetrics()
 
     const userService = new KubeOIDCUserService();
 

--- a/src/services/kube-oidc-user-service.js
+++ b/src/services/kube-oidc-user-service.js
@@ -6,6 +6,7 @@ import mergeWith from "lodash/mergeWith.js";
 import cloneDeep from "lodash/cloneDeep.js";
 import isArray from "lodash/isArray.js";
 import {assessEmailOwnership, canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
+import {setGroupMembershipMetrics} from '../utils/usage-metrics.js';
 
 // Custom merge that replaces arrays instead of merging by index
 function mergeReplacingArrays(objValue, srcValue) {
@@ -140,6 +141,7 @@ export class KubeOIDCUserService {
             }
         }
         globalThis.metrics?.oidcUserEmailConflicts?.set(conflictedUsers)
+        setGroupMembershipMetrics(accounts)
         if (errors.length) throw new AggregateError(errors, `Failed to reconcile ${errors.length} OIDCUser email condition(s)`)
         return {accounts, ownership, conflictedUsers}
     }

--- a/src/utils/usage-metrics.js
+++ b/src/utils/usage-metrics.js
@@ -1,0 +1,78 @@
+import {Counter, Gauge} from "prom-client";
+import {scanKeyValues} from "../adapters/redis.js";
+
+export const groupMetricsEnabled = (env = process.env) => env.METRICS_GROUP_MEMBERSHIP === 'true'
+
+// Aggregate stored provider sessions into totals: every Session record counts
+// as an active session; unique accountIds across them count as active users.
+// Anonymous/pre-login sessions carry no accountId and only count as sessions.
+export const aggregateSessionUsage = (payloads) => {
+    const users = new Set()
+    let sessions = 0
+    for (const raw of payloads) {
+        if (!raw) continue
+        sessions++
+        try {
+            const accountId = JSON.parse(raw)?.accountId
+            if (accountId) users.add(accountId)
+        } catch {
+            // An unreadable record still counts as a session.
+        }
+    }
+    return {sessions, users: users.size}
+}
+
+export const countGroupMembers = (accounts) => {
+    const counts = new Map()
+    for (const account of accounts ?? []) {
+        for (const group of account.groups ?? []) {
+            const name = `${group.prefix}:${group.name}`
+            counts.set(name, (counts.get(name) ?? 0) + 1)
+        }
+    }
+    return counts
+}
+
+// Called from user reconciliation, which already holds the full account list.
+// Reset before setting so removed groups do not linger with stale counts.
+export const setGroupMembershipMetrics = (accounts, env = process.env) => {
+    const gauge = globalThis.metrics?.groupMembers
+    if (!gauge || !groupMetricsEnabled(env)) return
+    gauge.reset()
+    for (const [group, members] of countGroupMembers(accounts)) {
+        gauge.set({group}, members)
+    }
+}
+
+export const setupUsageMetrics = () => {
+    globalThis.metrics.authorizationSuccess = new Counter({
+        name: 'passmower_authorization_success_count',
+        help: 'Successful application authorizations, by client',
+        labelNames: ['client_id', 'kind'],
+    })
+    const activeUsers = new Gauge({
+        name: 'passmower_active_users',
+        help: 'Unique accounts with at least one active OIDC provider session',
+    })
+    new Gauge({
+        name: 'passmower_active_sessions',
+        help: 'Active OIDC provider sessions',
+        async collect() {
+            try {
+                // One Redis scan per scrape feeds both gauges.
+                const usage = aggregateSessionUsage(await scanKeyValues('oidc:Session:*'))
+                this.set(usage.sessions)
+                activeUsers.set(usage.users)
+            } catch (error) {
+                globalThis.logger?.warn({error: error.message}, 'Failed to collect session usage metrics')
+            }
+        },
+    })
+    if (groupMetricsEnabled()) {
+        globalThis.metrics.groupMembers = new Gauge({
+            name: 'passmower_group_members',
+            help: 'OIDCUser accounts per group, updated on user reconciliation',
+            labelNames: ['group'],
+        })
+    }
+}

--- a/test/unit/usage-metrics.test.js
+++ b/test/unit/usage-metrics.test.js
@@ -1,0 +1,66 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+    aggregateSessionUsage,
+    countGroupMembers,
+    groupMetricsEnabled,
+    setGroupMembershipMetrics,
+} from '../../src/utils/usage-metrics.js'
+
+describe('usage metrics', () => {
+    it('aggregates sessions and unique users from stored session payloads', () => {
+        const payloads = [
+            JSON.stringify({jti: 's1', accountId: 'alice'}),
+            JSON.stringify({jti: 's2', accountId: 'alice'}),
+            JSON.stringify({jti: 's3', accountId: 'bob'}),
+            JSON.stringify({jti: 's4'}), // anonymous / pre-login
+            'not json',                  // unreadable record still counts as a session
+            null,                        // expired between SCAN and MGET
+        ]
+        expect(aggregateSessionUsage(payloads)).toEqual({sessions: 5, users: 2})
+        expect(aggregateSessionUsage([])).toEqual({sessions: 0, users: 0})
+    })
+
+    it('counts members per prefixed group', () => {
+        const accounts = [
+            {groups: [{prefix: 'passmower', name: 'admins'}, {prefix: 'github.com', name: 'devs'}]},
+            {groups: [{prefix: 'passmower', name: 'admins'}]},
+            {groups: []},
+            {},
+        ]
+        expect(Object.fromEntries(countGroupMembers(accounts))).toEqual({
+            'passmower:admins': 2,
+            'github.com:devs': 1,
+        })
+    })
+
+    describe('group membership gauge', () => {
+        const gauge = {reset: vi.fn(), set: vi.fn()}
+
+        beforeEach(() => {
+            gauge.reset.mockClear()
+            gauge.set.mockClear()
+            globalThis.metrics = {groupMembers: gauge}
+        })
+
+        afterEach(() => {
+            delete globalThis.metrics
+        })
+
+        it('is opt-in via METRICS_GROUP_MEMBERSHIP', () => {
+            expect(groupMetricsEnabled({})).toBe(false)
+            expect(groupMetricsEnabled({METRICS_GROUP_MEMBERSHIP: 'true'})).toBe(true)
+
+            setGroupMembershipMetrics([{groups: [{prefix: 'p', name: 'g'}]}], {})
+            expect(gauge.set).not.toHaveBeenCalled()
+        })
+
+        it('resets before setting so removed groups do not linger', () => {
+            setGroupMembershipMetrics(
+                [{groups: [{prefix: 'p', name: 'g'}]}],
+                {METRICS_GROUP_MEMBERSHIP: 'true'},
+            )
+            expect(gauge.reset).toHaveBeenCalledOnce()
+            expect(gauge.set).toHaveBeenCalledWith({group: 'p:g'}, 1)
+        })
+    })
+})


### PR DESCRIPTION
Implements #50 along the issue's initial ideas:

- `passmower_authorization_success_count{client_id,kind}` — successful application authorizations, incremented from the `authorization.success` event.
- `passmower_active_sessions` and `passmower_active_users` — computed from Redis at scrape time with a single SCAN+MGET pass shared by both gauges; anonymous/pre-login sessions count toward sessions but not users. Collection failures log a warning instead of failing the scrape.
- `passmower_group_members{group}` — opt-in via `passmower.metrics.groupMembershipCounts` (default **off**, as the issue requests, since group membership can leak sensitive information). Updated during user reconciliation, which already holds the full account list — no extra Kubernetes traffic.
- Request-rate metrics intentionally stay with the ingress layer per the issue's no-duplication note.
- `docs/metrics.md` documents all `passmower_*` metrics, existing ones included.

262 unit tests pass (4 new); helm template renders.

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)