### PR TITLE
fix: return the created Secret from the Kubernetes adapter

### DIFF
--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -266,7 +266,7 @@ export class KubernetesAdapter {
             ...metadata
         }
         kubeSecret.data = await this.#generateSecretData(data)
-        await this.coreV1Api.createNamespacedSecret({
+        return await this.coreV1Api.createNamespacedSecret({
             namespace,
             body: kubeSecret
         }, this.defaultOptions).then(async (r) => {

--- a/test/fixtures/kubeconfig.yaml
+++ b/test/fixtures/kubeconfig.yaml
@@ -1,0 +1,21 @@
+# Minimal kubeconfig so KubernetesAdapter can be constructed in tests without a
+# cluster: the API clients are built but never used — tests stub the *Api
+# properties. Needed because the adapter's secret helpers are private methods,
+# so a real instance (not Object.create) is required to call them.
+apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+  - name: test
+    cluster:
+      server: https://kubernetes.invalid:6443
+contexts:
+  - name: test
+    context:
+      cluster: test
+      user: test
+      namespace: default
+users:
+  - name: test
+    user:
+      token: test-token

--- a/test/unit/kubernetes-secret.test.js
+++ b/test/unit/kubernetes-secret.test.js
@@ -1,0 +1,67 @@
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
+import {fileURLToPath} from 'node:url'
+import {KubernetesAdapter} from '../../src/adapters/kubernetes.js'
+
+// The client operator treats a falsy return from these as a reconcile failure
+// (#createKubeSecret / #patchKubeSecret), and the fake adapter always resolves
+// the secret it stored — so only a test against the real adapter catches a
+// dropped `return`. createSecret shipped without one: every freshly created
+// OIDCClient reported SecretReconcileFailed and never reached
+// redisAdapter.upsert(), leaving it absent from Redis (and so unusable at the
+// authorization endpoint) until its spec was next edited, even though its
+// Secret had been written correctly.
+describe('Kubernetes Secret reconciliation', () => {
+    let adapter
+    const secretName = 'oidc-client-grafana-owner-secrets'
+    const data = {
+        OIDC_CLIENT_ID: 'default.grafana',
+        OIDC_GRANT_TYPES: ['authorization_code'],
+    }
+
+    // A real instance, not Object.create: createSecret/patchSecret call the
+    // adapter's private #generateSecretData / #parseSecretData, and private
+    // members brand-check the receiver.
+    const kubeconfig = process.env.KUBECONFIG
+    beforeAll(() => {
+        process.env.KUBECONFIG = fileURLToPath(new URL('../fixtures/kubeconfig.yaml', import.meta.url))
+    })
+    afterAll(() => {
+        if (kubeconfig === undefined) delete process.env.KUBECONFIG
+        else process.env.KUBECONFIG = kubeconfig
+    })
+
+    beforeEach(() => {
+        globalThis.logger = {error: vi.fn()}
+        adapter = new KubernetesAdapter()
+    })
+
+    it('resolves the created Secret data so the operator can report Ready', async () => {
+        adapter.coreV1Api = {
+            createNamespacedSecret: vi.fn().mockImplementation(async ({body}) => ({data: body.data})),
+        }
+
+        await expect(adapter.createSecret('default', secretName, data, {})).resolves.toEqual(data)
+        const {body} = adapter.coreV1Api.createNamespacedSecret.mock.calls[0][0]
+        expect(body.metadata.name).toBe(secretName)
+        expect(body.data.OIDC_CLIENT_ID).toBe(Buffer.from('default.grafana').toString('base64'))
+    })
+
+    it('resolves the patched Secret data', async () => {
+        adapter.coreV1Api = {
+            patchNamespacedSecret: vi.fn().mockResolvedValue({
+                data: {OIDC_CLIENT_ID: Buffer.from('default.grafana').toString('base64')},
+            }),
+        }
+
+        await expect(adapter.patchSecret('default', secretName, data, {}, {metadata: {}, data: {}}))
+            .resolves.toEqual({OIDC_CLIENT_ID: 'default.grafana'})
+    })
+
+    it('resolves null and logs when the API rejects the create', async () => {
+        const forbidden = Object.assign(new Error('Forbidden'), {code: 403})
+        adapter.coreV1Api = {createNamespacedSecret: vi.fn().mockRejectedValue(forbidden)}
+
+        await expect(adapter.createSecret('default', secretName, data, {})).resolves.toBeNull()
+        expect(globalThis.logger.error).toHaveBeenCalledWith(forbidden)
+    })
+})


### PR DESCRIPTION
## Problem

`src/adapters/kubernetes.js` — `createSecret()` awaits `createNamespacedSecret()` but never returns the promise chain:

```js
async createSecret(namespace, id, data, metadata) {
    ...
    await this.coreV1Api.createNamespacedSecret({...})   // <- no `return`
        .then(async (r) => this.#parseSecretData(r.data))
        .catch((e) => { globalThis.logger.error(e); return null })
}
```

Its siblings `getSecret`, `patchSecret` and `createJob` all `return await`, and its only consumer treats a falsy result as a failure (`kube-oidc-client-operator.js:131`, `#createKubeSecret`):

```js
if (!secret) throw this.#reconcileError('SecretReconcileFailed', 'Failed to create client Secret')
```

So **every newly created `OIDCClient` fails its first reconcile**:

- `Ready=False / SecretReconcileFailed` and a `Warning` event, despite the Secret being written correctly
- the throw happens before `redisAdapter.upsert()` (`kube-oidc-client-operator.js:123`), so the client is absent from Redis — authorization requests for it fail with `invalid_client`

It self-heals on the next reconcile, which finds the existing Secret and takes the patch path: a watch re-list (~5 min in my dev cluster, `WATCH_TIMEOUT_MS` at the outside), an operator restart, or any **spec** edit. An annotation-only edit does not do it — that's filtered by the reconcile fingerprint. Net effect is a few minutes of a broken-looking new client, a spurious Warning event, and a misleading `Ready=False` window.

## Fix

Add the missing `return`. One line, no behaviour change for any other caller (there is only one).

`deleteSecret` and `watchObjects` have the same omission but no caller uses their return value, so they're left alone rather than changed speculatively.

## Test

The existing operator tests could not catch this — `test/fakes/fake-kubernetes-adapter.js:98` always resolves the secret it stored, so the real adapter's return contract was never exercised. That fake-vs-real drift is the actual gap, so the new `test/unit/kubernetes-secret.test.js` tests the real adapter with a stubbed `CoreV1Api`:

- `createSecret` resolves the parsed Secret data (fails without the fix)
- `createSecret` resolves `null` and logs when the API rejects it (fails without the fix)
- `patchSecret` resolves its parsed data — a guard so the same omission in a sibling gets caught

Unlike the other adapter tests, this one needs a real instance instead of `Object.create(KubernetesAdapter.prototype)`, because the secret helpers call private methods that brand-check the receiver — hence the minimal `test/fixtures/kubeconfig.yaml` (the API clients are built but never used).

Full unit suite green: 59 files, 285 tests.

## Validated on minikube

Paired before/after against the running dev operator (same pod, nodemon reload, identical client spec):

| | Result |
|---|---|
| Fresh OIDCClient, unpatched `develop` in the pod | `Ready=False / SecretReconcileFailed`, `Warning` event |
| Fresh OIDCClient, patched adapter in the pod | `Ready=True / Reconciled` on the first reconcile, `Normal` event, Secret present, `oidc:Client:default.<name>` present in Redis |

Test resources removed and the pod's source restored afterwards.

Found while validating #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)