### PR TITLE
Decouple email collection from EMAIL_ENABLED; rename to outboundEmailEnabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | `OIDC_PROVIDERS` | JSON object of generic upstream OIDC providers keyed by provider slug. |
 | `OIDC_ALLOW_INSECURE_UPSTREAM` | Permit `http://` upstreams (local dev only). |
 | `GITHUB_ENABLED`, `GH_CLIENT_ID/SECRET`, `GITHUB_ORGANIZATION` | GitHub upstream. |
-| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Outbound email delivery. `false` disables delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email; upstream email collection and downstream email claims are unaffected. When enabled (the default), `EMAIL_HOST/PORT/SSL` are required at boot; `EMAIL_USERNAME/PASSWORD` are optional as a pair (unauthenticated relay), with `EMAIL_FROM` required when they are absent. |
+| `OUTBOUND_EMAIL_ENABLED` (legacy `EMAIL_ENABLED` honored), `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Outbound email delivery. `false` disables delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email; upstream email collection and downstream email claims are unaffected. When enabled (the default), `EMAIL_HOST/PORT/SSL` are required at boot; `EMAIL_USERNAME/PASSWORD` are optional as a pair (unauthenticated relay), with `EMAIL_FROM` required when they are absent. |
 | `WEBAUTHN_ENABLED`, `WEBAUTHN_RP_NAME` | Passkeys. |
 | `SLACK_TOKEN` | Slack integration. |
 | `GROUP_PREFIX`, `ADMIN_GROUP`, `REQUIRED_GROUP` | Group/authorization policy. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | `OIDC_PROVIDERS` | JSON object of generic upstream OIDC providers keyed by provider slug. |
 | `OIDC_ALLOW_INSECURE_UPSTREAM` | Permit `http://` upstreams (local dev only). |
 | `GITHUB_ENABLED`, `GH_CLIENT_ID/SECRET`, `GITHUB_ORGANIZATION` | GitHub upstream. |
-| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Global email capability. `false` disables all delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email. When enabled (the default), `EMAIL_HOST/PORT/SSL` are required at boot; `EMAIL_USERNAME/PASSWORD` are optional as a pair (unauthenticated relay), with `EMAIL_FROM` required when they are absent. |
+| `EMAIL_ENABLED`, `EMAIL_HOST/PORT/SSL/USERNAME/PASSWORD/FROM` | Outbound email delivery. `false` disables delivery, magic-link login, ToS receipts, and email invitations, and permits enrollment by stable upstream identity without email; upstream email collection and downstream email claims are unaffected. When enabled (the default), `EMAIL_HOST/PORT/SSL` are required at boot; `EMAIL_USERNAME/PASSWORD` are optional as a pair (unauthenticated relay), with `EMAIL_FROM` required when they are absent. |
 | `WEBAUTHN_ENABLED`, `WEBAUTHN_RP_NAME` | Passkeys. |
 | `SLACK_TOKEN` | Slack integration. |
 | `GROUP_PREFIX`, `ADMIN_GROUP`, `REQUIRED_GROUP` | Group/authorization policy. |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ single generic connector (discovery + PKCE + `id_token` validation). Stable
 provider subjects identify returning users; verified email can additionally
 link identities across providers.
 
