### PR TITLE
chore: migrate styles to Sass @use

### DIFF
--- a/styles/package.json
+++ b/styles/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
-    "sass-dev": "sass --style=expanded src/main.scss dist/style.css && sass --watch --update --style=expanded src/main.scss dist/style.css",
-    "sass-prod": "sass --no-source-map --style=compressed src/main.scss dist/style.css"
+    "sass-dev": "sass --style=expanded --fatal-deprecation=import src/main.scss dist/style.css && sass --watch --update --style=expanded --fatal-deprecation=import src/main.scss dist/style.css",
+    "sass-prod": "sass --no-source-map --style=compressed --fatal-deprecation=import src/main.scss dist/style.css"
   },
   "devDependencies": {
     "sass": "^1.103.1"

--- a/styles/src/main.scss
+++ b/styles/src/main.scss
@@ -1,4 +1,9 @@
-@import 'base';
+// `@use`, not `@import`: Sass @import is deprecated and goes away in Dart Sass
+// 3.0. Both sass scripts pass --fatal-deprecation=import so a reintroduced
+// @import fails the build instead of warning. base.scss holds only custom
+// properties and element rules, so nothing here needs the `base.` namespace —
+// a Sass variable or mixin added there would.
+@use 'base';
 
 body {
   max-width: 1280px;


### PR DESCRIPTION
Sass `@import` is deprecated and is **removed in Dart Sass 3.0**, so `npm run dev-styles` and the image build have both been printing this on every compile:

```
DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
  ╷
1 │ @import 'base';
```

(Pre-existing — verified it warns identically on the sass 1.102.0 that was in `develop` before #222, so this is not fallout from that bump.)

## The migration

`styles/src` is the only Sass in the repo (no `.scss` elsewhere, no `lang="scss"` blocks, `sass` is a dependency of `styles/` alone), it has exactly one `@import`, and there are no Sass variables, mixins or functions anywhere in it. So the change is one line:

```diff
-@import 'base';
+@use 'base';
```

`base.scss` holds only custom properties and element rules, so nothing needs the `base.` namespace that `@use` introduces — a Sass member added there later would, which the comment in `main.scss` notes.

## Guard against it coming back

Both scripts now pass `--fatal-deprecation=import`, so a reintroduced `@import` fails the build instead of warning:

| | exit code |
|---|---|
| `@use 'base'` | 0 |
| `@import 'base'` | 65 (`Error: ... only an error because you've set the import deprecation to be fatal`) |

That covers `npm run dev-styles`, `npm run sass-prod`, and the `RUN npm run sass-prod` in the Dockerfile's build stage — i.e. CI's "Build frontend + styles" step and the published image.

## Verification

Compiled CSS is **byte-identical** before and after, in both output styles — `diff` clean on `--style=compressed` (the 6303-byte `dist/style.css` that ships) and on `--style=expanded`. The build now emits zero deprecation warnings.

No behavioural change, no dependency change, purely the source syntax plus the build guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)