### PR TITLE
feat: send the Slack login link as a Block Kit message

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -33,3 +33,26 @@ passmower:
 
 The audit log independently records the same events regardless of these
 settings; notifications are user-facing transparency, not the audit trail.
+
+## Slack message format
+
+The magic-link sign-in DM is a [Block Kit](https://api.slack.com/block-kit)
+message: what is being signed in to, a **Sign in** button carrying the one-time
+link, and the requesting browser and IP underneath. It replaces the earlier
+plain-text DM, where the raw URL was prone to being wrapped, truncated in a
+preview, or turned into an unhelpful unfurl.
+
+Every Slack message still carries plain `text` alongside its blocks — Slack uses
+that for the notification and the channel preview, and falls back to it in
+clients that cannot render blocks. The magic link is present in both, so the DM
+is usable either way.
+
+The button is a **link button**: it carries a URL and no `action_id`, so Slack
+opens the browser and never calls back. That is deliberate — a button Slack has
+to POST about would require a public interactivity request URL with
+signing-secret verification, i.e. an inbound webhook surface on the identity
+provider. Values interpolated into a message (client display names, ids) are
+escaped for Slack mrkdwn, since they come from `OIDCClient` resources.
+
+The security notices above are still sent as plain text; they have no action to
+offer beyond what the text says.

--- a/src/adapters/slack.js
+++ b/src/adapters/slack.js
@@ -36,10 +36,15 @@ export class SlackAdapter {
         return teamIdPromise
     }
 
-    async sendMessage(userId, text) {
+    // `text` is always sent: Slack renders it in the notification and the
+    // channel preview, and falls back to it wherever blocks cannot render.
+    // `blocks` is optional so callers that have nothing to lay out keep sending
+    // exactly the payload they did before.
+    async sendMessage(userId, text, blocks) {
         return await this.client.chat.postMessage({
             channel: userId,
-            text
+            text,
+            ...(blocks?.length ? {blocks} : {}),
         })
     }
 }

--- a/src/services/login/email-login.js
+++ b/src/services/login/email-login.js
@@ -6,6 +6,7 @@ import EmailAdapter from "../../adapters/email.js";
 import {CustomOIDCProviderError} from "oidc-provider/lib/helpers/errors.js";
 import {getEmailContent, getEmailSubject} from "../../utils/get-email-content.js";
 import {SlackAdapter} from "../../adapters/slack.js";
+import {loginLinkMessage} from "../../utils/slack-message.js";
 import {parseRequestMetadata} from "../../utils/session/parse-request-headers.js";
 import {auditLog} from "../../utils/session/audit-log.js";
 import {IdentityIntegrityError} from "../../utils/user/identity-integrity.js";
@@ -71,7 +72,18 @@ export class EmailLogin {
             .then(() => true)
             .catch((error) => logger.error({ctx, error}, 'email-login.email_error'))
 
-        const sendSlack = this.slackAdapter.client && account?.slackId ? this.slackAdapter.sendMessage(account.slackId, content.text)
+        // Same link, laid out as Block Kit with a Sign in button (#17) — the
+        // email body stays the notification/fallback text.
+        const slackMessage = loginLinkMessage({
+            url,
+            instance: process.env.ISSUER_URL,
+            email,
+            client: client?.displayName || client?.clientId,
+            browser: metadata.browser,
+            ip: metadata.ip,
+            text: content.text,
+        })
+        const sendSlack = this.slackAdapter.client && account?.slackId ? this.slackAdapter.sendMessage(account.slackId, slackMessage.text, slackMessage.blocks)
             .then(() => auditLog(ctx, {email, slackId: account.slackId}, 'Sent login link via Slack'))
             .then(() => true)
             .catch((error) => logger.error({ctx, error}, 'email-login.slack_error'))

--- a/src/utils/slack-message.js
+++ b/src/utils/slack-message.js
@@ -1,0 +1,61 @@
+// Slack messages Passmower composes as Block Kit rather than a wall of text
+// (#17). Block Kit is what gives a DM a real call-to-action button instead of a
+// raw URL the client may line-wrap, truncate in a preview, or turn into an
+// unhelpful unfurl.
+//
+// The buttons here are **link buttons** — they carry a `url` and no
+// `action_id`, so clicking one opens the browser and Slack never calls back.
+// That is deliberate: a button Slack has to POST about would require a public
+// interactivity request URL and signing-secret verification, i.e. an inbound
+// webhook surface on the IdP. A link button gets the UX with no new surface.
+//
+// Every message keeps a plain `text` alongside its blocks: Slack uses it for
+// the notification, the sidebar preview, and clients that cannot render blocks.
+
+// Slack mrkdwn reserves these three characters, and unescaped they silently
+// mangle the message (`<` starts a link span). Display names and client ids
+// come from CRDs, so they are not ours to trust.
+export const escapeMrkdwn = (value) => String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+
+const section = (text) => ({type: 'section', text: {type: 'mrkdwn', text}})
+
+// Slack rejects a button whose text exceeds 75 characters, and a URL over 3000.
+const MAX_BUTTON_TEXT = 75
+
+const linkButton = (label, url) => ({
+    type: 'actions',
+    elements: [{
+        type: 'button',
+        text: {type: 'plain_text', text: label.slice(0, MAX_BUTTON_TEXT), emoji: true},
+        url,
+        style: 'primary',
+    }],
+})
+
+const context = (lines) => ({
+    type: 'context',
+    elements: lines.filter(Boolean).map(text => ({type: 'mrkdwn', text})),
+})
+
+// The magic-link DM: what is being signed in to, a Sign in button, and the
+// request's provenance so an unexpected message is recognisable as such.
+// `text` is the same body the email carries, so the Slack notification preview
+// still says what happened and the link survives a blocks-less client.
+export const loginLinkMessage = ({url, instance, email, client, browser, ip, text}) => {
+    const target = client ? `*${escapeMrkdwn(client)}*` : `*${escapeMrkdwn(instance)}*`
+    return {
+        text,
+        blocks: [
+            section(`Sign in to ${target} as ${escapeMrkdwn(email)}`),
+            linkButton('Sign in', url),
+            context([
+                browser ? `Requested from ${escapeMrkdwn(browser)}` : null,
+                ip ? `IP ${escapeMrkdwn(ip)}` : null,
+                'If this wasn\'t you, ignore this message.',
+            ]),
+        ],
+    }
+}

--- a/test/integration/slack-login-link.test.js
+++ b/test/integration/slack-login-link.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import request from 'supertest'
+
+// Slack has to be stubbed at the SDK boundary (and SLACK_TOKEN set) before the
+// app is imported: SlackAdapter reads the token in its constructor, and
+// EmailLogin builds one at wiring time.
+process.env.SLACK_TOKEN = 'xoxb-test-token'
+
+export const slackCalls = { postMessage: [] }
+
+vi.mock('../../src/adapters/kubernetes.js', () => import('../fakes/shared-kube.js'))
+vi.mock('../../src/adapters/email.js', () => import('../fakes/email-capture.js'))
+vi.mock('@slack/web-api', () => ({
+    WebClient: class {
+        chat = {
+            postMessage: async (payload) => {
+                slackCalls.postMessage.push(payload)
+                return { ok: true }
+            },
+        }
+        auth = { test: async () => ({ team_id: 'T123' }) }
+        users = { lookupByEmail: async () => ({ user: { id: 'U-looked-up' } }) }
+    },
+}))
+
+import { fakeKube } from '../fakes/shared-kube.js'
+import { sentEmails } from '../fakes/email-capture.js'
+
+const RP = {
+    client_id: 'grafana',
+    client_secret: 'grafana-secret',
+    redirect_uri: 'https://grafana.test/login/generic_oauth',
+}
+
+describe('login link over Slack (HTTP)', () => {
+    let callback
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        process.env.EMAIL_ENABLED = 'true'
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        const provider = await buildProvider()
+        callback = provider.callback()
+
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        await new RedisAdapter('Client').upsert(RP.client_id, {
+            client_id: RP.client_id,
+            client_secret: RP.client_secret,
+            redirect_uris: [RP.redirect_uri],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'client_secret_basic',
+            availableScopes: ['openid', 'email'],
+            allowedGroups: [],
+            allowedCORSOrigins: [],
+            displayName: 'Grafana',
+        })
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+        delete process.env.SLACK_TOKEN
+    })
+
+    beforeEach(() => {
+        fakeKube.store.clear()
+        sentEmails.length = 0
+        slackCalls.postMessage.length = 0
+        fakeKube.seed('OIDCUser', {
+            metadata: { name: 'testuser', labels: {} },
+            spec: {
+                email: 'test@example.com', name: 'Test User',
+                groups: [{ prefix: 'local', name: 'staff' }],
+            },
+            passmower: { email: 'test@example.com' },
+            slack: { id: 'U-testuser' },
+            status: {
+                primaryEmail: 'test@example.com',
+                emails: ['test@example.com'],
+                groups: [{ prefix: 'local', name: 'staff' }],
+                profile: { name: 'Test User' },
+                slackId: 'U-testuser',
+                conditions: [],
+                termsOfService: {
+                    acceptedAt: '2026-08-06T12:00:00.000Z',
+                    contentHash: 'test-content-hash',
+                },
+            },
+        })
+    })
+
+    const jar = () => new Map()
+    const cookieHeader = (j) => [...j.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+    function store(j, res) {
+        for (const c of res.headers['set-cookie'] ?? []) {
+            const pair = c.split(';')[0]
+            const i = pair.indexOf('=')
+            const name = pair.slice(0, i).trim()
+            const val = pair.slice(i + 1)
+            if (val === '') j.delete(name)
+            else j.set(name, val)
+        }
+    }
+    async function req(j, method, path, form) {
+        let r = request(callback)[method](path).set('Cookie', cookieHeader(j))
+        if (form) r = r.type('form').send(form)
+        const res = await r
+        store(j, res)
+        return res
+    }
+    async function follow(j, res, maxHops = 12) {
+        let cur = res
+        for (let i = 0; i < maxHops && cur.status >= 300 && cur.status < 400; i++) {
+            const loc = cur.headers.location
+            if (!loc) break
+            const u = loc.startsWith('http') ? new URL(loc) : new URL(loc, process.env.ISSUER_URL)
+            if (u.host === new URL(RP.redirect_uri).host) return cur
+            cur = await req(j, 'get', u.pathname + u.search)
+        }
+        return cur
+    }
+
+    async function requestLoginLink() {
+        const j = jar()
+        const authQuery = new URLSearchParams({
+            client_id: RP.client_id,
+            redirect_uri: RP.redirect_uri,
+            response_type: 'code',
+            scope: 'openid email',
+            state: 'state-17',
+        })
+        const res = await follow(j, await req(j, 'get', `/auth?${authQuery}`))
+        const uid = (res.headers.location ?? res.request.url).match(/\/interaction\/([^/?]+)/)[1]
+        return req(j, 'post', `/interaction/${uid}/email`, { email: 'test@example.com' })
+    }
+
+    it('DMs the link as a Block Kit button, with the email body as fallback text', async () => {
+        await requestLoginLink()
+
+        expect(slackCalls.postMessage).toHaveLength(1)
+        const dm = slackCalls.postMessage[0]
+        expect(dm.channel).toBe('U-testuser')
+
+        const button = dm.blocks.find(b => b.type === 'actions').elements[0]
+        const emailedLink = sentEmails[0].text.match(/https:\S+verify-email\/[0-9a-f-]+/)[0]
+        // Same one-time link the email carries — on a button instead of inline.
+        expect(button.url).toBe(emailedLink)
+        expect(button.text.text).toBe('Sign in')
+
+        // Slack needs text for the notification and blocks-less clients.
+        expect(dm.text).toContain('verify-email/')
+        expect(dm.blocks.find(b => b.type === 'section').text.text)
+            .toBe('Sign in to *Grafana* as test@example.com')
+    })
+
+    it('still sends the email, and both channels are reported to the user', async () => {
+        const res = await requestLoginLink()
+
+        expect(sentEmails).toHaveLength(1)
+        expect(res.headers.location).toContain('email=true')
+        expect(res.headers.location).toContain('slack=true')
+    })
+
+    it('skips the DM for an account with no linked Slack user', async () => {
+        const user = fakeKube.store.get('OIDCUser/testuser')
+        delete user.slack
+        delete user.status.slackId
+
+        const res = await requestLoginLink()
+
+        expect(slackCalls.postMessage).toHaveLength(0)
+        expect(sentEmails).toHaveLength(1)
+        expect(res.headers.location).toContain('slack=false')
+    })
+})

--- a/test/unit/slack-adapter.test.js
+++ b/test/unit/slack-adapter.test.js
@@ -8,6 +8,45 @@ afterEach(() => {
     vi.unstubAllEnvs()
 })
 
+describe('SlackAdapter.sendMessage', () => {
+    const adapterWithSpy = () => {
+        const adapter = new SlackAdapter()
+        adapter.client = {chat: {postMessage: vi.fn().mockResolvedValue({ok: true})}}
+        return adapter
+    }
+
+    it('omits blocks entirely when a caller has none, keeping the old payload', async () => {
+        const adapter = adapterWithSpy()
+
+        await adapter.sendMessage('U1', 'plain notice')
+
+        expect(adapter.client.chat.postMessage).toHaveBeenCalledWith({
+            channel: 'U1', text: 'plain notice',
+        })
+    })
+
+    it('sends blocks alongside the text fallback when given', async () => {
+        const adapter = adapterWithSpy()
+        const blocks = [{type: 'section', text: {type: 'mrkdwn', text: 'hi'}}]
+
+        await adapter.sendMessage('U1', 'fallback', blocks)
+
+        expect(adapter.client.chat.postMessage).toHaveBeenCalledWith({
+            channel: 'U1', text: 'fallback', blocks,
+        })
+    })
+
+    it('treats an empty block list as no blocks', async () => {
+        const adapter = adapterWithSpy()
+
+        await adapter.sendMessage('U1', 'fallback', [])
+
+        expect(adapter.client.chat.postMessage).toHaveBeenCalledWith({
+            channel: 'U1', text: 'fallback',
+        })
+    })
+})
+
 describe('SlackAdapter.getTeamId', () => {
     it('retries workspace discovery after a transient failure without requiring a logger', async () => {
         vi.stubEnv('SLACK_TEAM_ID', '')

--- a/test/unit/slack-message.test.js
+++ b/test/unit/slack-message.test.js
@@ -1,0 +1,74 @@
+import {describe, expect, it} from 'vitest'
+import {escapeMrkdwn, loginLinkMessage} from '../../src/utils/slack-message.js'
+
+const message = (overrides = {}) => loginLinkMessage({
+    url: 'https://id.example.com/interaction/abc/verify-email/def',
+    instance: 'https://id.example.com/',
+    email: 'user@example.com',
+    client: 'Grafana',
+    browser: 'Firefox on Fedora',
+    ip: '198.51.100.7',
+    text: 'plain body',
+    ...overrides,
+})
+
+const blockOfType = (msg, type) => msg.blocks.find(block => block.type === type)
+
+describe('Slack login link message', () => {
+    it('carries the link on a button rather than in the body', () => {
+        const msg = message()
+        const button = blockOfType(msg, 'actions').elements[0]
+
+        expect(button.type).toBe('button')
+        expect(button.url).toBe('https://id.example.com/interaction/abc/verify-email/def')
+        expect(button.text.text).toBe('Sign in')
+        // No action_id: a link button opens the browser and Slack never posts
+        // back, so this needs no interactivity endpoint on the IdP.
+        expect(button.action_id).toBeUndefined()
+    })
+
+    it('always keeps a text fallback for the notification and blocks-less clients', () => {
+        expect(message().text).toBe('plain body')
+    })
+
+    it('names the client, falling back to the issuer when there is none', () => {
+        expect(blockOfType(message(), 'section').text.text)
+            .toBe('Sign in to *Grafana* as user@example.com')
+        expect(blockOfType(message({client: undefined}), 'section').text.text)
+            .toBe('Sign in to *https://id.example.com/* as user@example.com')
+    })
+
+    it('escapes mrkdwn in values that come from CRDs', () => {
+        const msg = message({client: 'A <b> & C'})
+
+        expect(blockOfType(msg, 'section').text.text).toContain('A &lt;b&gt; &amp; C')
+        expect(blockOfType(msg, 'section').text.text).not.toContain('<b>')
+    })
+
+    it('reports provenance and drops the parts it does not have', () => {
+        const full = blockOfType(message(), 'context').elements.map(e => e.text)
+        expect(full).toEqual([
+            'Requested from Firefox on Fedora',
+            'IP 198.51.100.7',
+            "If this wasn't you, ignore this message.",
+        ])
+
+        const sparse = blockOfType(message({browser: undefined, ip: undefined}), 'context')
+        expect(sparse.elements.map(e => e.text)).toEqual([
+            "If this wasn't you, ignore this message.",
+        ])
+    })
+
+    it('keeps button text inside the 75 character limit Slack enforces', () => {
+        // The label is fixed today; the cap is asserted so a future longer one
+        // is truncated rather than rejected by Slack at send time.
+        const button = blockOfType(message(), 'actions').elements[0]
+        expect(button.text.text.length).toBeLessThanOrEqual(75)
+    })
+
+    it('escapes only the three characters Slack reserves', () => {
+        expect(escapeMrkdwn('a&b<c>d')).toBe('a&amp;b&lt;c&gt;d')
+        expect(escapeMrkdwn('*bold* _em_ `code`')).toBe('*bold* _em_ `code`')
+        expect(escapeMrkdwn(undefined)).toBe('')
+    })
+})


### PR DESCRIPTION
Addresses the remaining open item on #17 — *"Refactor login link to interactive message"* — which is still live: `src/services/login/email-login.js:74` was DMing `content.text`, i.e. the email body verbatim with the one-time URL inline. Slack wraps it, truncates it in the channel preview, and sometimes unfurls it into something less useful than a link.

## The message

The DM is now Block Kit — what is being signed in to, a **Sign in** button carrying the link, and the requesting browser and IP as context:

```json
{
  "channel": "U-testuser",
  "text": "<the email body — Slack's notification and blocks-less fallback>",
  "blocks": [
    {"type": "section", "text": {"type": "mrkdwn", "text": "Sign in to *Grafana* as user@example.com"}},
    {"type": "actions", "elements": [
      {"type": "button", "text": {"type": "plain_text", "text": "Sign in"},
       "url": "https://id.example.com/interaction/abc/verify-email/def", "style": "primary"}
    ]},
    {"type": "context", "elements": [
      {"type": "mrkdwn", "text": "Requested from Firefox on Fedora"},
      {"type": "mrkdwn", "text": "IP 198.51.100.7"},
      {"type": "mrkdwn", "text": "If this wasn't you, ignore this message."}
    ]}
  ]
}
```

## Two decisions worth flagging

**It is a link button, not a callback button.** It carries a `url` and no `action_id`, so Slack opens the browser and never posts back. A button Slack has to POST about would require a public interactivity request URL with signing-secret verification — an inbound webhook surface on the IdP — which is a lot of exposure for what is fundamentally a link. If you did want a true interactive flow (approve/deny in Slack), that surface is the prerequisite and belongs in its own change; the note in `docs/notifications.md` records why this stops here.

**`text` is always sent.** Slack uses it for the notification and the channel preview and falls back to it where blocks cannot render, so the link is present in both representations and the DM works either way. `SlackAdapter.sendMessage` takes `blocks` as an optional third argument and **omits the key when there are none**, so the security notices from `notification-service.js` keep sending byte-identical payloads — asserted in a test.

Client display names and ids are interpolated into the message and come from `OIDCClient` resources, so they are escaped for the three characters Slack mrkdwn reserves. An unescaped `<` opens a link span and mangles the message.

## Tests

- **Unit** (`slack-message.test.js`, 7): the link is on the button and not inline, the text fallback survives, the client name falls back to the issuer when a client has no display name, mrkdwn escaping (and *only* the three reserved characters — `*bold*` must stay literal), context lines drop the parts that are absent, and the button label stays inside Slack's 75-character cap.
- **Unit** (`slack-adapter.test.js`, +3): blocks are passed through, an empty list counts as none, and a caller with no blocks produces the pre-existing payload exactly.
- **Integration** (`slack-login-link.test.js`, 3): Slack stubbed at the `@slack/web-api` boundary, driving a real magic-link request through HTTP — asserts the button URL **equals the link the email carries**, that the email still goes out and the UI is told both channels succeeded (`email=true&slack=true`), and that an account with no linked Slack user gets no DM and `slack=false`.

Suites: unit 313, integration 51, all green.

## Not in scope

#17's other remaining item is *login via Slack OAuth* as an upstream identity source — a separate piece of work, so the issue should stay open after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)