### PR TITLE
Configurable OIDC_AVAILABLE_SCOPES delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ spec:
   tokenEndpointAuthMethod: none
 ```
 
+The generated client Secret exposes the scopes as `OIDC_AVAILABLE_SCOPES`,
+comma-delimited by default. Applications that split scope strings on spaces
+(the OAuth2 wire format) can set `availableScopesDelimiter: " "` on the
+`OIDCClient` to change how that value is rendered.
+
 Make sure to replace the `redirectURI` with the correct callback URL for your
 application. Secret named `oidc-client-grafana-owner-secrets` is written
 into the originating namespace.

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -810,6 +810,10 @@ spec:
                       - profile
                       - offline_access
                       - groups
+                availableScopesDelimiter:
+                  type: string
+                  default: ","
+                  description: Delimiter used when rendering OIDC_AVAILABLE_SCOPES into the generated client secret. OAuth2 scope strings are space-delimited, but the historical default here is a comma; set to " " for apps that split scopes on spaces.
                       - allowed_groups
                       - applications
                       - all_applications

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -38,6 +38,7 @@ class OIDCClient {
     #allowedUsers = null
     #overrideIncomingScopes = null
     #availableScopes = null
+    #availableScopesDelimiter = ','
     #instanceUri = null
     #uri = null
     #displayName = null
@@ -94,6 +95,9 @@ class OIDCClient {
         this.#allowedUsers = incomingClient.spec.allowedUsers || []
         this.#overrideIncomingScopes = incomingClient.spec.overrideIncomingScopes
         this.#availableScopes = incomingClient.spec.availableScopes
+        // OAuth2 scope strings are space-delimited, but the generated secret
+        // historically used a comma; the CR can pick what its consumer expects.
+        this.#availableScopesDelimiter = incomingClient.spec.availableScopesDelimiter ?? ','
         this.#instanceUri = process.env.ISSUER_URL
         this.#uri = incomingClient.spec.uri
         this.#displayName = incomingClient.spec.displayName
@@ -120,7 +124,7 @@ class OIDCClient {
             [OIDCClientSecretRedirectUrisKey]: this.#redirectUris.join(','),
             [OIDCClientSecretIdpUriKey]: this.#instanceUri,
             [OIDCClientSecretWellKnownUriKey]: new URL('.well-known/openid-configuration', this.#instanceUri).href,
-            [OIDCClientSecretAvailableScopesKey]: this.#availableScopes.join(','),
+            [OIDCClientSecretAvailableScopesKey]: this.#availableScopes.join(this.#availableScopesDelimiter),
             [OIDCClientSecretAuthUriKey]: provider.urlFor('authorization'),
             [OIDCClientSecretTokenUriKey]: provider.urlFor('token'),
             [OIDCClientSecretUserInfoUriKey]: provider.urlFor('userinfo'),

--- a/test/unit/oidc-client.test.js
+++ b/test/unit/oidc-client.test.js
@@ -47,3 +47,20 @@ describe('OIDCClient model — user ACL', () => {
             .toMatchObject({OIDC_ALLOWED_USERS: 'alice,bob'})
     })
 })
+
+describe('OIDCClient model — scopes delimiter', () => {
+    it('joins OIDC_AVAILABLE_SCOPES with a comma by default and honors the CR delimiter', () => {
+        const urlFor = route => `https://oidc.example/${route}`
+        const base = incomingClient({availableScopes: ['openid', 'email', 'profile']})
+
+        expect(new OIDCClient().fromIncomingClient(base).toClientSecret({urlFor}))
+            .toMatchObject({OIDC_AVAILABLE_SCOPES: 'openid,email,profile'})
+
+        const spaced = incomingClient({
+            availableScopes: ['openid', 'email', 'profile'],
+            availableScopesDelimiter: ' ',
+        })
+        expect(new OIDCClient().fromIncomingClient(spaced).toClientSecret({urlFor}))
+            .toMatchObject({OIDC_AVAILABLE_SCOPES: 'openid email profile'})
+    })
+})


### PR DESCRIPTION
Implements #217: the generated client Secret's `OIDC_AVAILABLE_SCOPES` was always comma-joined, but OAuth2 scope strings are space-delimited on the wire and some applications split on spaces.

- New `OIDCClient.spec.availableScopesDelimiter` (string, CRD default `","` so every existing CR and consumer is unchanged); set `" "` for space-splitting apps.
- Applied only to the scopes key — the other list-valued secret keys aren't OAuth scope strings and keep their comma format.
- CRD schema is YAML-anchored, so both `v1` and `v1beta1` pick it up; documented in the README next to the client example.

282 unit tests pass (1 new, covering both default and space delimiter). Changing the field on an existing CR regenerates the owner secret through the normal reconcile.

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)