### PR TITLE
Stop pino redaction from corrupting request cookies

### DIFF
--- a/src/providers/setup-logger.js
+++ b/src/providers/setup-logger.js
@@ -1,27 +1,63 @@
 import pino from "pino";
 
+const headerSnapshot = (header) => header && typeof header === 'object' ? {...header} : header
+
+// pino 10's @pinojs/redact selectively clones the log object before censoring,
+// but Koa exposes request/response `header` through prototype getters, which
+// the clone walk (hasOwnProperty) skips while the censor walk (`in`) follows.
+// Redacting `ctx.request.header.cookie` therefore wrote "[Redacted]" straight
+// into the live req.headers, destroying every cookie for the remainder of the
+// request (site-session validation looped forever). Serializers run before
+// redaction, so snapshotting ctx into plain owned objects keeps the censor away
+// from live request state. Never log a raw Koa ctx under any other key.
+export const serializeCtx = (ctx) => {
+    if (!ctx || typeof ctx !== 'object') return ctx
+    if (!ctx.request && !ctx.response) return ctx
+    return {
+        request: ctx.request ? {
+            method: ctx.request.method,
+            url: ctx.request.url,
+            header: headerSnapshot(ctx.request.header),
+        } : undefined,
+        response: ctx.response ? {
+            status: ctx.response.status,
+            message: ctx.response.message,
+            header: headerSnapshot(ctx.response.header),
+        } : undefined,
+        originalUrl: ctx.originalUrl,
+        app: {issuer: process.env.ISSUER_URL},
+    }
+}
+
+export const loggerOptions = () => ({
+    level: process.env.NODE_ENV === 'production' ? 'info' : 'trace',
+    serializers: {
+        ctx: serializeCtx,
+    },
+    redact: [
+        'ctx.request.header.cookie',
+        // NOTE: do NOT redact 'ctx.response.header["set-cookie"]'. Koa's
+        // ctx.response.header is a getter returning a fresh object each
+        // access, which breaks pino/fast-redact's mutate-then-restore for
+        // array-wildcard paths: it mutates the *live* Set-Cookie array in
+        // place but restores into a throwaway copy, leaving "[Redacted]" on
+        // the actual response and corrupting every cookie (breaks login).
+        // The ctx serializer above snapshots headers, so redaction below only
+        // ever touches plain copies.
+        'interaction.session.cookie',
+        '*.jti',
+        'interaction.result.token',
+        'interaction.result.oauth.token',
+        'interaction.result.request.header.cookie',
+        'interaction.result.request.url',
+        '*.cookie',
+        'result.oauth.token',
+        'err.response.headers',
+        'err.response.request.headers',
+        'err.stack',
+    ],
+})
+
 export const setupLogger = () => {
-    globalThis.logger = pino({
-        level: process.env.NODE_ENV === 'production' ? 'info' : 'trace',
-        redact: [
-            'ctx.request.header.cookie',
-            // NOTE: do NOT redact 'ctx.response.header["set-cookie"]'. Koa's
-            // ctx.response.header is a getter returning a fresh object each
-            // access, which breaks pino/fast-redact's mutate-then-restore for
-            // array-wildcard paths: it mutates the *live* Set-Cookie array in
-            // place but restores into a throwaway copy, leaving "[Redacted]" on
-            // the actual response and corrupting every cookie (breaks login).
-            'interaction.session.cookie',
-            '*.jti',
-            'interaction.result.token',
-            'interaction.result.oauth.token',
-            'interaction.result.request.header.cookie',
-            'interaction.result.request.url',
-            '*.cookie',
-            'result.oauth.token',
-            'err.response.headers',
-            'err.response.request.headers',
-            'err.stack',
-        ]
-    })
+    globalThis.logger = pino(loggerOptions())
 }

