### PR TITLE
chore: release 2.1.1

### DIFF
--- a/charts/passmower/Chart.yaml
+++ b/charts/passmower/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -810,14 +810,14 @@ spec:
                       - profile
                       - offline_access
                       - groups
-                availableScopesDelimiter:
-                  type: string
-                  default: ","
-                  description: Delimiter used when rendering OIDC_AVAILABLE_SCOPES into the generated client secret. OAuth2 scope strings are space-delimited, but the historical default here is a comma; set to " " for apps that split scopes on spaces.
                       - allowed_groups
                       - applications
                       - all_applications
                       - namespaces
+                availableScopesDelimiter:
+                  type: string
+                  default: ","
+                  description: Delimiter used when rendering OIDC_AVAILABLE_SCOPES into the generated client secret. OAuth2 scope strings are space-delimited, but the historical default here is a comma; set to " " for apps that split scopes on spaces.
                 displayName:
                   type: string
                 disabled:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "@playwright/test": "^1.62.1",
         "@vitest/coverage-v8": "^4.1.10",
+        "js-yaml": "^4.2.0",
         "nodemon": "^3.1.14",
         "npm-run-all": "^4.1.5",
         "oauth2-mock-server": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@playwright/test": "^1.62.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "js-yaml": "^4.2.0",
     "nodemon": "^3.1.14",
     "npm-run-all": "^4.1.5",
     "oauth2-mock-server": "^9.1.0",

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -266,7 +266,7 @@ export class KubernetesAdapter {
             ...metadata
         }
         kubeSecret.data = await this.#generateSecretData(data)
