### PR TITLE
Conditions are not embedded resources

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -608,7 +608,6 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                    x-kubernetes-embedded-resource: true
                 emails:
                   type: array
                   items:
@@ -896,7 +895,6 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                    x-kubernetes-embedded-resource: true
                 instance:
                   type: string
                 lastUsedAt:
@@ -1010,7 +1008,6 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                    x-kubernetes-embedded-resource: true
                 instance:
                   type: string
                 lastUsedAt:

--- a/src/conditions/base-condition.js
+++ b/src/conditions/base-condition.js
@@ -1,5 +1,4 @@
 import {V1Condition} from "@kubernetes/client-node";
-import {defaultApiGroupVersion} from "../utils/kubernetes/kube-constants.js";
 
 export const conditionStatusTrue = 'True'
 export const conditionStatusFalse = 'False'
@@ -31,9 +30,12 @@ export class BaseCondition {
     }
 
     toKubeCondition() {
+        // Plain metav1.Condition shape — no apiVersion/kind. Those were only
+        // ever added to satisfy the CRD schema's x-kubernetes-embedded-resource
+        // marker, which was wrong (conditions are not embedded resources) and
+        // made any CR whose conditions lacked them fail validation on every
+        // subsequent update (kubectl apply on a reconciled OIDCClient broke).
         const condition = new V1Condition()
-        condition.apiVersion = defaultApiGroupVersion
-        condition.kind = 'Condition'
         condition.lastTransitionTime = new Date
         condition.status = this.status ? conditionStatusTrue : conditionStatusFalse
         condition.type = this.type

--- a/test/unit/conditions.test.js
+++ b/test/unit/conditions.test.js
@@ -25,3 +25,15 @@ describe('Approved condition', () => {
         expect(new Approved().check(nonMember)).toBeFalsy()
     })
 })
+
+describe('condition shape', () => {
+    it('emits plain metav1.Condition objects without apiVersion/kind', () => {
+        // The CRD schema used to mark conditions as embedded resources, which
+        // required apiVersion/kind inside every item and made any CR whose
+        // conditions lacked them fail validation on every subsequent update.
+        const condition = new Approved().toKubeCondition()
+        expect(condition.type).toBe('Approved')
+        expect(condition.apiVersion).toBeUndefined()
+        expect(condition.kind).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Found in the field upgrading katri-kube to 2.0.1: adding the `email` scope to an existing `OIDCClient` failed with `status.conditions[0].apiVersion: Required value`.

The CRD schemas mark `status.conditions` items with `x-kubernetes-embedded-resource: true`, which requires `apiVersion`/`kind` inside every condition object. OIDCUser conditions have carried bogus `apiVersion: v1, kind: Condition` to satisfy it, but the newer OIDCClient reconciliation conditions (#183) don't — so once a client is reconciled, **every subsequent `kubectl apply` of that OIDCClient fails validation**. Affects all three CRDs.

- Remove the `x-kubernetes-embedded-resource` marker from OIDCUser/OIDCClient/OIDCMiddlewareClient condition schemas (`x-kubernetes-preserve-unknown-fields` stays, so previously stored conditions — bogus fields included — remain valid).
- Stop writing the bogus `apiVersion`/`kind` in new conditions; they only existed to satisfy the marker.
- Regression test pins the clean metav1.Condition shape.

281 unit tests pass. Should ship as 2.0.2 — this breaks GitOps flows on existing clients for every 2.0.x deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)