### PR TITLE
Support unauthenticated SMTP relays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | `OIDC_PROVIDERS` | JSON object of generic upstream OIDC providers keyed by provider slug. |
 | `OIDC_ALLOW_INSECURE_UPSTREAM` | Permit `http://` upstreams (local dev only). |
 | `GITHUB_ENABLED`, `GH_CLIENT_ID/SECRET`, `GITHUB_ORGANIZATION` | GitHub upstream. |
-| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Global email capability. `false` disables all delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email. When enabled (the default), all SMTP variables except `EMAIL_FROM` are required at boot. |
+| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Global email capability. `false` disables all delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email. When enabled (the default), `EMAIL_HOST/PORT/SSL` are required at boot; `EMAIL_USERNAME/PASSWORD` are optional as a pair (unauthenticated relay), with `EMAIL_FROM` required when they are absent. |
 | `WEBAUTHN_ENABLED`, `WEBAUTHN_RP_NAME` | Passkeys. |
 | `SLACK_TOKEN` | Slack integration. |
 | `GROUP_PREFIX`, `ADMIN_GROUP`, `REQUIRED_GROUP` | Group/authorization policy. |

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -29,7 +29,11 @@ passmower:
 ```
 
 When email is enabled, Passmower fails at startup unless `EMAIL_HOST`,
-`EMAIL_PORT`, `EMAIL_SSL`, `EMAIL_USERNAME`, and `EMAIL_PASSWORD` are present.
+`EMAIL_PORT`, and `EMAIL_SSL` are present. SMTP authentication is optional for
+unauthenticated relays (an internal relay, MailHog in dev): `EMAIL_USERNAME`
+and `EMAIL_PASSWORD` must be set together or not at all, and without a username
+`EMAIL_FROM` is required as the sender address. When no credentials are
+configured, Nodemailer skips AUTH entirely.
 The Helm chart likewise requires `passmower.emailCredentialsSecretRef`. A
 temporary ToS receipt failure is logged but does not undo acceptance or block
 login; magic-link delivery failures remain fatal to that login attempt.

--- a/src/adapters/email.js
+++ b/src/adapters/email.js
@@ -11,16 +11,20 @@ class EmailAdapter {
             host: process.env.EMAIL_HOST,
             port: process.env.EMAIL_PORT,
             ssl: process.env.EMAIL_SSL,
-            auth: {
+            // Unauthenticated relays (MailHog in dev) advertise no AUTH;
+            // passing credentials anyway makes Nodemailer fail the handshake.
+            auth: process.env.EMAIL_USERNAME ? {
                 user: process.env.EMAIL_USERNAME,
                 pass: process.env.EMAIL_PASSWORD
-            }
+            } : undefined
         })
         return await this.#transporter.sendMail({
             to,
             subject,
             headers: {
-                From: `${process.env.EMAIL_FROM || process.env.EMAIL_USERNAME} <${process.env.EMAIL_USERNAME}>`,
+                From: process.env.EMAIL_USERNAME
+                    ? `${process.env.EMAIL_FROM || process.env.EMAIL_USERNAME} <${process.env.EMAIL_USERNAME}>`
+                    : process.env.EMAIL_FROM,
             },
             text: textContent,
             html: htmlContent

--- a/src/utils/email-configuration.js
+++ b/src/utils/email-configuration.js
@@ -4,8 +4,6 @@ const requiredEmailEnvironment = [
     'EMAIL_HOST',
     'EMAIL_PORT',
     'EMAIL_SSL',
-    'EMAIL_USERNAME',
-    'EMAIL_PASSWORD',
 ]
 
 export function validateEmailConfiguration(env = process.env) {
@@ -13,5 +11,14 @@ export function validateEmailConfiguration(env = process.env) {
     const missing = requiredEmailEnvironment.filter(key => !env[key])
     if (missing.length) {
         throw new Error(`Email is enabled but required configuration is missing: ${missing.join(', ')}`)
+    }
+    // Unauthenticated SMTP (an internal relay, MailHog in dev) is legal:
+    // credentials are optional, but must come as a pair, and without a
+    // username there is no fallback sender address, so EMAIL_FROM is required.
+    if (Boolean(env.EMAIL_USERNAME) !== Boolean(env.EMAIL_PASSWORD)) {
+        throw new Error('EMAIL_USERNAME and EMAIL_PASSWORD must be set together')
+    }
+    if (!env.EMAIL_USERNAME && !env.EMAIL_FROM) {
+        throw new Error('EMAIL_FROM is required when SMTP authentication is not configured')
     }
 }

--- a/test/unit/email-adapter.test.js
+++ b/test/unit/email-adapter.test.js
@@ -41,4 +41,21 @@ describe('EmailAdapter', () => {
             .rejects.toThrow('SMTP unavailable')
         expect(mocks.createTransport).toHaveBeenCalledOnce()
     })
+
+    it('omits AUTH and uses EMAIL_FROM against an unauthenticated relay', async () => {
+        for (const [key, value] of Object.entries({
+            EMAIL_ENABLED: 'true', EMAIL_HOST: 'mailhog', EMAIL_PORT: '1025',
+            EMAIL_SSL: 'false', EMAIL_FROM: 'passmower@example.com',
+        })) vi.stubEnv(key, value)
+        vi.stubEnv('EMAIL_USERNAME', '')
+        vi.stubEnv('EMAIL_PASSWORD', '')
+
+        await new EmailAdapter().sendMail('a@example.com', 'subject', 'text', 'html')
+
+        expect(mocks.createTransport).toHaveBeenCalledWith(
+            expect.objectContaining({host: 'mailhog', auth: undefined}))
+        expect(mocks.sendMail).toHaveBeenCalledWith(expect.objectContaining({
+            headers: {From: 'passmower@example.com'},
+        }))
+    })
 })

--- a/test/unit/email-configuration.test.js
+++ b/test/unit/email-configuration.test.js
@@ -22,4 +22,15 @@ describe('email configuration', () => {
         expect(isEmailEnabled({EMAIL_ENABLED: 'false'})).toBe(false)
         expect(() => validateEmailConfiguration({EMAIL_ENABLED: 'false'})).not.toThrow()
     })
+
+    it('accepts unauthenticated SMTP with a From address', () => {
+        const unauthenticated = {...configured, EMAIL_USERNAME: '', EMAIL_PASSWORD: ''}
+        expect(() => validateEmailConfiguration({...unauthenticated, EMAIL_FROM: 'passmower@example.com'}))
+            .not.toThrow()
+        expect(() => validateEmailConfiguration(unauthenticated)).toThrow(/EMAIL_FROM/)
+        expect(() => validateEmailConfiguration({...configured, EMAIL_PASSWORD: ''}))
+            .toThrow(/set together/)
+        expect(() => validateEmailConfiguration({...configured, EMAIL_USERNAME: '', EMAIL_FROM: 'a@example.com'}))
+            .toThrow(/set together/)
+    })
 })


### PR DESCRIPTION
Found while bringing the dev instance up in minikube: email-enabled boot required `EMAIL_USERNAME`/`EMAIL_PASSWORD`, which an unauthenticated relay (internal relay, MailHog in dev) legitimately does not have — the pod crash-looped at `validateEmailConfiguration` and, because the skaffold helm upgrade also rolls the ephemeral in-cluster Redis, the dashboard self client was never re-seeded, leaving logins failing with `invalid_client`.

- `EMAIL_HOST/PORT/SSL` remain required at boot; `EMAIL_USERNAME`/`EMAIL_PASSWORD` are now optional but must be set together, and `EMAIL_FROM` is required when they are absent (no fallback sender otherwise).
- Nodemailer omits `auth` entirely when no username is configured — relays that advertise no AUTH fail the handshake when credentials are passed anyway.
- Docs updated (`docs/email-configuration.md`, AGENTS.md env table).

Verified on the minikube dev instance: pod boots, self client re-seeds, dashboard sign-in page renders. 268 unit tests pass (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)