-        await this.coreV1Api.createNamespacedSecret({
+        return await this.coreV1Api.createNamespacedSecret({
             namespace,
             body: kubeSecret
         }, this.defaultOptions).then(async (r) => {

--- a/test/fixtures/kubeconfig.yaml
+++ b/test/fixtures/kubeconfig.yaml
@@ -1,0 +1,21 @@
+# Minimal kubeconfig so KubernetesAdapter can be constructed in tests without a
+# cluster: the API clients are built but never used — tests stub the *Api
+# properties. Needed because the adapter's secret helpers are private methods,
+# so a real instance (not Object.create) is required to call them.
+apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+  - name: test
+    cluster:
+      server: https://kubernetes.invalid:6443
+contexts:
+  - name: test
+    context:
+      cluster: test
+      user: test
+      namespace: default
+users:
+  - name: test
+    user:
+      token: test-token

--- a/test/unit/crd-schema.test.js
+++ b/test/unit/crd-schema.test.js
@@ -1,5 +1,7 @@
 import {readFileSync} from 'node:fs'
 import {describe, expect, it} from 'vitest'
+import {loadAll} from 'js-yaml'
+import configuration from '../../src/configuration.js'
 
 const crds = readFileSync(new URL('../../charts/passmower/templates/crds.yaml', import.meta.url), 'utf8')
 
@@ -22,4 +24,29 @@ describe('OIDCUser CRD schema', () => {
         expect(spec).not.toContain('termsOfService:')
         expect(status).toContain('termsOfService:')
     })
+})
+
+describe('OIDCClient CRD schema', () => {
+    // Parse rather than string-match: the enum values that went missing in
+    // 746ebc9 were still literally present in the file, just folded into the
+    // preceding description as a multi-line plain scalar.
+    const oidcClientCrd = loadAll(crds).find(doc => doc?.metadata?.name === 'oidcclients.codemowers.cloud')
+
+    it.each(oidcClientCrd.spec.versions.map(version => version.name))(
+        '%s offers every scope the provider supports in availableScopes',
+        (versionName) => {
+            const version = oidcClientCrd.spec.versions.find(v => v.name === versionName)
+            const availableScopes = version.schema.openAPIV3Schema.properties.spec.properties.availableScopes
+
+            // oidc-provider derives its scopes from `scopes` plus every `claims`
+            // key that maps to a set of claims (helpers/configuration.js
+            // collectScopes), so this is the full set a client may request.
+            const claimDefinedScopes = Object.entries(configuration.claims)
+                .filter(([, claims]) => Array.isArray(claims))
+                .map(([scope]) => scope)
+            const supportedScopes = new Set([...configuration.scopes, ...claimDefinedScopes])
+
+            expect(new Set(availableScopes.items.enum)).toEqual(supportedScopes)
+        }
+    )
 })

--- a/test/unit/kubernetes-secret.test.js
+++ b/test/unit/kubernetes-secret.test.js
@@ -1,0 +1,67 @@
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
+import {fileURLToPath} from 'node:url'
+import {KubernetesAdapter} from '../../src/adapters/kubernetes.js'
+
+// The client operator treats a falsy return from these as a reconcile failure
+// (#createKubeSecret / #patchKubeSecret), and the fake adapter always resolves
+// the secret it stored — so only a test against the real adapter catches a
+// dropped `return`. createSecret shipped without one: every freshly created
+// OIDCClient reported SecretReconcileFailed and never reached
+// redisAdapter.upsert(), leaving it absent from Redis (and so unusable at the
+// authorization endpoint) until its spec was next edited, even though its
+// Secret had been written correctly.
+describe('Kubernetes Secret reconciliation', () => {
+    let adapter
+    const secretName = 'oidc-client-grafana-owner-secrets'
+    const data = {
+        OIDC_CLIENT_ID: 'default.grafana',
+        OIDC_GRANT_TYPES: ['authorization_code'],
+    }
+
+    // A real instance, not Object.create: createSecret/patchSecret call the
+    // adapter's private #generateSecretData / #parseSecretData, and private
+    // members brand-check the receiver.
+    const kubeconfig = process.env.KUBECONFIG
+    beforeAll(() => {
+        process.env.KUBECONFIG = fileURLToPath(new URL('../fixtures/kubeconfig.yaml', import.meta.url))
+    })
+    afterAll(() => {
+        if (kubeconfig === undefined) delete process.env.KUBECONFIG
+        else process.env.KUBECONFIG = kubeconfig
+    })
+
+    beforeEach(() => {
+        globalThis.logger = {error: vi.fn()}
+        adapter = new KubernetesAdapter()
+    })
+
+    it('resolves the created Secret data so the operator can report Ready', async () => {
+        adapter.coreV1Api = {
+            createNamespacedSecret: vi.fn().mockImplementation(async ({body}) => ({data: body.data})),
+        }
+
+        await expect(adapter.createSecret('default', secretName, data, {})).resolves.toEqual(data)
+        const {body} = adapter.coreV1Api.createNamespacedSecret.mock.calls[0][0]
+        expect(body.metadata.name).toBe(secretName)
+        expect(body.data.OIDC_CLIENT_ID).toBe(Buffer.from('default.grafana').toString('base64'))
+    })
+
+    it('resolves the patched Secret data', async () => {
+        adapter.coreV1Api = {
+            patchNamespacedSecret: vi.fn().mockResolvedValue({
+                data: {OIDC_CLIENT_ID: Buffer.from('default.grafana').toString('base64')},
+            }),
+        }
+
+        await expect(adapter.patchSecret('default', secretName, data, {}, {metadata: {}, data: {}}))
+            .resolves.toEqual({OIDC_CLIENT_ID: 'default.grafana'})
+    })
+
+    it('resolves null and logs when the API rejects the create', async () => {
+        const forbidden = Object.assign(new Error('Forbidden'), {code: 403})
+        adapter.coreV1Api = {createNamespacedSecret: vi.fn().mockRejectedValue(forbidden)}
+
+        await expect(adapter.createSecret('default', secretName, data, {})).resolves.toBeNull()
+        expect(globalThis.logger.error).toHaveBeenCalledWith(forbidden)
+    })
+})


### PR DESCRIPTION
Patch release off `master` for two bugs affecting released installs. Both fixes are already on `develop` (#224, #225) and would otherwise wait for 2.2.0; these are cherry-picks of `866efbe` and `ae1d122` plus the `Chart.yaml` bump.

## 1. `availableScopes` enum regression — new in 2.1.0

`746ebc9` (in 2.1.0) inserted `availableScopesDelimiter` into the middle of the `availableScopes` enum list. The four trailing values were left more indented than the new `description:` key, so YAML folded them into that plain scalar — the enum silently lost `allowed_groups`, `applications`, `all_applications` and `namespaces` on both `v1` and `v1beta1`, while the values remained literally present in the file.

Effect on a 2.1.0 install: the API server rejects any `OIDCClient` that requests one of those four scopes, all of which the provider fully supports. Clients created on ≤2.0.2 keep working (Kubernetes does not re-validate stored objects) but cannot be re-applied, so an ArgoCD sync of an unchanged manifest fails. The example in shipped `docs/application-listing.md` is itself rejected.

Upgrading fixes it with no action required: the CRDs live in `templates/` with no hooks or values gate, so `helm upgrade` applies the corrected schema, and widening an enum cannot invalidate anything already stored.

## 2. `createSecret()` never returned its result — every 2.x install

`src/adapters/kubernetes.js` awaited `createNamespacedSecret()` without returning the chain, so it always resolved `undefined` while its siblings all `return await`. Its only consumer treats a falsy result as failure, so **every newly created `OIDCClient` failed its first reconcile**: `Ready=False / SecretReconcileFailed`, a spurious Warning event, and the throw skipped `redisAdapter.upsert()`, leaving the client absent from Redis (`invalid_client` at the authorization endpoint) even though its Secret was written correctly. It self-heals on the next reconcile via the patch path — a watch re-list, an operator restart, or any spec edit.

Latent since the file was created in 2023; harmful since `f33c4e4` added the status reporting in 2.0.0. The upgrade is better than neutral here: the rollout restarts the operator, which re-reconciles every client through the working path, so anything sitting at `Ready=False / SecretReconcileFailed` clears as part of it.

## Scope

- No new features, no schema removals, no config or state migration.
- Both changes are strictly widening/repairing; rollback is safe (the bugs return, nothing is corrupted).
- Regression tests come with the cherry-picks: the CRD test parses the rendered schema and compares the enum against the scopes derived from `src/configuration.js` (a string-matching test cannot catch this class of bug), and the adapter test pins `createSecret`'s return contract against a stubbed `CoreV1Api` — the fake adapter always returned the secret, which is why no operator test caught it.

## Verified on the 2.1.x tree

`npm ci` on this branch (oidc-provider 9.11.3, as shipped in 2.1.0), then: unit 59 files / 287 tests green, integration 9 files / 45 tests green. The enum parses as all 9 values on both served versions, and `createSecret` returns.

Merging tags `v2.1.1`, publishes the release and the chart. `master` will be back-merged into `develop` afterwards, keeping `develop` at `2.2.0-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)