### PR TITLE
feat: per-client claim mappings for application roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,11 @@ npm run test:e2e         # Playwright browser login against Dex (docker-compose.
   the live `Set-Cookie` header to `[Redacted]` on the wire and breaks every login.
 - `end_session` reads `ctx.cookies`, not `ctx.oidc.cookies` (set both if shimming).
 - `base-domain` must guard IP/`localhost` hosts (no public suffix → return the hostname).
+- `oidc-provider` **silently drops any claim it was not configured with**: the mask
+  in `helpers/claims.js` filters against `claimsSupported`, built once at boot from
+  the `claims` config. Runtime claim names (per-client `spec.claimMappings`) must be
+  added to `instance(provider).configuration` — `src/utils/claim-mappings.js` owns
+  that, and `test/unit/claim-mappings.test.js` pins the internal shape.
 
 ## Local development
 
@@ -237,4 +242,4 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | `KUBERNETES_SERVICE_HOST`, `POD_NAMESPACE` | Set in-cluster; switch kubeconfig/namespace behaviour. |
 
 See also: `README.md` (install + upstream config), `docs/application-listing.md`,
-`docs/username-configuration.md`.
+`docs/claim-mappings.md`, `docs/username-configuration.md`.

--- a/README.md
+++ b/README.md
@@ -308,6 +308,15 @@ user is allowed to open — via the `applications` userinfo claim, or the full
 admin-only catalog at `GET /api/apps/all`. See
 [docs/application-listing.md](docs/application-listing.md).
 
+## Mapping groups to application roles
+
+Many applications carry their own role or entitlement model and expect to be told
+which one a user has, in a claim of their own naming. Per-client
+`OIDCClient.spec.claimMappings` derives such a claim from group membership, so an
+application's roles can be governed alongside its client in Git without Passmower
+knowing anything about that application — and without a code change here for the
+next one. See [docs/claim-mappings.md](docs/claim-mappings.md).
+
 ## Audit logging and application activity
 
 Passmower emits minimal structured audit records and maintains bounded recent

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -818,6 +818,37 @@ spec:
                   type: string
                   default: ","
                   description: Delimiter used when rendering OIDC_AVAILABLE_SCOPES into the generated client secret. OAuth2 scope strings are space-delimited, but the historical default here is a comma; set to " " for apps that split scopes on spaces.
+                claimMappings:
+                  type: object
+                  description: >-
+                    Extra claims emitted to this client only, derived from group
+                    membership — for applications that expect their own role or
+                    entitlement in a claim of their own naming. Keyed by
+                    claim name; rules are evaluated in order and the first one
+                    with a matching group wins, `default` applies when none
+                    match, and the claim is omitted when there is no match and
+                    no default. A rule without groups never matches. Claim names
+                    Passmower owns (sub, email, groups, ...) are rejected.
+                  additionalProperties:
+                    type: object
+                    properties:
+                      default:
+                        type: string
+                        description: Value emitted when no rule matches. Omit to emit nothing.
+                      rules:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - value
+                          properties:
+                            value:
+                              type: string
+                            groups:
+                              type: array
+                              description: Prefixed group names, as in allowedGroups and the groups claim (e.g. github:admins). Matching is OR within a rule.
+                              items:
+                                type: string
                 displayName:
                   type: string
                 disabled:

