### PR TITLE
fix: restore missing availableScopes enum values in OIDCClient CRD

### DIFF
--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -810,14 +810,14 @@ spec:
                       - profile
                       - offline_access
                       - groups
-                availableScopesDelimiter:
-                  type: string
-                  default: ","
-                  description: Delimiter used when rendering OIDC_AVAILABLE_SCOPES into the generated client secret. OAuth2 scope strings are space-delimited, but the historical default here is a comma; set to " " for apps that split scopes on spaces.
                       - allowed_groups
                       - applications
                       - all_applications
                       - namespaces
+                availableScopesDelimiter:
+                  type: string
+                  default: ","
+                  description: Delimiter used when rendering OIDC_AVAILABLE_SCOPES into the generated client secret. OAuth2 scope strings are space-delimited, but the historical default here is a comma; set to " " for apps that split scopes on spaces.
                 displayName:
                   type: string
                 disabled:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "@playwright/test": "^1.62.1",
         "@vitest/coverage-v8": "^4.1.10",
+        "js-yaml": "^4.2.0",
         "nodemon": "^3.1.14",
         "npm-run-all": "^4.1.5",
         "oauth2-mock-server": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@playwright/test": "^1.62.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "js-yaml": "^4.2.0",
     "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",
     "oauth2-mock-server": "^9.1.0",

--- a/test/unit/crd-schema.test.js
+++ b/test/unit/crd-schema.test.js
@@ -1,5 +1,7 @@
 import {readFileSync} from 'node:fs'
 import {describe, expect, it} from 'vitest'
+import {loadAll} from 'js-yaml'
+import configuration from '../../src/configuration.js'
 
 const crds = readFileSync(new URL('../../charts/passmower/templates/crds.yaml', import.meta.url), 'utf8')
 
@@ -22,4 +24,29 @@ describe('OIDCUser CRD schema', () => {
         expect(spec).not.toContain('termsOfService:')
         expect(status).toContain('termsOfService:')
     })
+})
+
+describe('OIDCClient CRD schema', () => {
+    // Parse rather than string-match: the enum values that went missing in
+    // 746ebc9 were still literally present in the file, just folded into the
+    // preceding description as a multi-line plain scalar.
+    const oidcClientCrd = loadAll(crds).find(doc => doc?.metadata?.name === 'oidcclients.codemowers.cloud')
+
+    it.each(oidcClientCrd.spec.versions.map(version => version.name))(
+        '%s offers every scope the provider supports in availableScopes',
+        (versionName) => {
+            const version = oidcClientCrd.spec.versions.find(v => v.name === versionName)
+            const availableScopes = version.schema.openAPIV3Schema.properties.spec.properties.availableScopes
+
+            // oidc-provider derives its scopes from `scopes` plus every `claims`
+            // key that maps to a set of claims (helpers/configuration.js
+            // collectScopes), so this is the full set a client may request.
+            const claimDefinedScopes = Object.entries(configuration.claims)
+                .filter(([, claims]) => Array.isArray(claims))
+                .map(([scope]) => scope)
+            const supportedScopes = new Set([...configuration.scopes, ...claimDefinedScopes])
+
+            expect(new Set(availableScopes.items.enum)).toEqual(supportedScopes)
+        }
+    )
 })


### PR DESCRIPTION
## Problem

`746ebc9` ("feat: configurable OIDC_AVAILABLE_SCOPES delimiter") inserted `availableScopesDelimiter` into the middle of the `availableScopes` enum list in the OIDCClient CRD. The four trailing enum values were left more indented than the new `description:` key, so YAML folded them into that plain scalar:

```yaml
availableScopes:
  items:
    enum:
      - openid
      - email
      - profile
      - offline_access
      - groups            # <- enum ends here
availableScopesDelimiter:
  type: string
  default: ","
  description: Delimiter used ... for apps that split scopes on spaces.
      - allowed_groups    # <- folded into the description above
      - applications
      - all_applications
      - namespaces
```

Parsed, the delimiter's description ends with `"…split scopes on spaces. - allowed_groups - applications - all_applications - namespaces"` and the enum is four values short. `v1` and `v1beta1` share the `&oidcClientSchema` anchor, so both versions are affected.

Effect: since that commit, the API server rejects any `OIDCClient` whose `availableScopes` contains `allowed_groups`, `applications`, `all_applications` or `namespaces` — all four of which the provider fully supports (`src/configuration.js`).

## Fix

Move `availableScopesDelimiter` after the enum, restoring the four values.

## Test

A string-matching test cannot catch this class of bug — the values are still literally present in the file. The new test in `test/unit/crd-schema.test.js` therefore parses the rendered CRD and asserts, per served version, that the enum equals the scope set derived from `src/configuration.js`: `scopes` plus every claim-defined scope, the same derivation `oidc-provider`'s `collectScopes()` performs. That keeps the CRD from drifting as scopes are added.

Verified failing on the pre-fix YAML (both versions, missing exactly those four values) and passing after. Full unit suite green (284 tests).

`js-yaml` moves from `overrides` into a declared devDependency — it was already installed transitively via `@kubernetes/client-node`.

Found while investigating #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)