### PR TITLE
Send GitHub scopes as one space-delimited parameter

### DIFF
--- a/src/services/login/github-login.js
+++ b/src/services/login/github-login.js
@@ -16,7 +16,10 @@ export const getGitHubAuthorizeParams = (state, env = process.env) => {
     const scopes = getGitHubScopes(env)
     return {
         redirect_uri: `${env.ISSUER_URL}interaction/callback/gh`,
-        ...(scopes.length ? {scope: scopes} : {}),
+        // Must be a single space-delimited value: an array querystring-encodes
+        // as repeated scope= params and GitHub honors only one of them, issuing
+        // a token without user:email.
+        ...(scopes.length ? {scope: scopes.join(' ')} : {}),
         state,
     }
 }
@@ -27,7 +30,13 @@ export async function getGitHubEmails(token, fetchImpl = fetch, env = process.en
         method: 'GET',
         headers: {'Authorization': `Bearer ${token}`},
     })
-    return (await response.json()).filter(email => email.verified).map(email => ({...email, observedAt}))
+    const body = await response.json().catch(() => undefined)
+    if (!Array.isArray(body)) {
+        // A JSON error object (missing user:email scope, revoked token) —
+        // surface what GitHub said instead of a bare TypeError.
+        throw new Error(`GitHub /user/emails returned ${response.status}: ${JSON.stringify(body)?.slice(0, 200)}`)
+    }
+    return body.filter(email => email.verified).map(email => ({...email, observedAt}))
 }
 
 export default async (ctx, provider) => {
@@ -82,7 +91,8 @@ export default async (ctx, provider) => {
     }
 
     const emails = await getGitHubEmails(token).catch(error => {
-            auditLog(ctx,{error, interactionDetails}, 'Error getting emails from GitHub')
+            // Error instances serialize to {} in the log; keep the message.
+            auditLog(ctx,{error: error?.message ?? error, interactionDetails}, 'Error getting emails from GitHub')
         });
 
     if (!emails) {

--- a/test/unit/github-login.test.js
+++ b/test/unit/github-login.test.js
@@ -28,6 +28,26 @@ describe('email-free GitHub login', () => {
         expect(params).not.toHaveProperty('scope')
     })
 
+    it('sends multiple scopes as one space-delimited value', () => {
+        // An array here querystring-encodes as repeated scope= params and
+        // GitHub honors only one, issuing a token without user:email.
+        const params = getGitHubAuthorizeParams('state', {
+            EMAIL_ENABLED: 'true',
+            GITHUB_ORGANIZATION: 'codemowers',
+            ISSUER_URL: 'https://passmower.example/',
+        })
+        expect(params.scope).toBe('user:email read:org')
+    })
+
+    it('surfaces the GitHub error body when the email API rejects the token', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            status: 404,
+            json: async () => ({message: 'Not Found'}),
+        })
+        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}))
+            .rejects.toThrow(/404.*Not Found/)
+    })
+
     it('retains only verified GitHub addresses when enabled', async () => {
         const fetchImpl = vi.fn().mockResolvedValue({json: async () => [
             {email: 'verified@example.com', verified: true},


### PR DESCRIPTION
Fixes a regression from the email-free refactor (#201): the authorize `scope` became an array, which the `oauth` library querystring-encodes as repeated `scope=` params. GitHub honors only one, so with `GITHUB_ORGANIZATION` set the token was issued **without `user:email`** — `/user/emails` returned an error object, `.filter` threw, and every GitHub login failed with "Error getting emails from GitHub". (Pre-refactor code sent one comma-joined value, which is why this worked before.)

- Join scopes with a space, as GitHub expects.
- `getGitHubEmails` now surfaces the GitHub status + error body when the response is not an array, and the audit log records the message instead of an empty `{}` (Error instances don't JSON-serialize).

Found and verified on the minikube dev instance. 270 unit tests pass (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)