--- a/test/unit/logger-redaction.test.js
+++ b/test/unit/logger-redaction.test.js
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'vitest'
+import pino from 'pino'
+import {Writable} from 'node:stream'
+import {loggerOptions, serializeCtx} from '../../src/providers/setup-logger.js'
+
+// Koa exposes request.header through a prototype getter. @pinojs/redact's
+// selective clone skips prototype getters (hasOwnProperty) while its censor
+// walk follows them (`in`), so redacting through a live Koa ctx mutates the
+// real req.headers. These tests pin the serializer that keeps redaction away
+// from live request state.
+class KoaLikeRequest {
+    constructor(req) {
+        this.req = req
+    }
+    get header() {
+        return this.req.headers
+    }
+    get method() {
+        return this.req.method
+    }
+    get url() {
+        return this.req.url
+    }
+}
+
+const liveCookie = '_site_session.passmower=abc; _session=xyz'
+
+const makeCtx = () => {
+    const req = {method: 'GET', url: '/auth/x', headers: {cookie: liveCookie, host: 'x'}}
+    return {request: new KoaLikeRequest(req), originalUrl: '/auth/x', req}
+}
+
+describe('logger redaction safety', () => {
+    it('redacts the logged cookie without mutating the live request headers', () => {
+        const lines = []
+        const sink = new Writable({write(chunk, encoding, callback) {
+            lines.push(chunk.toString())
+            callback()
+        }})
+        const logger = pino(loggerOptions(), sink)
+        const ctx = makeCtx()
+
+        logger.error({ctx}, 'authorization.error')
+        logger.debug({ctx}, 'interaction.started')
+
+        expect(ctx.req.headers.cookie).toBe(liveCookie)
+        const out = lines.join('')
+        expect(out).toContain('"cookie":"[Redacted]"')
+        expect(out).not.toContain('_site_session.passmower=abc')
+    })
+
+    it('snapshots headers into plain owned objects', () => {
+        const ctx = makeCtx()
+        const snapshot = serializeCtx(ctx)
+        expect(snapshot.request.header).not.toBe(ctx.req.headers)
+        expect(snapshot.request.header.cookie).toBe(liveCookie)
+        expect(snapshot.request.method).toBe('GET')
+        // non-koa values pass through untouched
+        expect(serializeCtx(undefined)).toBeUndefined()
+        expect(serializeCtx({foo: 1})).toEqual({foo: 1})
+    })
+})


### PR DESCRIPTION
Root cause of the dashboard login loop on the dev instance ("seems it crashed"): **pino 10 replaced fast-redact with `@pinojs/redact`, which selectively clones the log object before censoring — but Koa exposes `request.header` through a *prototype* getter, which the clone walk (`hasOwnProperty`) skips while the censor walk (`in`) follows.** Redacting `ctx.request.header.cookie` therefore wrote `[Redacted]` straight into the **live `req.headers`**, and the clone-based design has no restore.

Effect: after any `{ctx}` log mid-request, every cookie is gone for the remainder of that request. The site-session cookie check then fails on each `/auth` resume, and the login flow loops forever minting new consent interactions. Debug-level `{ctx}` logs (`interaction.started`/`ended`) trigger this on every request in dev; error-level ones (`authorization.error`, `grant.error`, …) trigger it **in production** too.

Diagnosed on the live dev instance by trapping the mutation with an accessor on `headers.cookie` — the poisoning stack pointed at `@pinojs/redact`'s `setValue` invoked from `logger.debug({ctx, prompt}, 'interaction.started')`. Minimal repro confirms the prototype-getter condition (an own-property getter clones fine). Upstream bug candidate for `@pinojs/redact@0.4.0`.

Fix: a pino `ctx` serializer snapshots request/response into plain owned objects — serializers run before redaction (`pino/lib/tools.js` applies `serializers[key]` before the redact stringifier), so the censor only ever touches copies. Regression test pins both the no-mutation guarantee and that the logged output stays redacted. Companion to 2e2c188, which fixed the same bug class on the Set-Cookie side.

272 unit tests pass (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)