-Set `passmower.emailEnabled: false` to run without SMTP credentials or email
+Set `passmower.outboundEmailEnabled: false` to run without SMTP credentials or email
 addresses. This disables all delivery and email-based login/invitations while
 allowing upstream enrollment by stable provider identity. See
 [docs/email-configuration.md](docs/email-configuration.md).

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -1,5 +1,8 @@
-{{- if and .Values.passmower.emailEnabled (not .Values.passmower.emailCredentialsSecretRef) }}
-{{- fail "passmower.emailCredentialsSecretRef is required when passmower.emailEnabled is true" }}
+{{- if hasKey .Values.passmower "emailEnabled" }}
+{{- fail "passmower.emailEnabled was renamed to passmower.outboundEmailEnabled (it governs outbound delivery only; email collection and downstream claims are unaffected)" }}
+{{- end }}
+{{- if and .Values.passmower.outboundEmailEnabled (not .Values.passmower.emailCredentialsSecretRef) }}
+{{- fail "passmower.emailCredentialsSecretRef is required when passmower.outboundEmailEnabled is true" }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -94,8 +97,8 @@ spec:
               value: {{ .Values.passmower.webauthnEnabled | quote }}
             - name: GITHUB_ENABLED
               value: {{ .Values.passmower.githubEnabled | quote }}
-            - name: EMAIL_ENABLED
-              value: {{ .Values.passmower.emailEnabled | quote }}
+            - name: OUTBOUND_EMAIL_ENABLED
+              value: {{ .Values.passmower.outboundEmailEnabled | quote }}
             - name: PASSMOWER_VERIFIED_EMAIL_OVERRIDE
               value: {{ .Values.passmower.passmowerVerifiedEmailOverride | quote }}
             - name: AUDIT_ENABLED
@@ -182,7 +185,7 @@ spec:
           envFrom:
             - secretRef:
                 name: oidc-keys
-            {{- if and .Values.passmower.emailEnabled .Values.passmower.emailCredentialsSecretRef }}
+            {{- if and .Values.passmower.outboundEmailEnabled .Values.passmower.emailCredentialsSecretRef }}
             - secretRef:
                 name: {{ .Values.passmower.emailCredentialsSecretRef }}
             {{- end }}

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -61,7 +61,7 @@ passmower:
   # mounted and upstream users may enroll using their stable provider identity
   # without an email address. Email identity collection from upstreams and
   # downstream email claims are independent of this switch.
-  emailEnabled: true
+  outboundEmailEnabled: true
   # Accept upstream OIDC logins carrying an explicit email_verified: false when
   # the upstream identity is already linked to an account holding Passmower
   # magic-link verification for that exact address. Returning users are not
@@ -111,7 +111,7 @@ passmower:
     ttlSeconds: 604800
 
   # Security notifications broadcast to the affected user over every channel
-  # they have: email (when emailEnabled) and a Slack DM (when
+  # they have: email (when outboundEmailEnabled) and a Slack DM (when
   # slackClientSecretRef is configured and the user is linked). Delivery is
   # best-effort and never blocks the flow that triggered it.
   notifications:

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -56,9 +56,11 @@ passmower:
   webauthnEnabled: true
   # Enable GitHub OAuth login. Requires githubClientSecretRef to be set.
   githubEnabled: true
-  # Enable all email delivery, including magic-link login and ToS receipts.
-  # When false, no SMTP credentials are mounted and upstream users may enroll
-  # using their stable provider identity without an email address.
+  # Enable outbound email delivery: magic-link login, ToS receipts, email
+  # invitations, notification emails. When false, no SMTP credentials are
+  # mounted and upstream users may enroll using their stable provider identity
+  # without an email address. Email identity collection from upstreams and
+  # downstream email claims are independent of this switch.
   emailEnabled: true
   # Accept upstream OIDC logins carrying an explicit email_verified: false when
   # the upstream identity is already linked to an account holding Passmower

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -1,12 +1,15 @@
 # Email delivery and email-free operation
 
-`EMAIL_ENABLED=false` (Helm: `passmower.emailEnabled: false`) disables every
+`OUTBOUND_EMAIL_ENABLED=false` (Helm: `passmower.outboundEmailEnabled: false`;
+the pre-2.1 names `EMAIL_ENABLED` / `passmower.emailEnabled` — the env var is
+still honored as a fallback, the Helm key fails the render with a rename
+message) disables every
 outbound email path. Passmower does not initialize Nodemailer, does not mount
 `emailCredentialsSecretRef`, hides magic-link login and email-based admin
 invitations, and records Terms of Service acceptance without attempting to send
 a receipt.
 
-`EMAIL_ENABLED` governs **outbound delivery only**. Email identity collection
+`OUTBOUND_EMAIL_ENABLED` governs **outbound delivery only**. Email identity collection
 and downstream email claims are independent of it: GitHub logins always request
 `user:email` and store per-address verification evidence, generic providers
 default to the `openid email profile` scopes, and clients allowed the `email`
@@ -25,7 +28,7 @@ Forward-auth also omits the configured email header for those accounts.
 
 ```yaml
 passmower:
-  emailEnabled: false
+  outboundEmailEnabled: false
   # emailCredentialsSecretRef may be empty or omitted
   oidcProviders:
     dex:

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -6,12 +6,18 @@ outbound email path. Passmower does not initialize Nodemailer, does not mount
 invitations, and records Terms of Service acceptance without attempting to send
 a receipt.
 
+`EMAIL_ENABLED` governs **outbound delivery only**. Email identity collection
+and downstream email claims are independent of it: GitHub logins always request
+`user:email` and store per-address verification evidence, generic providers
+default to the `openid email profile` scopes, and clients allowed the `email`
+scope keep receiving `email`/`email_verified` — so delivery-disabled
+deployments can still provision addresses to downstream applications. Override
+a provider's `scopes` if its issuer rejects the `email` scope.
+
 Email-free installations can enroll users from GitHub or generic OIDC by the
-provider's stable identity (GitHub numeric ID or OIDC provider key plus `sub`).
-Generic providers default to the `openid profile` scopes in this mode, and
-GitHub does not request `user:email` or call the email API. Provider definitions
-may still explicitly request `email`; an address returned in that case is
-retained for identity linking and downstream claims, but it is not required.
+provider's stable identity (GitHub numeric ID or OIDC provider key plus `sub`):
+while delivery is disabled, an upstream that returns no address is tolerated
+at login instead of being an error.
 
 Accounts without a primary address omit `email` and `email_verified` from ID
 tokens and UserInfo, even when a downstream client requests the `email` scope.

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -46,7 +46,10 @@ configuration will crash-loop after upgrading. Before upgrading, choose one of:
 - set `passmower.emailEnabled: false` explicitly. This disables SMTP delivery,
   magic-link login, ToS receipts, and email invitations while permitting users to
   enroll through GitHub or another OIDC provider using their stable upstream
-  identity without an email address.
+  identity without an email address. Since 2.1, this switch governs delivery
+  only: email identity collection from upstreams and downstream email claims
+  keep working while it is off (in 2.0.x, disabling it also stopped requesting
+  and storing upstream emails).
 
 SMTP delivery errors are no longer swallowed. A failed magic-link send now fails
 that login attempt; ToS acceptance remains successful if its receipt cannot be sent.

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -43,7 +43,8 @@ configuration will crash-loop after upgrading. Before upgrading, choose one of:
 
 - configure a credentials Secret with the required variables and set
   `passmower.emailCredentialsSecretRef`, or
-- set `passmower.emailEnabled: false` explicitly. This disables SMTP delivery,
+- set `passmower.emailEnabled: false` explicitly (renamed to
+  `passmower.outboundEmailEnabled` in 2.1). This disables SMTP delivery,
   magic-link login, ToS receipts, and email invitations while permitting users to
   enroll through GitHub or another OIDC provider using their stable upstream
   identity without an email address. Since 2.1, this switch governs delivery

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -4,7 +4,7 @@ Passmower can send short security notices to the affected user over every
 channel they have:
 
 - **Email** — the account's primary address, when email delivery is enabled
-  (`passmower.emailEnabled`).
+  (`passmower.outboundEmailEnabled`).
 - **Slack DM** — when the Slack workspace integration is configured
   (`slackClientSecretRef`) and the account is linked to a Slack user.
 

--- a/src/adapters/email.js
+++ b/src/adapters/email.js
@@ -1,11 +1,11 @@
 import Nodemailer from "nodemailer";
-import {isEmailEnabled, validateEmailConfiguration} from '../utils/email-configuration.js';
+import {isOutboundEmailEnabled, validateEmailConfiguration} from '../utils/email-configuration.js';
 
 class EmailAdapter {
     #transporter
 
     async sendMail(to, subject, textContent, htmlContent) {
-        if (!isEmailEnabled()) throw new Error('Email delivery is disabled')
+        if (!isOutboundEmailEnabled()) throw new Error('Email delivery is disabled')
         validateEmailConfiguration()
         this.#transporter ??= Nodemailer.createTransport({
             host: process.env.EMAIL_HOST,

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -14,7 +14,7 @@ import validator, {
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import {getText} from "../utils/get-text.js";
 import {getUsernameSource} from "../utils/username-source.js";
-import {isEmailEnabled} from '../utils/email-configuration.js';
+import {isOutboundEmailEnabled} from '../utils/email-configuration.js';
 import {getAccountTypeAccessFailure} from '../utils/user/account-type-access.js';
 import {listIncidents} from '../utils/session/incident-log.js';
 import {dismissAccessRequest, listAccessRequests} from '../utils/session/access-requests.js';
@@ -57,7 +57,7 @@ export default (provider) => {
         ctx.body = {
             groupPrefix: GroupPrefix,
             requireUsername: getUsernameSource() !== 'generated',
-            emailEnabled: isEmailEnabled(),
+            emailEnabled: isOutboundEmailEnabled(),
             disableEditing: process.env.DISABLE_FRONTEND_EDIT === 'true',
             disableEditingText: getText('disable_frontend_edit'),
         }
@@ -162,7 +162,7 @@ export default (provider) => {
     })
 
     router.post('/admin/api/account/invite', async (ctx, next) => {
-        if (!isEmailEnabled()) {
+        if (!isOutboundEmailEnabled()) {
             ctx.throw(404, 'Email-based invitations are disabled')
         }
         const email = ctx.request.body.email

--- a/src/routes/oidcRoutes.js
+++ b/src/routes/oidcRoutes.js
@@ -31,7 +31,7 @@ import {recordIncident} from "../utils/session/incident-log.js";
 import {canRequestAccess, recordAccessRequest} from "../utils/session/access-requests.js";
 import {UsernameCommitted} from "../conditions/username-committed.js";
 import validator, {checkEmail, checkRealName, checkUsername} from "../utils/session/validator.js";
-import {isEmailEnabled} from '../utils/email-configuration.js';
+import {isOutboundEmailEnabled} from '../utils/email-configuration.js';
 import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 
 // Which login methods are surfaced on the sign-in page. Each is enabled
@@ -39,7 +39,7 @@ import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 const authMethodsEnabled = () => ({
     webauthnEnabled: process.env.WEBAUTHN_ENABLED !== 'false',
     githubEnabled: process.env.GITHUB_ENABLED !== 'false',
-    emailEnabled: isEmailEnabled(),
+    emailEnabled: isOutboundEmailEnabled(),
     oidcProviders: getOidcProviders(),
 });
 

--- a/src/services/login/github-login.js
+++ b/src/services/login/github-login.js
@@ -5,10 +5,12 @@ import accessDenied from "../../utils/session/access-denied.js";
 import getLoginResult from "../../utils/user/get-login-result.js";
 import {GitHubGroupPrefix} from "../../utils/kubernetes/kube-constants.js";
 import {auditLog} from "../../utils/session/audit-log.js";
-import {isEmailEnabled} from '../../utils/email-configuration.js';
 
+// EMAIL_ENABLED governs outbound delivery only; emails are always collected
+// from GitHub so downstream clients keep receiving email claims even on
+// delivery-disabled deployments.
 export const getGitHubScopes = (env = process.env) => [
-    ...(isEmailEnabled(env) ? ['user:email'] : []),
+    'user:email',
     ...(env.GITHUB_ORGANIZATION ? ['read:org'] : []),
 ]
 
@@ -24,8 +26,7 @@ export const getGitHubAuthorizeParams = (state, env = process.env) => {
     }
 }
 
-export async function getGitHubEmails(token, fetchImpl = fetch, env = process.env, observedAt = new Date().toISOString()) {
-    if (!isEmailEnabled(env)) return []
+export async function getGitHubEmails(token, fetchImpl = fetch, observedAt = new Date().toISOString()) {
     const response = await fetchImpl('https://api.github.com/user/emails', {
         method: 'GET',
         headers: {'Authorization': `Bearer ${token}`},

--- a/src/services/login/oidc-login.js
+++ b/src/services/login/oidc-login.js
@@ -5,7 +5,7 @@ import getLoginResult from "../../utils/user/get-login-result.js";
 import { auditLog } from "../../utils/session/audit-log.js";
 import { getOidcClient, oidcRedirectUri } from "../../utils/oidc-providers.js";
 import ScimLinkService from "../scim-link-service.js";
-import {isEmailEnabled} from '../../utils/email-configuration.js';
+import {isOutboundEmailEnabled} from '../../utils/email-configuration.js';
 import {canonicalizeEmail} from '../../utils/user/identity-integrity.js';
 
 // An explicit upstream `email_verified: false` is heeded from every issuer,
@@ -13,7 +13,7 @@ import {canonicalizeEmail} from '../../utils/user/identity-integrity.js';
 // never grant it, so acting on it is always safe. The per-provider
 // emailVerification setting governs only whether `true` is trusted.
 export const getOidcEmailError = (profile, env = process.env) => {
-    if (!profile.email && isEmailEnabled(env)) return 'missing'
+    if (!profile.email && isOutboundEmailEnabled(env)) return 'missing'
     if (profile.email && profile.email_verified === false) return 'unverified'
     return null
 }
@@ -186,7 +186,7 @@ export default async (ctx, provider, providerConfig) => {
                 auditLog(ctx, { interactionDetails }, `Accepting upstream-unverified email from ${displayName}: address is Passmower-verified for the already-linked account`);
             } else {
                 auditLog(ctx, { error: true, interactionDetails }, `Email not verified by ${displayName}`);
-                const remediation = isEmailEnabled()
+                const remediation = isOutboundEmailEnabled()
                     ? `Verify ${profile.email} at ${displayName} and sign in again, or use email login to verify it with Passmower.`
                     : `Verify ${profile.email} at ${displayName} and sign in again.`;
                 return accessDenied(ctx, provider, `Email not verified by ${displayName}. ${remediation}`);

--- a/src/services/notification-service.js
+++ b/src/services/notification-service.js
@@ -1,6 +1,6 @@
 import EmailAdapter from "../adapters/email.js";
 import {SlackAdapter} from "../adapters/slack.js";
-import {isEmailEnabled} from "../utils/email-configuration.js";
+import {isOutboundEmailEnabled} from "../utils/email-configuration.js";
 
 export const loginNotificationsEnabled = (env = process.env) => env.NOTIFY_ON_LOGIN === 'true'
 export const impersonationNotificationsEnabled = (env = process.env) => env.NOTIFY_ON_IMPERSONATION !== 'false'
@@ -16,7 +16,7 @@ export const notifyAccount = async (account, subject, text, {
 } = {}) => {
     if (!account) return
     const deliveries = []
-    if (isEmailEnabled(env) && account.primaryEmail) {
+    if (isOutboundEmailEnabled(env) && account.primaryEmail) {
         deliveries.push(emailAdapter.sendMail(account.primaryEmail, subject, text)
             .catch(error => globalThis.logger?.warn(
                 {error: error.message, accountId: account.accountId},

--- a/src/utils/email-configuration.js
+++ b/src/utils/email-configuration.js
@@ -1,4 +1,9 @@
-export const isEmailEnabled = (env = process.env) => env.EMAIL_ENABLED !== 'false'
+// OUTBOUND_EMAIL_ENABLED governs delivery only (SMTP, magic-link login, ToS
+// receipts, invitations, notification emails); email identity collection and
+// downstream email claims are independent of it. The pre-2.1 name
+// EMAIL_ENABLED remains honored as a fallback.
+export const isOutboundEmailEnabled = (env = process.env) =>
+    (env.OUTBOUND_EMAIL_ENABLED ?? env.EMAIL_ENABLED) !== 'false'
 
 const requiredEmailEnvironment = [
     'EMAIL_HOST',
@@ -7,7 +12,7 @@ const requiredEmailEnvironment = [
 ]
 
 export function validateEmailConfiguration(env = process.env) {
-    if (!isEmailEnabled(env)) return
+    if (!isOutboundEmailEnabled(env)) return
     const missing = requiredEmailEnvironment.filter(key => !env[key])
     if (missing.length) {
         throw new Error(`Email is enabled but required configuration is missing: ${missing.join(', ')}`)

--- a/src/utils/oidc-providers.js
+++ b/src/utils/oidc-providers.js
@@ -1,5 +1,4 @@
 import * as client from "openid-client";
-import {isEmailEnabled} from './email-configuration.js';
 
 // Generic OIDC upstream providers. GitHub is intentionally NOT here — its API
 // is not standards-compliant OIDC and keeps its own handler (github-login.js).
@@ -22,9 +21,10 @@ import {isEmailEnabled} from './email-configuration.js';
 // where <KEY> is the provider key upper-cased with non-alphanumerics replaced
 // by underscores (e.g. key "google" -> GOOGLE_CLIENT_ID, key "entra-id" ->
 // ENTRA_ID_CLIENT_ID). A provider is only surfaced when both are present.
-const defaultScopes = () => isEmailEnabled()
-    ? ['openid', 'email', 'profile']
-    : ['openid', 'profile'];
+// EMAIL_ENABLED governs outbound delivery only — email identity collection and
+// downstream email claims work regardless, so the email scope is always
+// requested by default. Providers that reject it can override `scopes`.
+const defaultScopes = () => ['openid', 'email', 'profile'];
 
 const envKey = (key) => key.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
 

--- a/src/utils/user/confirm-tos.js
+++ b/src/utils/user/confirm-tos.js
@@ -1,7 +1,7 @@
 import Account from "../../models/account.js";
 import EmailAdapter from "../../adapters/email.js";
 import {getEmailContent, getEmailSubject} from "../get-email-content.js";
-import {isEmailEnabled} from '../email-configuration.js';
+import {isOutboundEmailEnabled} from '../email-configuration.js';
 import {auditLog} from '../session/audit-log.js';
 import {getTermsOfServiceDocument} from './tos-required.js';
 
@@ -21,7 +21,7 @@ export const confirmTos = async (ctx, accountId, contentHash) => {
         current => current.acceptTermsOfService(contentHash, acceptedAt),
     )
 
-    if (!isEmailEnabled() || !account.primaryEmail) return
+    if (!isOutboundEmailEnabled() || !account.primaryEmail) return
     try {
         const content = await getEmailContent('emails/tos', {
             name: account.profile.name,

--- a/test/unit/email-configuration.test.js
+++ b/test/unit/email-configuration.test.js
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {isEmailEnabled, validateEmailConfiguration} from '../../src/utils/email-configuration.js'
+import {isOutboundEmailEnabled, validateEmailConfiguration} from '../../src/utils/email-configuration.js'
 
 const configured = {
     EMAIL_ENABLED: 'true',
@@ -12,14 +12,14 @@ const configured = {
 
 describe('email configuration', () => {
     it('defaults to enabled and validates every documented SMTP setting', () => {
-        expect(isEmailEnabled({})).toBe(true)
+        expect(isOutboundEmailEnabled({})).toBe(true)
         expect(() => validateEmailConfiguration(configured)).not.toThrow()
         expect(() => validateEmailConfiguration({...configured, EMAIL_HOST: ''}))
             .toThrow(/EMAIL_HOST/)
     })
 
     it('has no SMTP configuration dependency when explicitly disabled', () => {
-        expect(isEmailEnabled({EMAIL_ENABLED: 'false'})).toBe(false)
+        expect(isOutboundEmailEnabled({EMAIL_ENABLED: 'false'})).toBe(false)
         expect(() => validateEmailConfiguration({EMAIL_ENABLED: 'false'})).not.toThrow()
     })
 
@@ -32,5 +32,15 @@ describe('email configuration', () => {
             .toThrow(/set together/)
         expect(() => validateEmailConfiguration({...configured, EMAIL_USERNAME: '', EMAIL_FROM: 'a@example.com'}))
             .toThrow(/set together/)
+    })
+})
+
+describe('outbound email switch naming', () => {
+    it('honors OUTBOUND_EMAIL_ENABLED with EMAIL_ENABLED as legacy fallback', () => {
+        expect(isOutboundEmailEnabled({OUTBOUND_EMAIL_ENABLED: 'false'})).toBe(false)
+        expect(isOutboundEmailEnabled({EMAIL_ENABLED: 'false'})).toBe(false)
+        // the new name wins when both are set
+        expect(isOutboundEmailEnabled({OUTBOUND_EMAIL_ENABLED: 'true', EMAIL_ENABLED: 'false'})).toBe(true)
+        expect(isOutboundEmailEnabled({})).toBe(true)
     })
 })

--- a/test/unit/github-login.test.js
+++ b/test/unit/github-login.test.js
@@ -5,27 +5,19 @@ import {
     getGitHubScopes,
 } from '../../src/services/login/github-login.js'
 
-describe('email-free GitHub login', () => {
-    it('does not request email permission or call the email API when disabled', async () => {
-        const env = {EMAIL_ENABLED: 'false', GITHUB_ORGANIZATION: 'codemowers'}
-        const fetchImpl = vi.fn()
+describe('GitHub email collection', () => {
+    it('requests user:email regardless of EMAIL_ENABLED (delivery-only switch)', () => {
+        // EMAIL_ENABLED governs outbound delivery; email identity collection
+        // and downstream email claims must keep working when it is off.
+        expect(getGitHubScopes({EMAIL_ENABLED: 'false', GITHUB_ORGANIZATION: 'codemowers'}))
+            .toEqual(['user:email', 'read:org'])
+        expect(getGitHubScopes({EMAIL_ENABLED: 'false'})).toEqual(['user:email'])
 
-        expect(getGitHubScopes(env)).toEqual(['read:org'])
-        await expect(getGitHubEmails('token', fetchImpl, env)).resolves.toEqual([])
-        expect(fetchImpl).not.toHaveBeenCalled()
-    })
-
-    it('omits the scope parameter when no GitHub permissions are needed', () => {
         const params = getGitHubAuthorizeParams('state', {
             EMAIL_ENABLED: 'false',
             ISSUER_URL: 'https://passmower.example/',
         })
-
-        expect(params).toEqual({
-            redirect_uri: 'https://passmower.example/interaction/callback/gh',
-            state: 'state',
-        })
-        expect(params).not.toHaveProperty('scope')
+        expect(params.scope).toBe('user:email')
     })
 
     it('sends multiple scopes as one space-delimited value', () => {
@@ -44,7 +36,7 @@ describe('email-free GitHub login', () => {
             status: 404,
             json: async () => ({message: 'Not Found'}),
         })
-        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}))
+        await expect(getGitHubEmails('token', fetchImpl))
             .rejects.toThrow(/404.*Not Found/)
     })
 
@@ -55,7 +47,7 @@ describe('email-free GitHub login', () => {
         ]})
 
         expect(getGitHubScopes({EMAIL_ENABLED: 'true'})).toEqual(['user:email'])
-        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}, '2026-08-22T10:00:00.000Z'))
+        await expect(getGitHubEmails('token', fetchImpl, '2026-08-22T10:00:00.000Z'))
             .resolves.toEqual([{
                 email: 'verified@example.com', verified: true,
                 observedAt: '2026-08-22T10:00:00.000Z',
@@ -66,7 +58,7 @@ describe('email-free GitHub login', () => {
         const fetchImpl = vi.fn().mockResolvedValue({json: async () => [{
             email: 'private@example.com', primary: true, verified: true, visibility: null,
         }]})
-        await expect(getGitHubEmails('token', fetchImpl, {EMAIL_ENABLED: 'true'}, '2026-08-22T10:00:00.000Z'))
+        await expect(getGitHubEmails('token', fetchImpl, '2026-08-22T10:00:00.000Z'))
             .resolves.toMatchObject([{
                 email: 'private@example.com', primary: true, verified: true, visibility: null,
             }])

--- a/test/unit/oidc-providers.test.js
+++ b/test/unit/oidc-providers.test.js
@@ -57,12 +57,12 @@ describe('getOidcProviders', () => {
         })
     })
 
-    it('does not request email by default when email is disabled but preserves explicit scopes', () => {
+    it('requests email by default even when delivery is disabled, preserving explicit scopes', () => {
         vi.stubEnv('EMAIL_ENABLED', 'false')
         vi.stubEnv('GITLAB_CLIENT_ID', 'id')
         vi.stubEnv('GITLAB_CLIENT_SECRET', 'secret')
         vi.stubEnv('OIDC_PROVIDERS', JSON.stringify({gitlab: {issuer: 'https://gitlab.example.com'}}))
-        expect(getOidcProvider('gitlab').scopes).toEqual(['openid', 'profile'])
+        expect(getOidcProvider('gitlab').scopes).toEqual(['openid', 'email', 'profile'])
 
         vi.stubEnv('OIDC_PROVIDERS', JSON.stringify({
             gitlab: {issuer: 'https://gitlab.example.com', scopes: ['openid', 'email']},


### PR DESCRIPTION
`EMAIL_ENABLED=false` conflated two orthogonal things: **outbound delivery** and **email identity collection/claims**. Disabling delivery stopped requesting `user:email`/`email` scopes, and — because spec merges replace arrays — a GitHub or OIDC login while disabled **wiped previously stored `github.emails`/identity emails**, breaking deployments that disable SMTP but still need to pass addresses downstream.

**Commit 1 — decouple.** `EMAIL_ENABLED` governs delivery only: GitHub always requests `user:email` and stores per-address evidence; generic providers default to `openid email profile` (per-provider `scopes` override remains); downstream `email`/`email_verified` flow regardless, gated only by the client's `email` scope. All delivery paths stay gated (SMTP, magic-link button, invitations, ToS receipts, notification emails, remediation text), and email-less enrollment while delivery is disabled still works.

**Commit 2 — rename to match the semantics.** `OUTBOUND_EMAIL_ENABLED` / `passmower.outboundEmailEnabled`:
- the legacy **env var** stays honored as a fallback (new name wins when both set) — non-chart deployments and existing secrets keep working;
- the legacy **Helm key** fails the render with an explicit rename message, so a stale overlay can't silently flip delivery on.

Docs updated across `email-configuration.md`, the migration guide (2.0.x vs 2.1 note), README, chart values, and AGENTS.md. 282 unit tests pass, including explicit fallback-precedence coverage; helm renders with base and dev values, and the legacy-key guard is verified to fail loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)