### PR TITLE
Fix three findings from the develop-vs-master review

### DIFF
--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -29,7 +29,10 @@ passmower:
 ```
 
 When email is enabled, Passmower fails at startup unless `EMAIL_HOST`,
-`EMAIL_PORT`, and `EMAIL_SSL` are present. SMTP authentication is optional for
+`EMAIL_PORT`, and `EMAIL_SSL` are present. `EMAIL_SSL: "true"` enables implicit
+TLS (typically port 465); with `"false"`, STARTTLS is still negotiated
+opportunistically when the relay offers it (typically port 587). Do not combine
+`EMAIL_SSL: "true"` with a STARTTLS port. SMTP authentication is optional for
 unauthenticated relays (an internal relay, MailHog in dev): `EMAIL_USERNAME`
 and `EMAIL_PASSWORD` must be set together or not at all, and without a username
 `EMAIL_FROM` is required as the sender address. When no credentials are

--- a/src/adapters/email.js
+++ b/src/adapters/email.js
@@ -10,7 +10,11 @@ class EmailAdapter {
         this.#transporter ??= Nodemailer.createTransport({
             host: process.env.EMAIL_HOST,
             port: process.env.EMAIL_PORT,
-            ssl: process.env.EMAIL_SSL,
+            // Nodemailer's option is `secure` (implicit TLS); it has no `ssl`
+            // option, so EMAIL_SSL was silently ignored and implicit TLS only
+            // worked through the port-465 autodetect. Strict string compare:
+            // the raw "false" string would be truthy.
+            secure: process.env.EMAIL_SSL === 'true',
             // Unauthenticated relays (MailHog in dev) advertise no AUTH;
             // passing credentials anyway makes Nodemailer fail the handshake.
             auth: process.env.EMAIL_USERNAME ? {

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -22,6 +22,13 @@ import isEqual from 'lodash/isEqual.js';
 // Gated by KUBERNETES_API_SERVICE_DNS: 'auto' (default) only rewrites when the host is
 // an IPv6 literal (IPv4 clusters that work today are untouched); 'always' forces it;
 // 'never' disables it. Returns the replacement server URL, or null to leave it as-is.
+export const WATCH_TIMEOUT_MS = 60 * 60 * 1000
+
+// A clean end or the client-node request timeout is routine — reconnect
+// immediately so no CRD events are missed; back off only on genuine errors.
+export const watchRestartDelayMs = (err) =>
+    !err || err.name === 'TimeoutError' ? 0 : 10 * 1000
+
 export function apiServerUrlViaServiceDns({
     host = process.env.KUBERNETES_SERVICE_HOST,
     port = process.env.KUBERNETES_SERVICE_PORT,
@@ -373,6 +380,14 @@ export class KubernetesAdapter {
         const kind = plurals[this.watchParameters.kind]
         globalThis.logger.info(`Watching Kubernetes API for ${kind}`)
         const watch = new k8s.Watch(this.kc);
+        // @kubernetes/client-node 2.x aborts every watch request after
+        // requestTimeoutMs (default 30s) by design and expects the caller to
+        // re-watch. At the default, combined with the 10s error backoff below,
+        // every operator was blind for a quarter of its lifetime and silently
+        // missed CRD events. Keep the request alive for an hour (the apiserver
+        // ends watches on its own terms well before that) and reconnect
+        // immediately on expected termination.
+        watch.requestTimeoutMs = WATCH_TIMEOUT_MS
         let path = this.watchParameters.namespaceFilter?.namespace ?
             `/apis/${this.watchParameters.apiGroup}/${this.watchParameters.apiGroupVersion}/namespaces/${this.watchParameters.namespaceFilter.namespace}` :
             `/apis/${this.watchParameters.apiGroup}/${this.watchParameters.apiGroupVersion}`
@@ -399,14 +414,16 @@ export class KubernetesAdapter {
                     // console.warn(watchObj)
                 }
             },
-            // done callback is called if the watch terminates normally
+            // done callback is called when the watch terminates for any reason
             (err) => {
-                // tslint:disable-next-line:no-console
-                globalThis.logger.warn('Kubernetes API watch terminated')
-                if (err) {
+                const delay = watchRestartDelayMs(err)
+                if (delay) {
+                    globalThis.logger.warn('Kubernetes API watch terminated')
                     globalThis.logger.error(err)
+                } else {
+                    globalThis.logger.debug(`Kubernetes API watch for ${kind} expired, reconnecting`)
                 }
-                setTimeout(() => { this.watchObjects(); }, 10 * 1000);
+                setTimeout(() => { this.watchObjects(); }, delay);
             }).then((abortController) => {
             // watch returns an AbortController which you can use to abort the watch.
             // setTimeout(() => { abortController.abort(); }, 10);

--- a/src/utils/fetch-extra-claims.js
+++ b/src/utils/fetch-extra-claims.js
@@ -8,6 +8,26 @@
 // so any error yields {} (the enriched claim is simply absent) rather than
 // throwing. Keep this for small, stable signals only — never a hot-path
 // dependency.
+// Claims the webhook must never influence: identity, authorization, and
+// token-shape claims are owned by Passmower. The webhook's response is merged
+// into issued tokens verbatim, so without this filter a compromised or buggy
+// webhook could override sub/groups/email_verified and impersonate any user.
+const PROTECTED_CLAIMS = new Set([
+    'sub', 'iss', 'aud', 'exp', 'iat', 'nbf', 'jti', 'auth_time', 'nonce',
+    'sid', 'azp', 'at_hash', 'c_hash', 'scope', 'client_id',
+    'email', 'email_verified', 'emails', 'groups', 'username', 'name',
+])
+
+const sanitizeClaims = (claims, sub) => {
+    const entries = Object.entries(claims)
+    const safe = entries.filter(([key]) => !PROTECTED_CLAIMS.has(key))
+    if (safe.length !== entries.length) {
+        const stripped = entries.filter(([key]) => PROTECTED_CLAIMS.has(key)).map(([key]) => key)
+        console.error('Extra claims webhook tried to set protected claims; stripped', { stripped, sub })
+    }
+    return Object.fromEntries(safe)
+}
+
 export async function fetchExtraClaims({ sub, groups, client_id, scope }) {
     const url = process.env.EXTRA_CLAIMS_WEBHOOK_URL
     if (!url) {
@@ -29,7 +49,7 @@ export async function fetchExtraClaims({ sub, groups, client_id, scope }) {
             return {}
         }
         const claims = await response.json()
-        return (claims && typeof claims === 'object') ? claims : {}
+        return (claims && typeof claims === 'object' && !Array.isArray(claims)) ? sanitizeClaims(claims, sub) : {}
     } catch (error) {
         console.error('Extra claims webhook request failed', { error: error.message, sub })
         return {}

--- a/test/unit/email-adapter.test.js
+++ b/test/unit/email-adapter.test.js
@@ -53,9 +53,21 @@ describe('EmailAdapter', () => {
         await new EmailAdapter().sendMail('a@example.com', 'subject', 'text', 'html')
 
         expect(mocks.createTransport).toHaveBeenCalledWith(
-            expect.objectContaining({host: 'mailhog', auth: undefined}))
+            expect.objectContaining({host: 'mailhog', auth: undefined, secure: false}))
         expect(mocks.sendMail).toHaveBeenCalledWith(expect.objectContaining({
             headers: {From: 'passmower@example.com'},
         }))
+    })
+
+    it('maps EMAIL_SSL onto Nodemailer secure (implicit TLS)', async () => {
+        for (const [key, value] of Object.entries({
+            EMAIL_ENABLED: 'true', EMAIL_HOST: 'smtp.example.com', EMAIL_PORT: '465',
+            EMAIL_SSL: 'true', EMAIL_USERNAME: 'passmower', EMAIL_PASSWORD: 'secret',
+        })) vi.stubEnv(key, value)
+
+        await new EmailAdapter().sendMail('a@example.com', 'subject', 'text', 'html')
+
+        expect(mocks.createTransport).toHaveBeenCalledWith(
+            expect.objectContaining({secure: true}))
     })
 })

--- a/test/unit/fetch-extra-claims.test.js
+++ b/test/unit/fetch-extra-claims.test.js
@@ -49,3 +49,32 @@ describe('fetchExtraClaims', () => {
         expect(await fetchExtraClaims(ctx)).toEqual({})
     })
 })
+
+describe('fetchExtraClaims protected-claims filter', () => {
+    it('strips identity and authorization claims from the webhook response', async () => {
+        vi.stubEnv('EXTRA_CLAIMS_WEBHOOK_URL', 'http://webhook.test/enrich')
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                'codemowers.io/namespaces': ['tenant-demo'],
+                sub: 'victim',
+                groups: ['passmower:admins'],
+                email_verified: true,
+                aud: 'other-client',
+            }),
+        }))
+
+        expect(await fetchExtraClaims(ctx)).toEqual({
+            'codemowers.io/namespaces': ['tenant-demo'],
+        })
+    })
+
+    it('rejects non-object payloads such as arrays', async () => {
+        vi.stubEnv('EXTRA_CLAIMS_WEBHOOK_URL', 'http://webhook.test/enrich')
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => (['not', 'claims']),
+        }))
+        expect(await fetchExtraClaims(ctx)).toEqual({})
+    })
+})

--- a/test/unit/kubernetes-watch.test.js
+++ b/test/unit/kubernetes-watch.test.js
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest'
+import {WATCH_TIMEOUT_MS, watchRestartDelayMs} from '../../src/adapters/kubernetes.js'
+
+describe('kubernetes watch lifecycle', () => {
+    it('keeps the watch request alive far beyond the client default 30s', () => {
+        expect(WATCH_TIMEOUT_MS).toBeGreaterThanOrEqual(10 * 60 * 1000)
+    })
+
+    it('reconnects immediately on expected termination, backs off on errors', () => {
+        // clean end (apiserver closed the watch)
+        expect(watchRestartDelayMs(null)).toBe(0)
+        expect(watchRestartDelayMs(undefined)).toBe(0)
+        // client-node 2.x requestTimeoutMs abort
+        expect(watchRestartDelayMs(new DOMException('The operation was aborted due to timeout', 'TimeoutError'))).toBe(0)
+        // genuine failure
+        expect(watchRestartDelayMs(new Error('connection refused'))).toBe(10 * 1000)
+    })
+})


### PR DESCRIPTION
Pre-release review of the full master…develop range (245 commits) surfaced three issues; all fixed here.

**1. Kubernetes watches blind 25% of the time** (regression from `@kubernetes/client-node` 1→2). The v2 `Watch` aborts every request after `requestTimeoutMs` (default 30s) by design; passmower treated that as an error and slept 10s before re-watching, so each operator cycled 30s-on/10s-blind and silently missed CRD events in the gaps — worst case a deleted `OIDCClient` stayed live in Redis until pod restart. Now the request lives an hour (`watch.requestTimeoutMs`), expected termination reconnects immediately, and the 10s backoff applies only to genuine errors. Also eliminates the `TimeoutError` log spam every 30s per watch that was visible on the dev instance.

**2. Claims-enrichment webhook could override any claim, including `sub`** (security). Both merge sites (`configuration.js` JWT access tokens, `account.js` id_token/userinfo) did an unfiltered `Object.assign` of the webhook response over issued claims — a compromised or buggy webhook escalated to IdP-level impersonation for `namespaces`-scope clients. `fetchExtraClaims` now strips protected identity/authorization/token-shape claims (logging what was stripped) and rejects non-object payloads, covering both call sites.

**3. `EMAIL_SSL` was a silent no-op** (pre-existing, also on master). Nodemailer's option is `secure`, not `ssl` — implicit TLS only ever worked via the port-465 autodetect. Now mapped with a strict string compare, with the implicit-TLS-vs-STARTTLS semantics documented. Note for operators: `EMAIL_SSL: "true"` now genuinely enables implicit TLS — a config that had it set alongside a STARTTLS port (587) must switch to `"false"`.

280 unit tests pass (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)