--- a/docs/claim-mappings.md
+++ b/docs/claim-mappings.md
@@ -1,0 +1,167 @@
+# Claim mappings
+
+Many applications carry their own role or entitlement model and expect the
+identity provider to tell them which one a user has, in a claim of their own
+naming. `OIDCClient.spec.claimMappings` derives such a claim from Passmower group
+membership, for that client only.
+
+The point is that this needs no support for the specific application: whatever
+the app calls its claim and whatever values it accepts, the mapping is written in
+the client's own resource, so a new application is onboarded by editing its
+`OIDCClient` rather than by changing Passmower.
+
+```yaml
+apiVersion: codemowers.cloud/v1
+kind: OIDCClient
+metadata:
+  name: gallery
+  namespace: apps
+spec:
+  displayName: Gallery
+  uri: https://gallery.example.com
+  redirectUris:
+    - https://gallery.example.com/auth/login
+  grantTypes: ['authorization_code']
+  responseTypes: ['code']
+  availableScopes: ['openid', 'profile', 'email']
+  claimMappings:
+    gallery_role:
+      default: user
+      rules:
+        - value: admin
+          groups: ['github:platform-admins']
+```
+
+A user in `github:platform-admins` receives `"gallery_role": "admin"`; everyone
+else receives `"gallery_role": "user"`.
+
+## Semantics
+
+- **Keyed by claim name.** Each key becomes a claim emitted to this client.
+- **Rules are ordered; the first match wins.** A rule matches when the user is in
+  *any* of its `groups` (OR). Put the most privileged rule first.
+- **`groups` are prefixed names** — `github:admins`, `local:staff` — exactly as
+  they appear in the `groups` claim and in `allowedGroups`.
+- **`default` is the catch-all.** It applies when no rule matches. A rule with no
+  `groups` never matches, so `default` is the only way to express "everyone".
+- **No match and no default means no claim.** The claim is omitted rather than
+  emitted empty, so an app can tell "no opinion" from "the lowest role".
+- **Values are strings.** One rule, one value.
+
+## Where mapped claims appear
+
+Mapped claims are bound to the `openid` scope, which every authorization grants,
+so a client does not have to request anything extra to receive them. They are
+emitted in the **ID token**, from the **UserInfo endpoint**, and in **JWT access
+tokens** (the ones issued when a client requests an RFC 8707 `resource`).
+
+They are evaluated per request from the user's current groups, so a group change
+takes effect on the next token — the same freshness as the `groups` claim itself.
+
+Mapped claim names also appear in the discovery document's `claims_supported`
+once a client using them has been served, which is an accurate description of
+what the issuer emits.
+
+## Reserved claims
+
+A mapping may not name a claim Passmower owns — identity, authorization and
+token-shape claims (`sub`, `email`, `email_verified`, `groups`, `username`,
+`name`, `aud`, `exp`, …) or one Passmower computes itself (`applications`,
+`codemowers.io/namespaces`). This is the same list the claims-enrichment webhook
+is filtered against: a claim mapping is configuration, and configuration must not
+be able to rewrite who somebody is.
+
+A client whose `claimMappings` names a reserved claim, or uses a claim name that
+cannot go in a token, is **refused**: the `OIDCClient` gets
+`Ready=False` with reason `InvalidClaimMappings` and a message naming every
+problem, a Warning event, and it is not registered with the provider.
+
+```
+kubectl describe oidcclient gallery
+...
+  Conditions:
+    Type    Status  Reason                 Message
+    Ready   False   InvalidClaimMappings   Invalid spec.claimMappings: claim "groups" is reserved by Passmower
+```
+
+## Worked examples
+
+Two applications that came up when this was designed ([#220][issue]), as
+illustrations of the same mechanism — neither is special-cased anywhere in
+Passmower.
+
+[issue]: https://github.com/passmower/passmower/issues/220
+
+### An app that reads a fixed claim name (Immich)
+
+Immich reads a role claim from UserInfo and accepts two values. The mapping just
+has to produce those values under the name it reads:
+
+```yaml
+  claimMappings:
+    immich_role:
+      default: user
+      rules:
+        - value: admin
+          groups: ['github:platform-admins']
+```
+
+Check the application's own documentation for the claim name and the values it
+accepts; that is the whole integration.
+
+### An app that can read any claim (Grafana)
+
+An application flexible enough to evaluate an expression over its claims usually
+needs **no mapping at all**. Grafana's `role_attribute_path` is a JMESPath over
+the claims it receives, so it can read the existing `groups` claim directly,
+provided the client allows and requests the `groups` scope.
+
+```yaml
+# OIDCClient
+spec:
+  availableScopes: ['openid', 'profile', 'email', 'groups']
+```
+
+```ini
+# Grafana
+[auth.generic_oauth]
+scopes = openid profile email groups
+role_attribute_path = contains(groups[*], 'github:platform-admins') && 'Admin' || contains(groups[*], 'github:devs') && 'Editor' || 'Viewer'
+```
+
+Reach for a mapping when you would rather keep the role policy next to the
+client in Git than inside a JMESPath expression in Grafana's config, in which
+case a single claim is simpler to read on both sides:
+
+```yaml
+  claimMappings:
+    grafana_role:
+      default: Viewer
+      rules:
+        - value: Admin
+          groups: ['github:platform-admins']
+        - value: Editor
+          groups: ['github:devs']
+```
+
+```ini
+role_attribute_path = grafana_role
+```
+
+Grafana's `skip_org_role_sync` is unrelated to Passmower — it controls whether
+Grafana keeps managing org roles itself, and applies whichever source the role
+comes from.
+
+## Relationship to the enrichment webhook
+
+`EXTRA_CLAIMS_WEBHOOK_URL` and claim mappings solve different problems:
+
+| | Claim mappings | Enrichment webhook |
+|---|---|---|
+| Scope | One client, declared in its `OIDCClient` | Install-wide |
+| Source of truth | Group membership, in Git | Any external service |
+| Claim names | Chosen per client | Fixed (`codemowers.io/namespaces`) |
+| Failure mode | None — pure evaluation | Fail-open: claim absent |
+
+Use a mapping for "this app's roles come from these groups". Use the webhook when
+the value has to come from a system outside Kubernetes.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -4,6 +4,7 @@ import setupPolicies from "./providers/setup-policies.js";
 import {errors} from "oidc-provider";
 import isOrigin from "./utils/session/is-origin.js";
 import {fetchExtraClaims} from "./utils/fetch-extra-claims.js";
+import {mappedClaimsFor} from "./utils/claim-mappings.js";
 import {getAccountAccessFailure} from './utils/user/check-account-access.js';
 import {auditLog} from './utils/session/audit-log.js';
 
@@ -39,7 +40,13 @@ export default {
         const scopes = token.scope ? token.scope.split(' ') : [];
         const wantsGroups = scopes.includes('groups');
         const wantsNamespaces = scopes.includes('namespaces');
-        if (!wantsGroups && !wantsNamespaces) {
+        // Mapped claims are bound to the openid scope rather than requested, so
+        // they apply to any access token this client is issued.
+        const client = ctx?.oidc?.client?.clientId === token.clientId
+            ? ctx.oidc.client
+            : await ctx?.oidc?.provider?.Client?.find(token.clientId);
+        const hasClaimMappings = !!Object.keys(client?.claimMappings ?? {}).length;
+        if (!wantsGroups && !wantsNamespaces && !hasClaimMappings) {
             return undefined;
         }
         const account = await Account.findAccount(ctx, token.accountId);
@@ -61,6 +68,7 @@ export default {
                 scope: token.scope,
             }));
         }
+        Object.assign(claims, mappedClaimsFor(ctx?.oidc?.provider, client, groups));
         return Object.keys(claims).length ? claims : undefined;
     },
     cookies: {
@@ -196,6 +204,7 @@ export default {
         properties: [
             'allowedGroups',
             'allowedUsers',
+            'claimMappings',
             'clientNamespace',
             'availableScopes',
             'kind',
@@ -206,6 +215,13 @@ export default {
             'allowedCORSOrigins'
         ],
         validator(ctx, key, value, metadata) {
+            // Unlisted metadata is stripped by oidc-provider, and a client
+            // predating the field has none — normalise so the emission paths
+            // can read client.claimMappings without guarding.
+            if (key === 'claimMappings' && (value === undefined || value === null)) {
+                metadata['claimMappings'] = {};
+                return;
+            }
             if (key === 'allowedCORSOrigins') {
                 // set default (no CORS)
                 if (value === undefined) {

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -6,6 +6,7 @@ import {listMyApps} from "../utils/apps/list-apps.js";
 import {getUsernameSource} from "../utils/username-source.js";
 import {sanitizeUsername, isUsernameValid, isUsernameAvailable} from "../utils/user/username.js";
 import {fetchExtraClaims} from "../utils/fetch-extra-claims.js";
+import {mappedClaimsFor} from "../utils/claim-mappings.js";
 import {canonicalizeEmail, IdentityIntegrityError} from '../utils/user/identity-integrity.js';
 import {getTermsOfServiceDocument} from '../utils/user/tos-required.js';
 import {canImpersonateAccount} from '../utils/user/account-type-access.js';
@@ -140,6 +141,13 @@ class Account {
                 scope,
             }))
         }
+        // Group-derived claims of the application's own naming, from the
+        // client's spec.claimMappings (#220) — an application with its own role
+        // or entitlement model driven from Passmower groups. Merged last, but it
+        // cannot shadow anything above: reserved claim names are refused.
+        Object.assign(response, mappedClaimsFor(
+            this.#ctx?.oidc?.provider, this.#ctx?.oidc?.client, groups
+        ))
 
         return response
     }

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -36,6 +36,7 @@ class OIDCClient {
     #redirectUris = null
     #allowedGroups = null
     #allowedUsers = null
+    #claimMappings = null
     #overrideIncomingScopes = null
     #availableScopes = null
     #availableScopesDelimiter = ','
@@ -69,6 +70,7 @@ class OIDCClient {
             redirect_uris: this.#redirectUris,
             allowedGroups: this.#allowedGroups, // camel case because it's a custom metadata
             allowedUsers: this.#allowedUsers,
+            claimMappings: this.#claimMappings,
             availableScopes: this.#availableScopes,
             instanceUri: this.#instanceUri,
             uri: this.#uri,
@@ -93,6 +95,7 @@ class OIDCClient {
         this.#redirectUris = incomingClient.spec.redirectUris
         this.#allowedGroups = incomingClient.spec.allowedGroups || []
         this.#allowedUsers = incomingClient.spec.allowedUsers || []
+        this.#claimMappings = incomingClient.spec.claimMappings ?? {}
         this.#overrideIncomingScopes = incomingClient.spec.overrideIncomingScopes
         this.#availableScopes = incomingClient.spec.availableScopes
         // OAuth2 scope strings are space-delimited, but the generated secret
@@ -144,6 +147,10 @@ class OIDCClient {
             ],
             ...this.#secretMetadata
         }
+    }
+
+    getClaimMappings() {
+        return this.#claimMappings
     }
 
     getConditions() {

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -8,6 +8,7 @@ import {KubernetesAdapter} from "../adapters/kubernetes.js";
 import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 import {getActivityTracker} from "../services/activity-tracker.js";
 import {ClientReconcileState} from '../models/client-activity-state.js';
+import {validateClaimMappings} from '../utils/claim-mappings.js'
 
 export class KubeOIDCClientOperator {
     constructor(provider, adapter = new KubernetesAdapter(), redisAdapter = new RedisAdapter('Client')) {
@@ -33,6 +34,7 @@ export class KubeOIDCClientOperator {
     async #createOIDCClient (OIDCClient) {
         this.reconcileState.register(OIDCClient)
         try {
+            this.#assertValidClaimMappings(OIDCClient)
             if (OIDCClient.getInstance() === this.instance) {
                 if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
                     let secret = await this.adapter.getSecret(
@@ -99,6 +101,7 @@ export class KubeOIDCClientOperator {
             OIDCClient = claimedClient
         }
         try {
+            this.#assertValidClaimMappings(OIDCClient)
             if (OIDCClient.isDisabled()) {
                 await this.redisAdapter.destroy(OIDCClient.getClientId())
                 await this.#reportReady(OIDCClient, 'Disabled', 'Client is disabled and absent from Redis')
@@ -164,6 +167,20 @@ export class KubeOIDCClientOperator {
 
     #reconcileError(reason, message) {
         return Object.assign(new Error(message), {reason})
+    }
+
+    // Refuse a mapping that names a claim Passmower owns, or one that could not
+    // be put in a token, before the client reaches Redis — it would otherwise
+    // reconcile normally and emit that claim on every login. The message lands
+    // on the resource as Ready=False.
+    #assertValidClaimMappings(OIDCClient) {
+        const problems = validateClaimMappings(OIDCClient.getClaimMappings())
+        if (problems.length) {
+            throw this.#reconcileError(
+                'InvalidClaimMappings',
+                `Invalid spec.claimMappings: ${problems.join('; ')}`
+            )
+        }
     }
 
     async #reportReady(OIDCClient, reason, message) {

--- a/src/utils/claim-mappings.js
+++ b/src/utils/claim-mappings.js
@@ -1,0 +1,136 @@
+import instance from 'oidc-provider/lib/helpers/weak_cache.js'
+import {PROTECTED_CLAIMS} from './protected-claims.js'
+
+// Per-client claim mappings (OIDCClient spec.claimMappings): turn a user's
+// group membership into a claim of the application's own naming, so an
+// application with its own role or entitlement model can be driven from
+// Passmower groups — with no application-specific knowledge here, and no code
+// change for the next application that wants one (#220).
+//
+//   claimMappings:
+//     app_role:
+//       default: viewer
+//       rules:
+//         - value: admin
+//           groups: ['github:admins']
+//
+// Rules are evaluated in order and the first one with a matching group wins;
+// `default` applies when none match, and the claim is omitted entirely when
+// there is no match and no default. A rule with no groups never matches —
+// `default` is how you express a catch-all.
+
+// Claims Passmower computes itself, on top of the ones it owns outright: a
+// mapping may not shadow the apps list or the webhook-supplied namespaces.
+const RESERVED_CLAIMS = new Set([...PROTECTED_CLAIMS, 'applications', 'codemowers.io/namespaces'])
+
+// Deliberately narrower than the JWT spec (any string is a legal member name):
+// this is the shape claim names actually take — a bare word, a snake_cased one,
+// or a domain-prefixed one like codemowers.io/roles — and it keeps mapped names
+// printable and unambiguous in discovery metadata.
+const CLAIM_NAME = /^[a-zA-Z][a-zA-Z0-9._:/-]{0,63}$/
+
+// Returns human-readable problems for the operator to surface on the resource,
+// empty when the mappings are usable. The CRD schema covers the types; this
+// covers what a schema cannot express.
+export const validateClaimMappings = (claimMappings) => {
+    if (claimMappings === undefined || claimMappings === null) {
+        return []
+    }
+    if (typeof claimMappings !== 'object' || Array.isArray(claimMappings)) {
+        return ['claimMappings must be an object keyed by claim name']
+    }
+    const problems = []
+    for (const [claim, mapping] of Object.entries(claimMappings)) {
+        if (RESERVED_CLAIMS.has(claim)) {
+            problems.push(`claim "${claim}" is reserved by Passmower`)
+            continue
+        }
+        if (!CLAIM_NAME.test(claim)) {
+            problems.push(`claim "${claim}" is not a valid claim name`)
+            continue
+        }
+        const rules = mapping?.rules ?? []
+        if (!Array.isArray(rules)) {
+            problems.push(`claim "${claim}" has a non-list rules`)
+            continue
+        }
+        if (mapping?.default !== undefined && typeof mapping.default !== 'string') {
+            problems.push(`claim "${claim}" has a non-string default`)
+        }
+        rules.forEach((rule, index) => {
+            if (typeof rule?.value !== 'string') {
+                problems.push(`claim "${claim}" rule ${index} has a non-string value`)
+            }
+            if (rule?.groups !== undefined && !Array.isArray(rule.groups)) {
+                problems.push(`claim "${claim}" rule ${index} has a non-list groups`)
+            }
+        })
+        if (!rules.length && mapping?.default === undefined) {
+            problems.push(`claim "${claim}" has neither rules nor a default`)
+        }
+    }
+    return problems
+}
+
+// `groups` are the prefixed strings the groups claim carries ("github:admins"),
+// which is also how allowedGroups is written — so a mapping and an access rule
+// name a group the same way.
+export const evaluateClaimMappings = (claimMappings, groups = []) => {
+    const memberships = new Set(groups)
+    const claims = {}
+    for (const [claim, mapping] of Object.entries(claimMappings ?? {})) {
+        // Defence in depth: the operator refuses to reconcile a client whose
+        // mappings name a reserved claim, so this only fires if one reaches
+        // Redis another way.
+        if (RESERVED_CLAIMS.has(claim)) {
+            continue
+        }
+        const matched = (mapping?.rules ?? []).find(
+            rule => (rule?.groups ?? []).some(group => memberships.has(group))
+        )
+        const value = matched?.value ?? mapping?.default
+        if (typeof value === 'string') {
+            claims[claim] = value
+        }
+    }
+    return claims
+}
+
+// oidc-provider masks account claims down to the names declared in its `claims`
+// configuration, resolved into `claimsSupported` once at boot
+// (helpers/claims.js, helpers/configuration.js collectClaims) — a claim it has
+// never heard of is dropped silently. Mapped names arrive at runtime from CRDs,
+// so they have to be added to that live configuration.
+//
+// Bound to the `openid` scope: it is granted on every authorization, and an
+// application reading a role claim generally does not request a scope for it.
+// Registration is additive and global, but values are only ever produced for
+// the client being served, so no client sees another client's mapped claims.
+// The cost is that mapped names appear in the discovery document's
+// claims_supported, which is also the honest answer to what this issuer emits.
+export const registerMappedClaims = (provider, claimMappings) => {
+    const names = Object.keys(claimMappings ?? {}).filter(claim => !RESERVED_CLAIMS.has(claim))
+    if (!names.length) {
+        return []
+    }
+    const {claims, claimsSupported} = instance(provider).configuration
+    const registered = names.filter(claim => !claimsSupported.has(claim))
+    for (const claim of registered) {
+        claims.openid[claim] = null
+        claimsSupported.add(claim)
+    }
+    return registered
+}
+
+// Register, then evaluate. Registering here rather than at reconcile time means
+// the claim survives the mask on the very first request for a client, whichever
+// way that client reached Redis and whether or not the operator has seen it
+// since the process started. Both are idempotent.
+export const mappedClaimsFor = (provider, client, groups) => {
+    const claimMappings = client?.claimMappings
+    if (!provider || !claimMappings || !Object.keys(claimMappings).length) {
+        return {}
+    }
+    registerMappedClaims(provider, claimMappings)
+    return evaluateClaimMappings(claimMappings, groups)
+}

--- a/src/utils/fetch-extra-claims.js
+++ b/src/utils/fetch-extra-claims.js
@@ -1,3 +1,5 @@
+import {PROTECTED_CLAIMS} from './protected-claims.js'
+
 // Calls a generic, external claims-enrichment webhook (an operator-supplied
 // HTTP service, in the spirit of Auth0 Actions or Okta inline hooks) and
 // returns the JSON claims object to merge into the issued token. Configured
@@ -8,15 +10,10 @@
 // so any error yields {} (the enriched claim is simply absent) rather than
 // throwing. Keep this for small, stable signals only — never a hot-path
 // dependency.
-// Claims the webhook must never influence: identity, authorization, and
-// token-shape claims are owned by Passmower. The webhook's response is merged
-// into issued tokens verbatim, so without this filter a compromised or buggy
-// webhook could override sub/groups/email_verified and impersonate any user.
-const PROTECTED_CLAIMS = new Set([
-    'sub', 'iss', 'aud', 'exp', 'iat', 'nbf', 'jti', 'auth_time', 'nonce',
-    'sid', 'azp', 'at_hash', 'c_hash', 'scope', 'client_id',
-    'email', 'email_verified', 'emails', 'groups', 'username', 'name',
-])
+// The webhook's response is merged into issued tokens verbatim, so without
+// this filter a compromised or buggy webhook could override
+// sub/groups/email_verified and impersonate any user. Shared with per-client
+// claim mappings, which are filtered the same way.
 
 const sanitizeClaims = (claims, sub) => {
     const entries = Object.entries(claims)

--- a/src/utils/protected-claims.js
+++ b/src/utils/protected-claims.js
@@ -1,0 +1,11 @@
+// Claims whose values Passmower owns: identity, authorization and token shape.
+// Every mechanism that lets configuration outside the provider contribute
+// claims — the enrichment webhook (EXTRA_CLAIMS_WEBHOOK_URL) and per-client
+// claim mappings (OIDCClient spec.claimMappings) — filters against this list,
+// so a compromised webhook or a careless client cannot override
+// sub/groups/email_verified and impersonate a user.
+export const PROTECTED_CLAIMS = new Set([
+    'sub', 'iss', 'aud', 'exp', 'iat', 'nbf', 'jti', 'auth_time', 'nonce',
+    'sid', 'azp', 'at_hash', 'c_hash', 'scope', 'client_id',
+    'email', 'email_verified', 'emails', 'groups', 'username', 'name',
+])

--- a/test/integration/claim-mappings.test.js
+++ b/test/integration/claim-mappings.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import request from 'supertest'
+import { createHash, randomBytes } from 'node:crypto'
+
+// Replace the Kubernetes adapter and email adapter before the app is imported.
+vi.mock('../../src/adapters/kubernetes.js', () => import('../fakes/shared-kube.js'))
+vi.mock('../../src/adapters/email.js', () => import('../fakes/email-capture.js'))
+
+import { fakeKube } from '../fakes/shared-kube.js'
+import { sentEmails } from '../fakes/email-capture.js'
+
+const ISSUER = process.env.ISSUER_URL
+const RP = {
+    client_id: 'immich',
+    client_secret: 'immich-secret',
+    redirect_uri: 'https://immich.test/auth/callback',
+}
+// The shape from the issue (#220): an app with its own two-role model, driven
+// from group membership.
+const CLAIM_MAPPINGS = {
+    immich_role: {
+        default: 'user',
+        rules: [{value: 'admin', groups: ['local:platform-admins']}],
+    },
+}
+
+const base64url = (buf) => buf.toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+describe('per-client claim mappings (HTTP)', () => {
+    let callback
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        process.env.EMAIL_ENABLED = 'true'
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        const provider = await buildProvider()
+        callback = provider.callback()
+
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        await new RedisAdapter('Client').upsert(RP.client_id, {
+            client_id: RP.client_id,
+            client_secret: RP.client_secret,
+            redirect_uris: [RP.redirect_uri],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'client_secret_basic',
+            availableScopes: ['openid', 'email'],
+            allowedGroups: [],
+            allowedCORSOrigins: [],
+            claimMappings: CLAIM_MAPPINGS,
+        })
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    const seedUser = (groups) => {
+        fakeKube.store.clear()
+        sentEmails.length = 0
+        fakeKube.seed('OIDCUser', {
+            metadata: { name: 'testuser', labels: {} },
+            spec: { email: 'test@example.com', name: 'Test User', groups },
+            passmower: { email: 'test@example.com' },
+            status: {
+                primaryEmail: 'test@example.com',
+                emails: ['test@example.com'],
+                groups,
+                profile: { name: 'Test User' },
+                conditions: [],
+                termsOfService: {
+                    acceptedAt: '2026-08-06T12:00:00.000Z',
+                    contentHash: 'test-content-hash',
+                },
+            },
+        })
+    }
+
+    beforeEach(() => seedUser([{prefix: 'local', name: 'staff'}]))
+
+    // --- tiny cookie-jar HTTP driver ---------------------------------------
+    const jar = () => new Map()
+    const cookieHeader = (j) => [...j.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+    function store(j, res) {
+        for (const c of res.headers['set-cookie'] ?? []) {
+            const pair = c.split(';')[0]
+            const i = pair.indexOf('=')
+            const name = pair.slice(0, i).trim()
+            const val = pair.slice(i + 1)
+            if (val === '') j.delete(name)
+            else j.set(name, val)
+        }
+    }
+    async function req(j, method, path, form) {
+        let r = request(callback)[method](path).set('Cookie', cookieHeader(j))
+        if (form) r = r.type('form').send(form)
+        const res = await r
+        store(j, res)
+        return res
+    }
+    const rpHost = new URL(RP.redirect_uri).host
+    async function follow(j, res, maxHops = 12) {
+        let cur = res
+        for (let i = 0; i < maxHops && cur.status >= 300 && cur.status < 400; i++) {
+            const loc = cur.headers.location
+            if (!loc) break
+            const u = loc.startsWith('http') ? new URL(loc) : new URL(loc, ISSUER)
+            if (u.host === rpHost) return cur
+            cur = await req(j, 'get', u.pathname + u.search)
+        }
+        return cur
+    }
+
+    // Log in by magic link and return the token response plus userinfo.
+    async function login() {
+        const j = jar()
+        const verifier = base64url(randomBytes(32))
+        const challenge = base64url(createHash('sha256').update(verifier).digest())
+        const authQuery = new URLSearchParams({
+            client_id: RP.client_id,
+            redirect_uri: RP.redirect_uri,
+            response_type: 'code',
+            scope: 'openid email',
+            state: 'state-220',
+            nonce: 'nonce-220',
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+        })
+
+        let res = await follow(j, await req(j, 'get', `/auth?${authQuery}`))
+        const uid = (res.headers.location ?? res.request.url).match(/\/interaction\/([^/?]+)/)[1]
+        await req(j, 'post', `/interaction/${uid}/email`, { email: 'test@example.com' })
+        const linkPath = sentEmails[0].html.match(/\/interaction\/[^/]+\/verify-email\/[0-9a-f-]+/)[0]
+        const final = await follow(j, await req(j, 'get', linkPath))
+        const code = new URL(final.headers.location).searchParams.get('code')
+
+        const tokenRes = await request(callback)
+            .post('/token')
+            .auth(RP.client_id, RP.client_secret)
+            .type('form')
+            .send({
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: RP.redirect_uri,
+                code_verifier: verifier,
+            })
+            .expect(200)
+
+        const idClaims = JSON.parse(
+            Buffer.from(tokenRes.body.id_token.split('.')[1], 'base64url').toString())
+        const userinfo = await request(callback)
+            .get('/me')
+            .set('Authorization', `Bearer ${tokenRes.body.access_token}`)
+            .expect(200)
+
+        return { idClaims, userinfo: userinfo.body }
+    }
+
+    it('emits the default value for a user in none of the mapped groups', async () => {
+        const { idClaims, userinfo } = await login()
+
+        expect(idClaims.immich_role).toBe('user')
+        expect(userinfo.immich_role).toBe('user')
+        // The mapping is additive: nothing it does displaces the real claims.
+        expect(idClaims.sub).toBe('testuser')
+        expect(idClaims.email).toBe('test@example.com')
+    })
+
+    it('emits the matching rule value for a member of a mapped group', async () => {
+        seedUser([
+            {prefix: 'local', name: 'staff'},
+            {prefix: 'local', name: 'platform-admins'},
+        ])
+
+        const { idClaims, userinfo } = await login()
+
+        expect(idClaims.immich_role).toBe('admin')
+        expect(userinfo.immich_role).toBe('admin')
+    })
+
+    it('advertises a mapped claim in discovery once it has been registered', async () => {
+        await login()
+
+        const discovery = await request(callback)
+            .get('/.well-known/openid-configuration')
+            .expect(200)
+
+        expect(discovery.body.claims_supported).toContain('immich_role')
+    })
+})

--- a/test/unit/claim-mappings.test.js
+++ b/test/unit/claim-mappings.test.js
@@ -1,0 +1,142 @@
+import {describe, expect, it} from 'vitest'
+import Provider from 'oidc-provider'
+import instance from 'oidc-provider/lib/helpers/weak_cache.js'
+import configuration from '../../src/configuration.js'
+import {
+    evaluateClaimMappings,
+    mappedClaimsFor,
+    registerMappedClaims,
+    validateClaimMappings,
+} from '../../src/utils/claim-mappings.js'
+
+const immichRole = {
+    immich_role: {
+        default: 'user',
+        rules: [{value: 'admin', groups: ['github:admins', 'github:platform']}],
+    },
+}
+
+describe('claim mapping evaluation', () => {
+    it('emits the first matching rule and falls back to the default', () => {
+        const mappings = {
+            grafana_role: {
+                default: 'Viewer',
+                rules: [
+                    {value: 'Admin', groups: ['github:admins']},
+                    {value: 'Editor', groups: ['github:devs']},
+                ],
+            },
+        }
+
+        expect(evaluateClaimMappings(mappings, ['github:devs'])).toEqual({grafana_role: 'Editor'})
+        // Rule order decides, not group order.
+        expect(evaluateClaimMappings(mappings, ['github:devs', 'github:admins']))
+            .toEqual({grafana_role: 'Admin'})
+        expect(evaluateClaimMappings(mappings, ['github:everyone']))
+            .toEqual({grafana_role: 'Viewer'})
+    })
+
+    it('omits the claim when nothing matches and there is no default', () => {
+        const mappings = {immich_role: {rules: [{value: 'admin', groups: ['github:admins']}]}}
+
+        expect(evaluateClaimMappings(mappings, ['github:staff'])).toEqual({})
+        expect(evaluateClaimMappings(mappings, ['github:admins'])).toEqual({immich_role: 'admin'})
+    })
+
+    it('never matches a rule without groups, so default is the only catch-all', () => {
+        expect(evaluateClaimMappings({role: {rules: [{value: 'everyone', groups: []}]}}, ['a:b']))
+            .toEqual({})
+    })
+
+    it('tolerates absent, empty and malformed mappings', () => {
+        expect(evaluateClaimMappings(undefined, ['a:b'])).toEqual({})
+        expect(evaluateClaimMappings({}, ['a:b'])).toEqual({})
+        expect(evaluateClaimMappings(immichRole, undefined)).toEqual({immich_role: 'user'})
+        expect(evaluateClaimMappings({role: {default: 7}}, [])).toEqual({})
+    })
+
+    it('refuses to emit a claim Passmower owns even if one reaches Redis', () => {
+        const mappings = {groups: {default: 'nice-try'}, email_verified: {default: 'true'}, immich_role: {default: 'user'}}
+
+        expect(evaluateClaimMappings(mappings, [])).toEqual({immich_role: 'user'})
+    })
+})
+
+describe('claim mapping validation', () => {
+    it('accepts absent mappings and the documented shape', () => {
+        expect(validateClaimMappings(undefined)).toEqual([])
+        expect(validateClaimMappings({})).toEqual([])
+        expect(validateClaimMappings(immichRole)).toEqual([])
+        expect(validateClaimMappings({'codemowers.io/roles': {default: 'member'}})).toEqual([])
+    })
+
+    it('rejects claims Passmower owns or computes itself', () => {
+        for (const claim of ['sub', 'groups', 'email', 'email_verified', 'username', 'applications', 'codemowers.io/namespaces']) {
+            expect(validateClaimMappings({[claim]: {default: 'x'}}))
+                .toEqual([`claim "${claim}" is reserved by Passmower`])
+        }
+    })
+
+    it('rejects unusable claim names and rule shapes', () => {
+        expect(validateClaimMappings({'has space': {default: 'x'}})).toEqual(
+            ['claim "has space" is not a valid claim name'])
+        expect(validateClaimMappings({'1role': {default: 'x'}})).toEqual(
+            ['claim "1role" is not a valid claim name'])
+        expect(validateClaimMappings({role: {rules: [{groups: ['a:b']}]}})).toEqual(
+            ['claim "role" rule 0 has a non-string value'])
+        expect(validateClaimMappings({role: {rules: [{value: 'x', groups: 'a:b'}]}})).toEqual(
+            ['claim "role" rule 0 has a non-list groups'])
+        expect(validateClaimMappings({role: {default: 7}})).toEqual(
+            ['claim "role" has a non-string default'])
+        expect(validateClaimMappings({role: {}})).toEqual(
+            ['claim "role" has neither rules nor a default'])
+        expect(validateClaimMappings([immichRole])).toEqual(
+            ['claimMappings must be an object keyed by claim name'])
+    })
+
+    it('reports every problem so one reconcile message covers the resource', () => {
+        expect(validateClaimMappings({sub: {default: 'x'}, 'bad name': {default: 'y'}}))
+            .toHaveLength(2)
+    })
+})
+
+// oidc-provider drops any claim it has not been told about (helpers/claims.js
+// masks against claimsSupported, built once at boot). Mapped claim names come
+// from CRDs at runtime, so registration reaches into the provider's live
+// configuration — the one place this codebase depends on an oidc-provider
+// internal. If an upgrade changes that shape, this test is the canary: mapped
+// claims would otherwise start disappearing from tokens silently.
+describe('claim registration against oidc-provider internals', () => {
+    const buildProvider = () => new Provider(process.env.ISSUER_URL, {...configuration})
+
+    it('adds unknown claim names to the live provider configuration', () => {
+        const provider = buildProvider()
+        const {claims, claimsSupported} = instance(provider).configuration
+
+        expect(claimsSupported.has('immich_role')).toBe(false)
+        expect(registerMappedClaims(provider, immichRole)).toEqual(['immich_role'])
+        // Bound to openid, which every authorization grants — the mask resolves
+        // claims per granted scope, so an unbound name would never be emitted.
+        expect(claims.openid.immich_role).toBeNull()
+        expect(claimsSupported.has('immich_role')).toBe(true)
+    })
+
+    it('is idempotent and leaves reserved names alone', () => {
+        const provider = buildProvider()
+
+        expect(registerMappedClaims(provider, immichRole)).toEqual(['immich_role'])
+        expect(registerMappedClaims(provider, immichRole)).toEqual([])
+        expect(registerMappedClaims(provider, {groups: {default: 'x'}})).toEqual([])
+        expect(registerMappedClaims(provider, undefined)).toEqual([])
+    })
+
+    it('registers and evaluates in one step for the request path', () => {
+        const provider = buildProvider()
+        const client = {claimMappings: immichRole}
+
+        expect(mappedClaimsFor(provider, client, ['github:admins'])).toEqual({immich_role: 'admin'})
+        expect(mappedClaimsFor(provider, client, [])).toEqual({immich_role: 'user'})
+        expect(mappedClaimsFor(provider, {}, ['github:admins'])).toEqual({})
+        expect(mappedClaimsFor(undefined, client, ['github:admins'])).toEqual({})
+    })
+})

--- a/test/unit/client-operator-status.test.js
+++ b/test/unit/client-operator-status.test.js
@@ -122,4 +122,47 @@ describe('OIDCClient reconciliation status', () => {
         })])
         expect(redis.records.size).toBe(0)
     })
+
+    it('refuses claimMappings naming a claim Passmower owns', async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        const redis = new FakeRedisAdapter()
+        const provider = {urlFor: endpoint => `https://id.example.com/${endpoint}`}
+        const operator = new KubeOIDCClientOperator(provider, adapter, redis)
+        await operator.watchClients()
+        const client = oidcClient('claim-squatter')
+        client.spec.claimMappings = {groups: {default: 'admins'}}
+        adapter.seed('OIDCClient', client)
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'claim-squatter')
+
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'False', reason: 'InvalidClaimMappings',
+            message: 'Invalid spec.claimMappings: claim "groups" is reserved by Passmower',
+        }))
+        expect(adapter.events).toEqual([expect.objectContaining({
+            reason: 'InvalidClaimMappings', type: 'Warning',
+        })])
+        // Rejected before the client can reach the provider.
+        expect(redis.records.size).toBe(0)
+    })
+
+    it('carries valid claimMappings through to the client record', async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        const redis = new FakeRedisAdapter()
+        const provider = {urlFor: endpoint => `https://id.example.com/${endpoint}`}
+        const operator = new KubeOIDCClientOperator(provider, adapter, redis)
+        await operator.watchClients()
+        const client = oidcClient('immich')
+        client.spec.claimMappings = {immich_role: {default: 'user', rules: [{value: 'admin', groups: ['github:admins']}]}}
+        adapter.seed('OIDCClient', client)
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'immich')
+
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(expect.objectContaining({
+            type: 'Ready', status: 'True', reason: 'Reconciled',
+        }))
+        expect(redis.records.get('apps.immich').claimMappings).toEqual(client.spec.claimMappings)
+    })
 })

