### PR TITLE
Drop unused koa-pino-logger dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "jsondiffpatch": "0.7.6",
         "koa": "^3.2.1",
         "koa-body": "^8.0.0",
-        "koa-pino-logger": "^5.0.0",
         "koa-static": "^5.0.0",
         "lodash": "^4.18.1",
         "marked": "^18.0.10",
@@ -946,9 +945,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -966,9 +962,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,9 +979,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1006,9 +996,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1026,9 +1013,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1046,9 +1030,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3191,15 +3172,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4426,15 +4398,6 @@
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
       "license": "MIT"
     },
-    "node_modules/koa-pino-logger": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/koa-pino-logger/-/koa-pino-logger-5.0.0.tgz",
-      "integrity": "sha512-iGx5P6CwsSsQ4a8B9rx6EMkmUKvM5toJjPPX4gXfx+l+Ikd+Ih6Akps4EQo/du+bVjHNGVKNMBETEVHYxDMM0g==",
-      "license": "MIT",
-      "dependencies": {
-        "pino-http": "^11.0.0"
-      }
-    },
     "node_modules/koa-send": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
@@ -4708,9 +4671,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4732,9 +4692,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4756,9 +4713,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4780,9 +4734,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5841,18 +5792,6 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
-      }
-    },
-    "node_modules/pino-http": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
-      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
-      "license": "MIT",
-      "dependencies": {
-        "get-caller-file": "^2.0.5",
-        "pino": "^10.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0"
       }
     },
     "node_modules/pino-std-serializers": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jsondiffpatch": "0.7.6",
     "koa": "^3.2.1",
     "koa-body": "^8.0.0",
-    "koa-pino-logger": "^5.0.0",
     "koa-static": "^5.0.0",
     "lodash": "^4.18.1",
     "marked": "^18.0.10",


### PR DESCRIPTION
Follow-up from the pre-release review: `koa-pino-logger` is no longer imported anywhere in `src/` — request logging goes through the shared pino instance from `setup-logger`. Removes the dependency and its lockfile subtree.

280 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)