--- a/test/unit/crd-schema.test.js
+++ b/test/unit/crd-schema.test.js
@@ -33,6 +33,20 @@ describe('OIDCClient CRD schema', () => {
     const oidcClientCrd = loadAll(crds).find(doc => doc?.metadata?.name === 'oidcclients.codemowers.cloud')
 
     it.each(oidcClientCrd.spec.versions.map(version => version.name))(
+        '%s declares claimMappings as claim-name-keyed rule sets',
+        (versionName) => {
+            const version = oidcClientCrd.spec.versions.find(v => v.name === versionName)
+            const mapping = version.schema.openAPIV3Schema.properties.spec.properties
+                .claimMappings.additionalProperties
+
+            expect(mapping.properties.default.type).toBe('string')
+            expect(mapping.properties.rules.items.required).toEqual(['value'])
+            expect(mapping.properties.rules.items.properties.value.type).toBe('string')
+            expect(mapping.properties.rules.items.properties.groups.items.type).toBe('string')
+        }
+    )
+
+    it.each(oidcClientCrd.spec.versions.map(version => version.name))(
         '%s offers every scope the provider supports in availableScopes',
         (versionName) => {
             const version = oidcClientCrd.spec.versions.find(v => v.name === versionName)


### PR DESCRIPTION
Closes #220 (needs closing by hand — PRs into `develop` don't auto-close).

## What

`OIDCClient.spec.claimMappings` derives a claim of the application's own naming from group membership, for that client only:

```yaml
spec:
  claimMappings:
    app_role:
      default: viewer
      rules:
        - value: admin
          groups: ['github:platform-admins']
```

The aim is broad compatibility rather than support for particular applications: whatever an app calls its claim and whatever values it accepts, the mapping lives in the client's own resource — so onboarding the next such application means editing its `OIDCClient`, not changing Passmower. Nothing is special-cased per app anywhere in the code, the CRD, or the README.

Rules are evaluated in order, first match wins (groups OR within a rule); `default` is the catch-all — a rule with no `groups` never matches; no match and no default omits the claim, so an app can tell "no opinion" from "the lowest role". Groups are the prefixed names already used by `allowedGroups` and the `groups` claim. Values are strings.

Mapped claims are bound to the `openid` scope, so a client requests nothing extra — they land in the **ID token**, **UserInfo**, and **JWT access tokens** (the RFC 8707 `resource` path). Evaluated per request, so a group change applies to the next token.

## Security boundary

A mapping may not name a claim Passmower owns — identity, authorization and token-shape claims — or one it computes itself (`applications`, `codemowers.io/namespaces`). That list moves to `src/utils/protected-claims.js` and is now shared with the claims-enrichment webhook, which was already filtered against it (no behaviour change there). Claim mappings are configuration, and configuration must not be able to rewrite who somebody is.

The operator refuses such a client with `Ready=False` / `InvalidClaimMappings` and a message naming every problem, in **both** the ADDED and MODIFIED reconcile paths, before it reaches Redis:

```
Ready   False   InvalidClaimMappings   Invalid spec.claimMappings: claim "groups" is reserved by Passmower
```

`evaluateClaimMappings` also skips reserved names as defence in depth, in case one reaches Redis another way.

## The oidc-provider subtlety

`oidc-provider` **silently drops any claim it was not configured with**: the mask in `helpers/claims.js:55` filters against `claimsSupported`, which `helpers/configuration.js` builds once at boot. Mapped names arrive at runtime from CRDs, so they have to be added to the provider's live configuration.

Registration happens at **emission** time, not reconcile time. The mask reads that configuration by live reference when it runs, and account claims are computed before the mask is constructed, so registering there takes effect on the very same request — which means the claim survives the *first* request for a client however it reached Redis (operator, direct Redis write, a test), and whether or not the operator has seen it since the process started. Registration and evaluation are both idempotent.

Bound to `openid` because it is granted on every authorization and an application reading a role claim generally does not request a scope for it. Registration is global but values are only ever produced for the client being served, so no client sees another's mapped claims. The cost is that mapped names show up in discovery `claims_supported` — which is an accurate description of what the issuer emits, and is asserted as such in the integration test.

This is the only place the codebase reaches for an oidc-provider internal (`lib/helpers/weak_cache.js`). It's confined to `src/utils/claim-mappings.js`, `test/unit/claim-mappings.test.js` pins the shape so a future major fails loudly rather than quietly dropping claims, and it's recorded in AGENTS.md's gotcha list.

## Docs

`docs/claim-mappings.md` leads with the mechanism and the semantics, then works through the two applications from the issue as illustrations of it — one that reads a fixed claim name, and one flexible enough to need **no mapping at all** (Grafana's `role_attribute_path` is a JMESPath and can read the existing `groups` claim directly; `skip_org_role_sync` is a Grafana-side switch, unrelated to which source the role comes from). The README section and the CRD field description stay generic.

## Tests

- **Unit** (`test/unit/claim-mappings.test.js`, 12 tests): first-match-wins, default fallback, claim omitted with neither, empty-`groups` rule never matching, malformed input, reserved-name refusal in both evaluation and validation, every validation message, and registration against a real `Provider` (adds to `claims.openid` + `claimsSupported`, idempotent, skips reserved).
- **Unit** (`client-operator-status.test.js`): a reserved-claim client gets `Ready=False`/`InvalidClaimMappings` + Warning and no Redis record; a valid one reconciles and carries `claimMappings` into the client record.
- **Unit** (`crd-schema.test.js`): the parsed CRD declares `claimMappings` with the documented shape on both served versions.
- **Integration** (`test/integration/claim-mappings.test.js`, 3 tests): a full magic-link login against a client with `claimMappings`, asserting the mapped claim in both the ID token and UserInfo — the default for a non-member, the rule value for a member of the mapped group — plus its appearance in discovery `claims_supported` afterwards.

Suites: unit 60 files / 303 tests, integration 10 files / 48 tests, all green.

## Validated on minikube

Against a real API server, using a throwaway CRD group so the live CRD and running operator were untouched: the documented shape is accepted, a rule missing `value` is rejected (`spec.claimMappings.<claim>.rules[0].value: Required value`), and a list-valued `default` is rejected (`must be of type string`). Probe CRD deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)